### PR TITLE
Make warp agents use real session data

### DIFF
--- a/docs/superpowers/specs/2026-04-23-unified-agent-dashboard-design.md
+++ b/docs/superpowers/specs/2026-04-23-unified-agent-dashboard-design.md
@@ -1,0 +1,278 @@
+# Unified Agent Dashboard Design
+
+Date: 2026-04-23
+Repo: `/Users/deryzh/dev/git-warp`
+Command surface: `warp agents`
+
+## Summary
+
+Upgrade `warp agents` from a demo-only TUI into a real unified dashboard that shows:
+
+- live Claude and Codex agent activity from Git-Warp hook status files
+- recent Claude and Codex sessions discovered from their local session stores
+- sessions scoped to the current repository and its worktrees
+
+The default view includes both open/live sessions and recently closed sessions from the last 7 days.
+
+## Goals
+
+- Show Claude and Codex sessions together in one dashboard.
+- Prefer live status from existing Git-Warp hook files when available.
+- Include recent closed sessions so the dashboard remains useful even when an agent is no longer running.
+- Restrict results to the current repository and its worktree locations.
+- Replace the current hard-coded mock data in `warp agents`.
+
+## Non-Goals
+
+- Adding remote or team-wide monitoring.
+- Persisting a new Git-Warp-owned session database.
+- Adding new CLI flags in the first pass.
+- Resuming, attaching to, or controlling sessions from the dashboard.
+
+## Product Decisions
+
+- Dashboard scope: unified Claude + Codex view.
+- History window: 7 days by default.
+- Default ordering: live sessions first, then recent closed sessions by newest activity.
+- Initial command surface: keep using `warp agents` with no required new arguments.
+
+## Current Reality
+
+Today, the repo already has part of the runtime foundation:
+
+- `warp hooks-install --runtime claude|codex|all` can install hooks for both runtimes.
+- Hooks write live status JSON into:
+  - `.claude/git-warp/status`
+  - `.codex/git-warp/status`
+- `warp agents` still renders hard-coded demo rows in the TUI and does not read real session data.
+
+Real local data sources are also available on disk:
+
+- Codex sessions under `~/.codex/sessions/**/*.jsonl`
+- Claude sessions under `~/.claude/projects/**/*.jsonl`
+
+## Data Sources
+
+### 1. Live status files
+
+For each repo root and worktree path, check for:
+
+- `<path>/.claude/git-warp/status`
+- `<path>/.codex/git-warp/status`
+
+These files provide the most accurate current state when present, because they are written by runtime hooks during active work.
+
+Expected status values currently include:
+
+- `working`
+- `processing`
+- `waiting`
+- `subagent_complete`
+
+### 2. Codex session store
+
+Read `~/.codex/sessions/**/*.jsonl` and extract session metadata from `session_meta` rows. The fields we can rely on are:
+
+- `payload.id`
+- `payload.cwd`
+- `payload.timestamp`
+- `payload.originator`
+- `payload.agent_nickname` when present
+- `payload.agent_role` when present
+
+For recent-activity timestamps, use the newest timestamp seen in the file when needed.
+
+### 3. Claude session store
+
+Read `~/.claude/projects/**/*.jsonl` and extract session information from top-level events. Useful fields include:
+
+- `sessionId`
+- `cwd`
+- `timestamp`
+- `gitBranch` when present
+
+Claude logs do not appear to provide the same clean single `session_meta` record as Codex, so parsing must tolerate mixed event shapes.
+
+## Repository Scoping
+
+The dashboard must only show sessions belonging to the current repo and its worktrees.
+
+Repo affinity rule:
+
+1. Resolve the current repo root with the existing git repo discovery code.
+2. Build the allowed path set from:
+   - the repo root itself
+   - all known worktree paths returned by Git-Warp's git worktree listing
+3. Keep a session only when its `cwd` is equal to or nested under one of those allowed paths.
+
+This keeps the dashboard focused on the active repo and avoids cross-repo noise from the user's global session stores.
+
+## Normalized Model
+
+Add a shared runtime-agnostic model for the TUI, for example:
+
+```rust
+pub struct AgentSessionSummary {
+    pub runtime: AgentRuntime,
+    pub session_id: Option<String>,
+    pub cwd: PathBuf,
+    pub branch: Option<String>,
+    pub agent_label: String,
+    pub state: AgentSessionState,
+    pub last_activity: DateTime<Local>,
+    pub is_live: bool,
+    pub source: AgentSessionSource,
+}
+```
+
+Support enums:
+
+- `AgentRuntime`: `Claude | Codex`
+- `AgentSessionState`: `Working | Processing | Waiting | Completed | Recent | Unknown`
+- `AgentSessionSource`: `LiveStatus | SessionStore | Merged`
+
+Notes:
+
+- `session_id` is optional because some Claude-derived history rows may not expose one cleanly.
+- `agent_label` should show Codex nickname/role when available, otherwise fall back to `Codex`.
+- Claude rows can default to `Claude` unless a better label is available later.
+
+## Discovery Pipeline
+
+Build the unified dashboard data in two passes.
+
+### Pass 1: collect live status
+
+- Inspect repo root and each worktree path for runtime status files.
+- Parse status JSON.
+- Produce provisional `AgentSessionSummary` rows marked `is_live = true`.
+- Use the file modification time as a fallback `last_activity` when the JSON timestamp is missing or invalid.
+
+### Pass 2: collect recent sessions
+
+- Scan the Codex and Claude session stores.
+- Parse only sessions from the last 7 days.
+- Filter to sessions whose `cwd` belongs to this repo/worktree set.
+- Produce provisional rows marked `is_live = false`.
+
+### Merge and dedupe
+
+Merge rows by a stable key:
+
+- prefer `runtime + session_id` when a session id is present
+- otherwise fall back to `runtime + cwd`
+
+Precedence rules:
+
+1. Live status file wins for state.
+2. Session-store row fills metadata such as agent nickname, role, branch, or better timestamps.
+3. If both exist, emit one merged row, not duplicates.
+
+## State Mapping
+
+Map raw runtime values into shared UI states:
+
+- `working` -> `Working`
+- `processing` -> `Processing`
+- `waiting` -> `Waiting`
+- `subagent_complete` -> `Completed`
+- recent session with no live status -> `Recent`
+- anything unrecognized -> `Unknown`
+
+This preserves current runtime semantics without forcing the TUI to understand each runtime's raw strings.
+
+## TUI Behavior
+
+Keep the command as `warp agents`, but replace the current fake activity list with real session summaries.
+
+### List view
+
+Each row should show:
+
+- state indicator
+- runtime
+- branch or worktree name
+- agent label
+- relative last-activity time
+
+Sorting:
+
+- live rows first
+- then by `last_activity` descending
+
+### Detail pane
+
+Selecting a row should show:
+
+- full cwd
+- session id
+- runtime
+- branch if known
+- live vs recent-only
+- exact timestamp
+- source data origin (`LiveStatus`, `SessionStore`, `Merged`)
+
+### Empty state
+
+If no sessions are found, render a useful empty state instead of a blank table:
+
+- no live or recent Claude/Codex sessions found for this repo in the last 7 days
+- suggest `warp hooks-install --runtime all --level user` if live monitoring is missing
+
+## Error Handling
+
+The dashboard must degrade gracefully.
+
+- Missing Claude or Codex home directories should not fail the command.
+- Malformed JSON lines should be skipped with debug logging.
+- A broken file in one runtime must not hide valid rows from the other runtime.
+- Missing status files should simply mean there is no live state for that path.
+
+## Module Boundaries
+
+Do not put discovery/parsing logic directly into the TUI rendering file.
+
+Preferred split:
+
+- new agent discovery module for reading status files and session stores
+- small normalized session model shared with the TUI
+- `src/tui.rs` limited to rendering and keyboard interaction
+
+This keeps the TUI testable and prevents parsing concerns from leaking into view code.
+
+## Testing Strategy
+
+Add unit coverage for:
+
+- Codex session parsing from representative `session_meta` lines
+- Claude session parsing from representative project log lines
+- repo/worktree path filtering
+- 7-day cutoff filtering
+- merge precedence between live status rows and session-store rows
+- ordering: live first, then newest recent sessions
+- state mapping from runtime-specific values into shared UI states
+
+Keep tests local and deterministic by using temporary directories and fixture content instead of real home-directory state.
+
+## Risks
+
+- Claude log formats are less uniform than Codex session metadata, so the parser must be conservative.
+- Large session stores can get expensive to scan; the first implementation should stay correct first, then optimize if needed.
+- A single status file per worktree/runtime may represent the current active state but not multiple concurrent agents in the same path. That limitation is acceptable for the first pass.
+
+## Future Extensions
+
+If the first pass lands well, later work could add:
+
+- optional `--days` or `--runtime` filters
+- action keys for resume/attach flows
+- file watching via `notify` for live refresh instead of manual refresh loops
+- a Warp-owned cache/index only if scan cost becomes a real problem
+
+## Acceptance Criteria
+
+- `warp agents` shows real Claude and Codex rows instead of mock data.
+- Live hook status is reflected when `.claude/git-warp/status` or `.codex/git-warp/status` exists in the repo or its worktrees.
+- Recent closed Claude and Codex sessions from the last 7 days appear when they belong to the current repo/worktrees.
+- Duplicate live/history rows collapse into one merged row.
+- The command still works when one runtime is not installed or has no local history.

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -1,16 +1,19 @@
 use crate::error::Result;
-use chrono::{DateTime, Local};
+use crate::git::GitRepository;
+use chrono::{DateTime, Duration, Local};
+use ignore::WalkBuilder;
 use serde_json::Value;
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum AgentRuntime {
     Claude,
     Codex,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum AgentSessionState {
     Working,
     Processing,
@@ -20,7 +23,7 @@ pub enum AgentSessionState {
     Unknown,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum AgentSessionSource {
     LiveStatus,
     SessionStore,
@@ -40,6 +43,11 @@ pub struct AgentSessionSummary {
     pub source: AgentSessionSource,
 }
 
+#[derive(Debug, Clone)]
+pub struct AgentDiscovery {
+    monitored_paths: Vec<PathBuf>,
+}
+
 fn parse_timestamp(value: &str) -> Option<DateTime<Local>> {
     chrono::DateTime::parse_from_rfc3339(value)
         .ok()
@@ -53,6 +61,119 @@ fn map_status(value: &str) -> AgentSessionState {
         "waiting" => AgentSessionState::Waiting,
         "subagent_complete" => AgentSessionState::Completed,
         _ => AgentSessionState::Unknown,
+    }
+}
+
+fn status_file_path(root: &Path, runtime: AgentRuntime) -> PathBuf {
+    match runtime {
+        AgentRuntime::Claude => root.join(".claude").join("git-warp").join("status"),
+        AgentRuntime::Codex => root.join(".codex").join("git-warp").join("status"),
+    }
+}
+
+fn is_path_within_root(path: &Path, root: &Path) -> bool {
+    path == root || path.starts_with(root)
+}
+
+fn is_fallback_label(runtime: AgentRuntime, label: &str) -> bool {
+    let label = label.trim();
+    label.is_empty()
+        || matches!(
+            (runtime, label),
+            (AgentRuntime::Claude, "Claude") | (AgentRuntime::Codex, "Codex")
+        )
+}
+
+fn preferred_group<'a>(items: &'a [AgentSessionSummary]) -> Vec<&'a AgentSessionSummary> {
+    let mut refs: Vec<&AgentSessionSummary> = items.iter().collect();
+    refs.sort_by(|a, b| {
+        b.is_live
+            .cmp(&a.is_live)
+            .then_with(|| b.last_activity.cmp(&a.last_activity))
+            .then_with(|| a.cwd.cmp(&b.cwd))
+    });
+    refs
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+enum AgentSessionKey {
+    SessionId {
+        runtime: AgentRuntime,
+        session_id: String,
+    },
+    Cwd {
+        runtime: AgentRuntime,
+        cwd: PathBuf,
+    },
+}
+
+fn session_key(session: &AgentSessionSummary) -> AgentSessionKey {
+    match &session.session_id {
+        Some(session_id) => AgentSessionKey::SessionId {
+            runtime: session.runtime,
+            session_id: session_id.clone(),
+        },
+        None => AgentSessionKey::Cwd {
+            runtime: session.runtime,
+            cwd: session.cwd.clone(),
+        },
+    }
+}
+
+fn jsonl_files_under(root: &Path) -> Vec<PathBuf> {
+    WalkBuilder::new(root)
+        .hidden(false)
+        .ignore(false)
+        .git_ignore(false)
+        .git_exclude(false)
+        .git_global(false)
+        .build()
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            let file_type = entry.file_type()?;
+            if !file_type.is_file() {
+                return None;
+            }
+            if entry.path().extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
+                return None;
+            }
+            Some(entry.path().to_path_buf())
+        })
+        .collect()
+}
+
+fn load_session_file_lines(path: &Path) -> Option<String> {
+    fs::read_to_string(path).ok()
+}
+
+impl AgentDiscovery {
+    pub fn new(monitored_paths: Vec<PathBuf>) -> Self {
+        Self { monitored_paths }
+    }
+
+    pub fn keep_session(&self, session: &AgentSessionSummary, now: DateTime<Local>) -> bool {
+        if now.signed_duration_since(session.last_activity) > Duration::days(7) {
+            return false;
+        }
+
+        self.monitored_paths
+            .iter()
+            .any(|root| is_path_within_root(&session.cwd, root))
+    }
+
+    pub fn discover(&self) -> Result<Vec<AgentSessionSummary>> {
+        let now = Local::now();
+        let mut sessions = Vec::new();
+
+        sessions.extend(load_live_statuses()?);
+        sessions.extend(load_codex_sessions()?);
+        sessions.extend(load_claude_sessions()?);
+
+        sessions.retain(|session| self.keep_session(session, now));
+
+        let mut merged = merge_session_summaries(sessions);
+        sort_session_summaries(&mut merged);
+        Ok(merged)
     }
 }
 
@@ -138,6 +259,133 @@ pub fn parse_codex_session_meta_line(line: &str) -> Option<AgentSessionSummary> 
         is_live: false,
         source: AgentSessionSource::SessionStore,
     })
+}
+
+pub fn load_live_statuses() -> Result<Vec<AgentSessionSummary>> {
+    let git_repo = match GitRepository::find() {
+        Ok(repo) => repo,
+        Err(_) => return Ok(Vec::new()),
+    };
+
+    let mut roots = vec![git_repo.root_path().to_path_buf()];
+    if let Ok(worktrees) = git_repo.list_worktrees() {
+        for worktree in worktrees {
+            if !roots.iter().any(|root| root == &worktree.path) {
+                roots.push(worktree.path);
+            }
+        }
+    }
+
+    let mut sessions = Vec::new();
+    for root in roots {
+        for runtime in [AgentRuntime::Claude, AgentRuntime::Codex] {
+            let status_path = status_file_path(&root, runtime);
+            if let Some(summary) = parse_live_status_file(runtime, &status_path)? {
+                sessions.push(summary);
+            }
+        }
+    }
+
+    Ok(sessions)
+}
+
+pub fn load_codex_sessions() -> Result<Vec<AgentSessionSummary>> {
+    let Some(home_dir) = dirs::home_dir() else {
+        return Ok(Vec::new());
+    };
+    let sessions_root = home_dir.join(".codex").join("sessions");
+
+    let mut sessions = Vec::new();
+    for file_path in jsonl_files_under(&sessions_root) {
+        let Some(content) = load_session_file_lines(&file_path) else {
+            continue;
+        };
+        sessions.extend(content.lines().filter_map(parse_codex_session_meta_line));
+    }
+
+    Ok(sessions)
+}
+
+pub fn load_claude_sessions() -> Result<Vec<AgentSessionSummary>> {
+    let Some(home_dir) = dirs::home_dir() else {
+        return Ok(Vec::new());
+    };
+    let sessions_root = home_dir.join(".claude").join("projects");
+
+    let mut sessions = Vec::new();
+    for file_path in jsonl_files_under(&sessions_root) {
+        let Some(content) = load_session_file_lines(&file_path) else {
+            continue;
+        };
+        sessions.extend(content.lines().filter_map(parse_claude_session_event_line));
+    }
+
+    Ok(sessions)
+}
+
+pub fn merge_session_summaries(items: Vec<AgentSessionSummary>) -> Vec<AgentSessionSummary> {
+    let mut grouped: HashMap<AgentSessionKey, Vec<AgentSessionSummary>> = HashMap::new();
+
+    for item in items {
+        grouped.entry(session_key(&item)).or_default().push(item);
+    }
+
+    let mut merged = Vec::with_capacity(grouped.len());
+
+    for mut group in grouped.into_values() {
+        if group.len() == 1 {
+            merged.push(group.pop().unwrap());
+            continue;
+        }
+
+        let ordered = preferred_group(&group);
+        let mut selected = ordered[0].clone();
+        let newest_timestamp = ordered
+            .iter()
+            .map(|item| item.last_activity)
+            .max()
+            .unwrap_or(selected.last_activity);
+        let live_item = ordered.iter().find(|item| item.is_live);
+
+        if let Some(item) = live_item {
+            selected.state = item.state;
+            selected.is_live = true;
+        }
+
+        if let Some(branch) = ordered
+            .iter()
+            .filter_map(|item| item.branch.clone())
+            .find(|branch| !branch.is_empty())
+        {
+            selected.branch = Some(branch);
+        }
+
+        if is_fallback_label(selected.runtime, &selected.agent_label) {
+            if let Some(label) = ordered
+                .iter()
+                .map(|item| item.agent_label.as_str())
+                .find(|label| !is_fallback_label(selected.runtime, label))
+            {
+                selected.agent_label = label.to_string();
+            }
+        }
+
+        selected.last_activity = newest_timestamp;
+        selected.source = AgentSessionSource::Merged;
+        merged.push(selected);
+    }
+
+    merged
+}
+
+pub fn sort_session_summaries(items: &mut [AgentSessionSummary]) {
+    items.sort_by(|a, b| {
+        b.is_live
+            .cmp(&a.is_live)
+            .then_with(|| b.last_activity.cmp(&a.last_activity))
+            .then_with(|| a.session_id.cmp(&b.session_id))
+            .then_with(|| a.cwd.cmp(&b.cwd))
+    });
 }
 
 pub fn parse_claude_session_event_line(line: &str) -> Option<AgentSessionSummary> {

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -71,7 +71,13 @@ pub fn parse_live_status_file(
         .get("last_activity")
         .and_then(|v| v.as_str())
         .and_then(parse_timestamp)
-        .unwrap_or_else(Local::now);
+        .unwrap_or_else(|| {
+            fs::metadata(status_path)
+                .ok()
+                .and_then(|meta| meta.modified().ok())
+                .map(DateTime::<Local>::from)
+                .unwrap_or_else(Local::now)
+        });
 
     let cwd = status_path
         .parent()

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -1,0 +1,158 @@
+use crate::error::Result;
+use chrono::{DateTime, Local};
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum AgentRuntime {
+    Claude,
+    Codex,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum AgentSessionState {
+    Working,
+    Processing,
+    Waiting,
+    Completed,
+    Recent,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum AgentSessionSource {
+    LiveStatus,
+    SessionStore,
+    Merged,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct AgentSessionSummary {
+    pub runtime: AgentRuntime,
+    pub session_id: Option<String>,
+    pub cwd: PathBuf,
+    pub branch: Option<String>,
+    pub agent_label: String,
+    pub state: AgentSessionState,
+    pub last_activity: DateTime<Local>,
+    pub is_live: bool,
+    pub source: AgentSessionSource,
+}
+
+fn parse_timestamp(value: &str) -> Option<DateTime<Local>> {
+    chrono::DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|dt| dt.with_timezone(&Local))
+}
+
+fn map_status(value: &str) -> AgentSessionState {
+    match value {
+        "working" => AgentSessionState::Working,
+        "processing" => AgentSessionState::Processing,
+        "waiting" => AgentSessionState::Waiting,
+        "subagent_complete" => AgentSessionState::Completed,
+        _ => AgentSessionState::Unknown,
+    }
+}
+
+pub fn parse_live_status_file(
+    runtime: AgentRuntime,
+    status_path: &Path,
+) -> Result<Option<AgentSessionSummary>> {
+    let content = match fs::read_to_string(status_path) {
+        Ok(content) => content,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err.into()),
+    };
+
+    let value: Value = serde_json::from_str(&content)?;
+    let last_activity = value
+        .get("last_activity")
+        .and_then(|v| v.as_str())
+        .and_then(parse_timestamp)
+        .unwrap_or_else(Local::now);
+
+    let cwd = status_path
+        .parent()
+        .and_then(|p| p.parent())
+        .and_then(|p| p.parent())
+        .unwrap_or_else(|| Path::new("."))
+        .to_path_buf();
+
+    Ok(Some(AgentSessionSummary {
+        runtime,
+        session_id: None,
+        cwd,
+        branch: None,
+        agent_label: match runtime {
+            AgentRuntime::Claude => "Claude".to_string(),
+            AgentRuntime::Codex => "Codex".to_string(),
+        },
+        state: value
+            .get("status")
+            .and_then(|v| v.as_str())
+            .map(map_status)
+            .unwrap_or(AgentSessionState::Unknown),
+        last_activity,
+        is_live: true,
+        source: AgentSessionSource::LiveStatus,
+    }))
+}
+
+pub fn parse_codex_session_meta_line(line: &str) -> Option<AgentSessionSummary> {
+    let value: Value = serde_json::from_str(line).ok()?;
+    let payload = value.get("payload")?;
+    let cwd = payload.get("cwd")?.as_str()?;
+    let nickname = payload.get("agent_nickname").and_then(|v| v.as_str());
+    let role = payload.get("agent_role").and_then(|v| v.as_str());
+    let agent_label = match (nickname, role) {
+        (Some(nickname), Some(role)) => format!("{nickname} ({role})"),
+        (Some(nickname), None) => nickname.to_string(),
+        _ => "Codex".to_string(),
+    };
+
+    Some(AgentSessionSummary {
+        runtime: AgentRuntime::Codex,
+        session_id: payload
+            .get("id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        cwd: PathBuf::from(cwd),
+        branch: None,
+        agent_label,
+        state: AgentSessionState::Recent,
+        last_activity: payload
+            .get("timestamp")
+            .and_then(|v| v.as_str())
+            .and_then(parse_timestamp)?,
+        is_live: false,
+        source: AgentSessionSource::SessionStore,
+    })
+}
+
+pub fn parse_claude_session_event_line(line: &str) -> Option<AgentSessionSummary> {
+    let value: Value = serde_json::from_str(line).ok()?;
+    let cwd = value.get("cwd")?.as_str()?;
+
+    Some(AgentSessionSummary {
+        runtime: AgentRuntime::Claude,
+        session_id: value
+            .get("sessionId")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        cwd: PathBuf::from(cwd),
+        branch: value
+            .get("gitBranch")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        agent_label: "Claude".to_string(),
+        state: AgentSessionState::Recent,
+        last_activity: value
+            .get("timestamp")
+            .and_then(|v| v.as_str())
+            .and_then(parse_timestamp)?,
+        is_live: false,
+        source: AgentSessionSource::SessionStore,
+    })
+}

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -66,7 +66,10 @@ pub fn parse_live_status_file(
         Err(err) => return Err(err.into()),
     };
 
-    let value: Value = serde_json::from_str(&content)?;
+    let value: Value = match serde_json::from_str(&content) {
+        Ok(value) => value,
+        Err(_) => return Ok(None),
+    };
     let last_activity = value
         .get("last_activity")
         .and_then(|v| v.as_str())

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -94,6 +94,31 @@ fn preferred_group<'a>(items: &'a [AgentSessionSummary]) -> Vec<&'a AgentSession
     refs
 }
 
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+enum AgentSessionKey {
+    SessionId {
+        runtime: AgentRuntime,
+        session_id: String,
+    },
+    Cwd {
+        runtime: AgentRuntime,
+        cwd: PathBuf,
+    },
+}
+
+fn session_key(session: &AgentSessionSummary) -> AgentSessionKey {
+    match &session.session_id {
+        Some(session_id) => AgentSessionKey::SessionId {
+            runtime: session.runtime,
+            session_id: session_id.clone(),
+        },
+        None => AgentSessionKey::Cwd {
+            runtime: session.runtime,
+            cwd: session.cwd.clone(),
+        },
+    }
+}
+
 fn jsonl_files_under(root: &Path) -> Vec<PathBuf> {
     WalkBuilder::new(root)
         .hidden(false)
@@ -136,13 +161,10 @@ impl AgentDiscovery {
     }
 
     pub fn discover(&self, now: DateTime<Local>) -> Result<Vec<AgentSessionSummary>> {
-        let mut sessions = Vec::new();
-
-        sessions.extend(self.load_live_statuses()?);
-        sessions.extend(self.load_codex_sessions()?);
-        sessions.extend(self.load_claude_sessions()?);
-
-        let mut merged = merge_session_summaries(sessions);
+        let live_sessions = merge_session_summaries(self.load_live_statuses()?);
+        let recent_history = self.load_recent_history_sessions(now)?;
+        let merged_history = merge_session_summaries(recent_history);
+        let mut merged = merge_live_sessions(live_sessions, merged_history);
         merged.retain(|session| self.keep_session(session, now));
         sort_session_summaries(&mut merged);
         Ok(merged)
@@ -193,6 +215,26 @@ impl AgentDiscovery {
             };
             sessions.extend(content.lines().filter_map(parse_claude_session_event_line));
         }
+
+        Ok(sessions)
+    }
+
+    fn load_recent_history_sessions(
+        &self,
+        now: DateTime<Local>,
+    ) -> Result<Vec<AgentSessionSummary>> {
+        let mut sessions = Vec::new();
+
+        sessions.extend(
+            self.load_codex_sessions()?
+                .into_iter()
+                .filter(|session| self.keep_session(session, now)),
+        );
+        sessions.extend(
+            self.load_claude_sessions()?
+                .into_iter()
+                .filter(|session| self.keep_session(session, now)),
+        );
 
         Ok(sessions)
     }
@@ -287,13 +329,10 @@ pub fn parse_codex_session_meta_line(line: &str) -> Option<AgentSessionSummary> 
 }
 
 pub fn merge_session_summaries(items: Vec<AgentSessionSummary>) -> Vec<AgentSessionSummary> {
-    let mut grouped: HashMap<(AgentRuntime, PathBuf), Vec<AgentSessionSummary>> = HashMap::new();
+    let mut grouped: HashMap<AgentSessionKey, Vec<AgentSessionSummary>> = HashMap::new();
 
     for item in items {
-        grouped
-            .entry((item.runtime, item.cwd.clone()))
-            .or_default()
-            .push(item);
+        grouped.entry(session_key(&item)).or_default().push(item);
     }
 
     let mut merged = Vec::with_capacity(grouped.len());
@@ -305,58 +344,101 @@ pub fn merge_session_summaries(items: Vec<AgentSessionSummary>) -> Vec<AgentSess
         }
 
         let ordered = preferred_group(&group);
-        let mut selected = ordered[0].clone();
-        let newest_timestamp = ordered
+        merged.push(merge_session_group(ordered));
+    }
+
+    merged
+}
+
+fn merge_session_group(items: Vec<&AgentSessionSummary>) -> AgentSessionSummary {
+    let mut selected = items[0].clone();
+    let newest_timestamp = items
+        .iter()
+        .map(|item| item.last_activity)
+        .max()
+        .unwrap_or(selected.last_activity);
+    let live_item = items.iter().copied().find(|item| item.is_live);
+    let session_store_item = items
+        .iter()
+        .copied()
+        .find(|item| matches!(item.source, AgentSessionSource::SessionStore));
+
+    if let Some(item) = live_item {
+        selected.state = item.state;
+        selected.is_live = true;
+    }
+
+    if selected.branch.is_none()
+        || is_fallback_label(selected.runtime, selected.agent_label.as_str())
+    {
+        if let Some(branch) = items
             .iter()
-            .map(|item| item.last_activity)
-            .max()
-            .unwrap_or(selected.last_activity);
-        let live_item = ordered.iter().find(|item| item.is_live);
-        let session_store_item = ordered
+            .filter_map(|item| item.branch.clone())
+            .find(|branch| !branch.is_empty())
+        {
+            selected.branch = Some(branch);
+        }
+    }
+
+    if is_fallback_label(selected.runtime, &selected.agent_label)
+        && session_store_item
+            .map(|item| !is_fallback_label(selected.runtime, &item.agent_label))
+            .unwrap_or(false)
+    {
+        if let Some(label) = items
             .iter()
-            .find(|item| matches!(item.source, AgentSessionSource::SessionStore));
-
-        if let Some(item) = live_item {
-            selected.state = item.state;
-            selected.is_live = true;
-        }
-
-        if selected.branch.is_none()
-            || is_fallback_label(selected.runtime, selected.agent_label.as_str())
+            .map(|item| item.agent_label.as_str())
+            .find(|label| !is_fallback_label(selected.runtime, label))
         {
-            if let Some(branch) = ordered
-                .iter()
-                .filter_map(|item| item.branch.clone())
-                .find(|branch| !branch.is_empty())
-            {
-                selected.branch = Some(branch);
+            selected.agent_label = label.to_string();
+        }
+    }
+
+    if selected.session_id.is_none() {
+        selected.session_id = items.iter().find_map(|item| item.session_id.clone());
+    }
+
+    selected.last_activity = newest_timestamp;
+    selected.source = AgentSessionSource::Merged;
+    selected
+}
+
+fn merge_live_sessions(
+    live_sessions: Vec<AgentSessionSummary>,
+    history_sessions: Vec<AgentSessionSummary>,
+) -> Vec<AgentSessionSummary> {
+    let mut history_by_cwd: HashMap<(AgentRuntime, PathBuf), Vec<AgentSessionSummary>> =
+        HashMap::new();
+
+    for session in history_sessions {
+        history_by_cwd
+            .entry((session.runtime, session.cwd.clone()))
+            .or_default()
+            .push(session);
+    }
+
+    let mut merged = Vec::new();
+
+    for live in live_sessions {
+        let key = (live.runtime, live.cwd.clone());
+        match history_by_cwd.remove(&key) {
+            Some(history_group) if history_group.len() == 1 => {
+                merged.push(merge_session_group(vec![&live, &history_group[0]]));
             }
-        }
-
-        if is_fallback_label(selected.runtime, &selected.agent_label)
-            && session_store_item
-                .map(|item| !is_fallback_label(selected.runtime, &item.agent_label))
-                .unwrap_or(false)
-        {
-            if let Some(label) = ordered
-                .iter()
-                .map(|item| item.agent_label.as_str())
-                .find(|label| !is_fallback_label(selected.runtime, label))
-            {
-                selected.agent_label = label.to_string();
+            Some(history_group) => {
+                merged.push(live);
+                merged.extend(history_group);
             }
+            None => merged.push(live),
         }
+    }
 
-        if selected.session_id.is_none() {
-            selected.session_id = ordered
-                .iter()
-                .find_map(|item| item.session_id.clone())
-                .or(selected.session_id);
+    for history_group in history_by_cwd.into_values() {
+        if history_group.len() == 1 {
+            merged.push(history_group.into_iter().next().unwrap());
+        } else {
+            merged.push(merge_session_group(history_group.iter().collect()));
         }
-
-        selected.last_activity = newest_timestamp;
-        selected.source = AgentSessionSource::Merged;
-        merged.push(selected);
     }
 
     merged

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -461,7 +461,7 @@ fn merge_live_sessions(
                 merged.push(merge_session_group(vec![&live, &history_group[0]]));
             }
             Some(mut history_group) => {
-                history_group.sort_by(|a, b| b.last_activity.cmp(&a.last_activity));
+                history_group.sort_by(history_merge_order);
                 let newest_history = history_group.remove(0);
                 merged.push(merge_session_group(vec![&live, &newest_history]));
                 merged.extend(history_group);
@@ -475,6 +475,15 @@ fn merge_live_sessions(
     }
 
     merged
+}
+
+fn history_merge_order(a: &AgentSessionSummary, b: &AgentSessionSummary) -> std::cmp::Ordering {
+    b.last_activity
+        .cmp(&a.last_activity)
+        .then_with(|| a.session_id.cmp(&b.session_id))
+        .then_with(|| a.branch.cmp(&b.branch))
+        .then_with(|| a.agent_label.cmp(&b.agent_label))
+        .then_with(|| a.cwd.cmp(&b.cwd))
 }
 
 pub fn sort_session_summaries(items: &mut [AgentSessionSummary]) {

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -1,5 +1,4 @@
 use crate::error::Result;
-use crate::git::GitRepository;
 use chrono::{DateTime, Duration, Local};
 use ignore::WalkBuilder;
 use serde_json::Value;
@@ -95,31 +94,6 @@ fn preferred_group<'a>(items: &'a [AgentSessionSummary]) -> Vec<&'a AgentSession
     refs
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-enum AgentSessionKey {
-    SessionId {
-        runtime: AgentRuntime,
-        session_id: String,
-    },
-    Cwd {
-        runtime: AgentRuntime,
-        cwd: PathBuf,
-    },
-}
-
-fn session_key(session: &AgentSessionSummary) -> AgentSessionKey {
-    match &session.session_id {
-        Some(session_id) => AgentSessionKey::SessionId {
-            runtime: session.runtime,
-            session_id: session_id.clone(),
-        },
-        None => AgentSessionKey::Cwd {
-            runtime: session.runtime,
-            cwd: session.cwd.clone(),
-        },
-    }
-}
-
 fn jsonl_files_under(root: &Path) -> Vec<PathBuf> {
     WalkBuilder::new(root)
         .hidden(false)
@@ -161,19 +135,66 @@ impl AgentDiscovery {
             .any(|root| is_path_within_root(&session.cwd, root))
     }
 
-    pub fn discover(&self) -> Result<Vec<AgentSessionSummary>> {
-        let now = Local::now();
+    pub fn discover(&self, now: DateTime<Local>) -> Result<Vec<AgentSessionSummary>> {
         let mut sessions = Vec::new();
 
-        sessions.extend(load_live_statuses()?);
-        sessions.extend(load_codex_sessions()?);
-        sessions.extend(load_claude_sessions()?);
-
-        sessions.retain(|session| self.keep_session(session, now));
+        sessions.extend(self.load_live_statuses()?);
+        sessions.extend(self.load_codex_sessions()?);
+        sessions.extend(self.load_claude_sessions()?);
 
         let mut merged = merge_session_summaries(sessions);
+        merged.retain(|session| self.keep_session(session, now));
         sort_session_summaries(&mut merged);
         Ok(merged)
+    }
+
+    pub fn load_live_statuses(&self) -> Result<Vec<AgentSessionSummary>> {
+        let mut sessions = Vec::new();
+
+        for root in &self.monitored_paths {
+            for runtime in [AgentRuntime::Claude, AgentRuntime::Codex] {
+                let status_path = status_file_path(root, runtime);
+                if let Some(summary) = parse_live_status_file(runtime, &status_path)? {
+                    sessions.push(summary);
+                }
+            }
+        }
+
+        Ok(sessions)
+    }
+
+    pub fn load_codex_sessions(&self) -> Result<Vec<AgentSessionSummary>> {
+        let Some(home_dir) = dirs::home_dir() else {
+            return Ok(Vec::new());
+        };
+        let sessions_root = home_dir.join(".codex").join("sessions");
+
+        let mut sessions = Vec::new();
+        for file_path in jsonl_files_under(&sessions_root) {
+            let Some(content) = load_session_file_lines(&file_path) else {
+                continue;
+            };
+            sessions.extend(content.lines().filter_map(parse_codex_session_meta_line));
+        }
+
+        Ok(sessions)
+    }
+
+    pub fn load_claude_sessions(&self) -> Result<Vec<AgentSessionSummary>> {
+        let Some(home_dir) = dirs::home_dir() else {
+            return Ok(Vec::new());
+        };
+        let sessions_root = home_dir.join(".claude").join("projects");
+
+        let mut sessions = Vec::new();
+        for file_path in jsonl_files_under(&sessions_root) {
+            let Some(content) = load_session_file_lines(&file_path) else {
+                continue;
+            };
+            sessions.extend(content.lines().filter_map(parse_claude_session_event_line));
+        }
+
+        Ok(sessions)
     }
 }
 
@@ -249,7 +270,11 @@ pub fn parse_codex_session_meta_line(line: &str) -> Option<AgentSessionSummary> 
             .and_then(|v| v.as_str())
             .map(str::to_string),
         cwd: PathBuf::from(cwd),
-        branch: None,
+        branch: payload
+            .get("gitBranch")
+            .or_else(|| payload.get("branch"))
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
         agent_label,
         state: AgentSessionState::Recent,
         last_activity: payload
@@ -261,73 +286,14 @@ pub fn parse_codex_session_meta_line(line: &str) -> Option<AgentSessionSummary> 
     })
 }
 
-pub fn load_live_statuses() -> Result<Vec<AgentSessionSummary>> {
-    let git_repo = match GitRepository::find() {
-        Ok(repo) => repo,
-        Err(_) => return Ok(Vec::new()),
-    };
-
-    let mut roots = vec![git_repo.root_path().to_path_buf()];
-    if let Ok(worktrees) = git_repo.list_worktrees() {
-        for worktree in worktrees {
-            if !roots.iter().any(|root| root == &worktree.path) {
-                roots.push(worktree.path);
-            }
-        }
-    }
-
-    let mut sessions = Vec::new();
-    for root in roots {
-        for runtime in [AgentRuntime::Claude, AgentRuntime::Codex] {
-            let status_path = status_file_path(&root, runtime);
-            if let Some(summary) = parse_live_status_file(runtime, &status_path)? {
-                sessions.push(summary);
-            }
-        }
-    }
-
-    Ok(sessions)
-}
-
-pub fn load_codex_sessions() -> Result<Vec<AgentSessionSummary>> {
-    let Some(home_dir) = dirs::home_dir() else {
-        return Ok(Vec::new());
-    };
-    let sessions_root = home_dir.join(".codex").join("sessions");
-
-    let mut sessions = Vec::new();
-    for file_path in jsonl_files_under(&sessions_root) {
-        let Some(content) = load_session_file_lines(&file_path) else {
-            continue;
-        };
-        sessions.extend(content.lines().filter_map(parse_codex_session_meta_line));
-    }
-
-    Ok(sessions)
-}
-
-pub fn load_claude_sessions() -> Result<Vec<AgentSessionSummary>> {
-    let Some(home_dir) = dirs::home_dir() else {
-        return Ok(Vec::new());
-    };
-    let sessions_root = home_dir.join(".claude").join("projects");
-
-    let mut sessions = Vec::new();
-    for file_path in jsonl_files_under(&sessions_root) {
-        let Some(content) = load_session_file_lines(&file_path) else {
-            continue;
-        };
-        sessions.extend(content.lines().filter_map(parse_claude_session_event_line));
-    }
-
-    Ok(sessions)
-}
-
 pub fn merge_session_summaries(items: Vec<AgentSessionSummary>) -> Vec<AgentSessionSummary> {
-    let mut grouped: HashMap<AgentSessionKey, Vec<AgentSessionSummary>> = HashMap::new();
+    let mut grouped: HashMap<(AgentRuntime, PathBuf), Vec<AgentSessionSummary>> = HashMap::new();
 
     for item in items {
-        grouped.entry(session_key(&item)).or_default().push(item);
+        grouped
+            .entry((item.runtime, item.cwd.clone()))
+            .or_default()
+            .push(item);
     }
 
     let mut merged = Vec::with_capacity(grouped.len());
@@ -346,21 +312,32 @@ pub fn merge_session_summaries(items: Vec<AgentSessionSummary>) -> Vec<AgentSess
             .max()
             .unwrap_or(selected.last_activity);
         let live_item = ordered.iter().find(|item| item.is_live);
+        let session_store_item = ordered
+            .iter()
+            .find(|item| matches!(item.source, AgentSessionSource::SessionStore));
 
         if let Some(item) = live_item {
             selected.state = item.state;
             selected.is_live = true;
         }
 
-        if let Some(branch) = ordered
-            .iter()
-            .filter_map(|item| item.branch.clone())
-            .find(|branch| !branch.is_empty())
+        if selected.branch.is_none()
+            || is_fallback_label(selected.runtime, selected.agent_label.as_str())
         {
-            selected.branch = Some(branch);
+            if let Some(branch) = ordered
+                .iter()
+                .filter_map(|item| item.branch.clone())
+                .find(|branch| !branch.is_empty())
+            {
+                selected.branch = Some(branch);
+            }
         }
 
-        if is_fallback_label(selected.runtime, &selected.agent_label) {
+        if is_fallback_label(selected.runtime, &selected.agent_label)
+            && session_store_item
+                .map(|item| !is_fallback_label(selected.runtime, &item.agent_label))
+                .unwrap_or(false)
+        {
             if let Some(label) = ordered
                 .iter()
                 .map(|item| item.agent_label.as_str())
@@ -368,6 +345,13 @@ pub fn merge_session_summaries(items: Vec<AgentSessionSummary>) -> Vec<AgentSess
             {
                 selected.agent_label = label.to_string();
             }
+        }
+
+        if selected.session_id.is_none() {
+            selected.session_id = ordered
+                .iter()
+                .find_map(|item| item.session_id.clone())
+                .or(selected.session_id);
         }
 
         selected.last_activity = newest_timestamp;

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -195,7 +195,9 @@ impl AgentDiscovery {
             let Some(content) = load_session_file_lines(&file_path) else {
                 continue;
             };
-            sessions.extend(content.lines().filter_map(parse_codex_session_meta_line));
+            if let Some(summary) = parse_codex_session_file(&content) {
+                sessions.push(summary);
+            }
         }
 
         Ok(sessions)
@@ -325,6 +327,40 @@ pub fn parse_codex_session_meta_line(line: &str) -> Option<AgentSessionSummary> 
         is_live: false,
         source: AgentSessionSource::SessionStore,
     })
+}
+
+fn parse_codex_session_file(content: &str) -> Option<AgentSessionSummary> {
+    let mut session = None;
+    let mut newest_event_timestamp = None;
+
+    for line in content.lines() {
+        let value: Value = match serde_json::from_str(line) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+
+        if let Some(timestamp) = value
+            .get("timestamp")
+            .and_then(|v| v.as_str())
+            .and_then(parse_timestamp)
+        {
+            newest_event_timestamp = Some(match newest_event_timestamp {
+                Some(current) if current >= timestamp => current,
+                _ => timestamp,
+            });
+        }
+
+        if value.get("type").and_then(|v| v.as_str()) == Some("session_meta") {
+            session = parse_codex_session_meta_line(line);
+        }
+    }
+
+    let mut session = session?;
+    if let Some(timestamp) = newest_event_timestamp {
+        session.last_activity = timestamp;
+    }
+
+    Some(session)
 }
 
 pub fn merge_session_summaries(items: Vec<AgentSessionSummary>) -> Vec<AgentSessionSummary> {

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -424,8 +424,10 @@ fn merge_live_sessions(
             Some(history_group) if history_group.len() == 1 => {
                 merged.push(merge_session_group(vec![&live, &history_group[0]]));
             }
-            Some(history_group) => {
-                merged.push(live);
+            Some(mut history_group) => {
+                history_group.sort_by(|a, b| b.last_activity.cmp(&a.last_activity));
+                let newest_history = history_group.remove(0);
+                merged.push(merge_session_group(vec![&live, &newest_history]));
                 merged.extend(history_group);
             }
             None => merged.push(live),

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -165,7 +165,6 @@ impl AgentDiscovery {
         let recent_history = self.load_recent_history_sessions(now)?;
         let merged_history = merge_session_summaries(recent_history);
         let mut merged = merge_live_sessions(live_sessions, merged_history);
-        merged.retain(|session| self.keep_session(session, now));
         sort_session_summaries(&mut merged);
         Ok(merged)
     }
@@ -434,11 +433,7 @@ fn merge_live_sessions(
     }
 
     for history_group in history_by_cwd.into_values() {
-        if history_group.len() == 1 {
-            merged.push(history_group.into_iter().next().unwrap());
-        } else {
-            merged.push(merge_session_group(history_group.iter().collect()));
-        }
+        merged.extend(history_group);
     }
 
     merged

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -314,10 +314,17 @@ pub fn parse_codex_session_meta_line(line: &str) -> Option<AgentSessionSummary> 
             .map(str::to_string),
         cwd: PathBuf::from(cwd),
         branch: payload
-            .get("gitBranch")
-            .or_else(|| payload.get("branch"))
+            .get("git")
+            .and_then(|git| git.get("branch"))
             .and_then(|v| v.as_str())
-            .map(str::to_string),
+            .map(str::to_string)
+            .or_else(|| {
+                payload
+                    .get("gitBranch")
+                    .or_else(|| payload.get("branch"))
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+            }),
         agent_label,
         state: AgentSessionState::Recent,
         last_activity: payload

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -487,10 +487,10 @@ fn merge_live_sessions(
 fn history_merge_order(a: &AgentSessionSummary, b: &AgentSessionSummary) -> std::cmp::Ordering {
     b.last_activity
         .cmp(&a.last_activity)
-        .then_with(|| a.session_id.cmp(&b.session_id))
-        .then_with(|| a.branch.cmp(&b.branch))
-        .then_with(|| a.agent_label.cmp(&b.agent_label))
-        .then_with(|| a.cwd.cmp(&b.cwd))
+        .then_with(|| b.session_id.cmp(&a.session_id))
+        .then_with(|| b.branch.cmp(&a.branch))
+        .then_with(|| b.agent_label.cmp(&a.agent_label))
+        .then_with(|| b.cwd.cmp(&a.cwd))
 }
 
 pub fn sort_session_summaries(items: &mut [AgentSessionSummary]) {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -686,6 +686,7 @@ impl Cli {
     }
 
     fn handle_agents(&self) -> Result<()> {
+        use crate::agents::AgentDiscovery;
         use crate::git::GitRepository;
         use crate::tui::AgentsDashboard;
 
@@ -695,20 +696,19 @@ impl Cli {
             return Ok(());
         }
 
-        // Find the Git repository
         let git_repo =
             GitRepository::find().map_err(|_| anyhow::anyhow!("Not in a Git repository"))?;
+        let mut monitored_paths = vec![git_repo.root_path().to_path_buf()];
+        monitored_paths.extend(
+            git_repo
+                .list_worktrees()?
+                .into_iter()
+                .map(|worktree| worktree.path),
+        );
+        monitored_paths.sort();
+        monitored_paths.dedup();
 
-        println!("🤖 Starting Agent Activity Monitor...");
-        println!("💡 This will show live Claude Code agent activities");
-        println!("⏱️  Press any key to start the dashboard...");
-
-        // Wait for user confirmation
-        use std::io::{self, Read};
-        let mut buffer = [0; 1];
-        io::stdin().read_exact(&mut buffer).ok();
-
-        let dashboard = AgentsDashboard::new();
+        let dashboard = AgentsDashboard::new(AgentDiscovery::new(monitored_paths));
         dashboard.run()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //! This crate combines Copy-on-Write (CoW) filesystem operations with advanced Git worktree
 //! management to provide fast, reliable development environment setup.
 
+pub mod agents;
 pub mod config;
 pub mod cow;
 pub mod error;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod agents;
 mod cli;
 mod config;
 mod cow;

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,5 +1,11 @@
-use crate::error::Result;
-use chrono::Timelike;
+use crate::{
+    agents::{
+        AgentDiscovery, AgentRuntime, AgentSessionSource, AgentSessionState, AgentSessionSummary,
+        sort_session_summaries,
+    },
+    error::Result,
+};
+use chrono::{DateTime, Duration as ChronoDuration, Local};
 use crossterm::{
     event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, poll},
     execute,
@@ -8,10 +14,10 @@ use crossterm::{
 use ratatui::{
     Frame, Terminal as RatatuiTerminal,
     backend::CrosstermBackend,
-    layout::{Alignment, Constraint, Direction, Layout, Margin},
+    layout::{Alignment, Constraint, Direction, Layout},
     style::{Color, Modifier, Style},
-    text::{Line, Span},
-    widgets::{Block, Borders, Cell, Gauge, List, ListItem, ListState, Paragraph, Row, Table},
+    text::Line,
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
 };
 use std::{
     io,
@@ -19,76 +25,41 @@ use std::{
     time::{Duration, Instant},
 };
 
+const REFRESH_INTERVAL: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DashboardRow {
+    pub session: AgentSessionSummary,
+    pub state_symbol: &'static str,
+    pub runtime_label: &'static str,
+    pub location_label: String,
+    pub agent_label: String,
+    pub relative_time: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DashboardModel {
+    pub rows: Vec<DashboardRow>,
+    pub empty_state_lines: Vec<String>,
+}
+
 pub struct TuiApp {
     should_quit: bool,
     selected_index: usize,
-    last_update: Instant,
-}
-
-#[derive(Debug, Clone)]
-pub struct AgentActivity {
-    pub timestamp: String,
-    pub agent_name: String,
-    pub activity: String,
-    pub file_path: Option<PathBuf>,
-    pub status: AgentStatus,
-}
-
-#[derive(Debug, Clone)]
-pub enum AgentStatus {
-    Active,
-    Waiting,
-    Completed,
-    Error,
-}
-
-impl AgentStatus {
-    pub fn color(&self) -> Color {
-        match self {
-            AgentStatus::Active => Color::Green,
-            AgentStatus::Waiting => Color::Yellow,
-            AgentStatus::Completed => Color::Blue,
-            AgentStatus::Error => Color::Red,
-        }
-    }
-
-    pub fn symbol(&self) -> &'static str {
-        match self {
-            AgentStatus::Active => "🔄",
-            AgentStatus::Waiting => "⏳",
-            AgentStatus::Completed => "✅",
-            AgentStatus::Error => "❌",
-        }
-    }
+    last_refresh: Instant,
+    discovery: AgentDiscovery,
+    sessions: Vec<AgentSessionSummary>,
 }
 
 impl TuiApp {
-    pub fn new() -> Self {
+    pub fn new(discovery: AgentDiscovery) -> Self {
         Self {
             should_quit: false,
             selected_index: 0,
-            last_update: Instant::now(),
+            last_refresh: Instant::now() - REFRESH_INTERVAL,
+            discovery,
+            sessions: Vec::new(),
         }
-    }
-
-    pub fn get_selected_index(&self) -> usize {
-        self.selected_index
-    }
-
-    pub fn set_selected_index(&mut self, index: usize) {
-        self.selected_index = index;
-    }
-
-    pub fn get_last_update(&self) -> Instant {
-        self.last_update
-    }
-
-    pub fn set_last_update(&mut self, time: Instant) {
-        self.last_update = time;
-    }
-
-    pub fn should_quit(&self) -> bool {
-        self.should_quit
     }
 
     pub fn run(&mut self) -> Result<()> {
@@ -99,6 +70,7 @@ impl TuiApp {
         let backend = CrosstermBackend::new(stdout);
         let mut terminal = RatatuiTerminal::new(backend)?;
 
+        self.refresh_sessions()?;
         let res = self.run_app(&mut terminal);
 
         // Restore terminal
@@ -117,32 +89,13 @@ impl TuiApp {
         &mut self,
         terminal: &mut RatatuiTerminal<CrosstermBackend<io::Stdout>>,
     ) -> Result<()> {
-        // Mock agent data for demo - in real implementation this would come from file watchers
-        let mut activities = vec![
-            AgentActivity {
-                timestamp: "14:32:15".to_string(),
-                agent_name: "Claude-Code".to_string(),
-                activity: "Analyzing code structure".to_string(),
-                file_path: Some(PathBuf::from("/project/src/main.rs")),
-                status: AgentStatus::Active,
-            },
-            AgentActivity {
-                timestamp: "14:31:42".to_string(),
-                agent_name: "Claude-Code".to_string(),
-                activity: "Refactoring function".to_string(),
-                file_path: Some(PathBuf::from("/project/src/utils.rs")),
-                status: AgentStatus::Completed,
-            },
-            AgentActivity {
-                timestamp: "14:30:18".to_string(),
-                agent_name: "Claude-Code".to_string(),
-                activity: "Waiting for user input".to_string(),
-                file_path: None,
-                status: AgentStatus::Waiting,
-            },
-        ];
-
         loop {
+            if self.last_refresh.elapsed() >= REFRESH_INTERVAL {
+                self.refresh_sessions()?;
+            }
+
+            terminal.draw(|f| self.draw_agents_dashboard(f, Local::now()))?;
+
             // Non-blocking event check
             let timeout = Duration::from_millis(100);
             if poll(timeout)? {
@@ -160,36 +113,17 @@ impl TuiApp {
                             }
                         }
                         KeyCode::Down => {
-                            if self.selected_index < activities.len().saturating_sub(1) {
+                            if self.selected_index < self.sessions.len().saturating_sub(1) {
                                 self.selected_index += 1;
                             }
                         }
                         KeyCode::Char('r') => {
-                            // Simulate refresh - add new activity
-                            activities.insert(
-                                0,
-                                AgentActivity {
-                                    timestamp: format!(
-                                        "{:02}:{:02}:{:02}",
-                                        chrono::Local::now().hour(),
-                                        chrono::Local::now().minute(),
-                                        chrono::Local::now().second()
-                                    ),
-                                    agent_name: "Claude-Code".to_string(),
-                                    activity: "Processing new request".to_string(),
-                                    file_path: Some(PathBuf::from("/project/src/new_module.rs")),
-                                    status: AgentStatus::Active,
-                                },
-                            );
-                            self.selected_index = 0;
+                            self.refresh_sessions()?;
                         }
                         _ => {}
                     }
                 }
             }
-
-            // Update UI
-            terminal.draw(|f| self.draw_agents_dashboard(f, &activities))?;
 
             if self.should_quit {
                 break;
@@ -199,20 +133,31 @@ impl TuiApp {
         Ok(())
     }
 
-    fn draw_agents_dashboard(&self, f: &mut Frame, activities: &[AgentActivity]) {
+    fn refresh_sessions(&mut self) -> Result<()> {
+        self.sessions = self.discovery.discover(Local::now())?;
+        if self.sessions.is_empty() {
+            self.selected_index = 0;
+        } else {
+            self.selected_index = self.selected_index.min(self.sessions.len() - 1);
+        }
+        self.last_refresh = Instant::now();
+        Ok(())
+    }
+
+    fn draw_agents_dashboard(&self, f: &mut Frame, now: DateTime<Local>) {
+        let model = build_dashboard_model(&self.sessions, now);
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .margin(1)
             .constraints([
                 Constraint::Length(3), // Header
                 Constraint::Min(8),    // Main content
-                Constraint::Length(5), // Stats
                 Constraint::Length(3), // Help
             ])
             .split(f.size());
 
         // Header
-        let header = Paragraph::new("🤖 Agent Activity Monitor")
+        let header = Paragraph::new(format!("Warp Agents ({})", model.rows.len()))
             .style(
                 Style::default()
                     .fg(Color::Cyan)
@@ -222,146 +167,222 @@ impl TuiApp {
             .block(Block::default().borders(Borders::ALL));
         f.render_widget(header, chunks[0]);
 
-        // Main activity list
-        let activity_items: Vec<ListItem> = activities
-            .iter()
-            .enumerate()
-            .map(|(i, activity)| {
-                let style = if i == self.selected_index {
-                    Style::default().bg(Color::DarkGray)
-                } else {
+        if model.rows.is_empty() {
+            let empty_state = Paragraph::new(model.empty_state_lines.join("\n\n"))
+                .block(Block::default().title("No Sessions").borders(Borders::ALL))
+                .alignment(Alignment::Center)
+                .style(Style::default().fg(Color::Gray))
+                .wrap(Wrap { trim: false });
+            f.render_widget(empty_state, chunks[1]);
+        } else {
+            let content_chunks = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
+                .split(chunks[1]);
+
+            let session_items: Vec<ListItem> = model
+                .rows
+                .iter()
+                .enumerate()
+                .map(|(index, row)| {
+                    let text = format!(
+                        "{} {:<6} {:<18} {:<20} {}",
+                        row.state_symbol,
+                        row.runtime_label,
+                        truncate_label(&row.location_label, 18),
+                        truncate_label(&row.agent_label, 20),
+                        row.relative_time
+                    );
+                    let style = if index == self.selected_index {
+                        Style::default().fg(session_state_color(row.session.state))
+                    } else {
+                        Style::default().fg(session_state_color(row.session.state))
+                    };
+                    ListItem::new(Line::from(text)).style(style)
+                })
+                .collect();
+
+            let sessions_list = List::new(session_items)
+                .block(Block::default().title("Sessions").borders(Borders::ALL))
+                .highlight_style(
                     Style::default()
-                };
+                        .bg(Color::DarkGray)
+                        .add_modifier(Modifier::BOLD),
+                )
+                .highlight_symbol(">> ");
+            let mut list_state = ListState::default();
+            list_state.select(Some(self.selected_index));
+            f.render_stateful_widget(sessions_list, content_chunks[0], &mut list_state);
 
-                let file_info = if let Some(path) = &activity.file_path {
-                    format!(
-                        " ({})",
-                        path.file_name().unwrap_or_default().to_string_lossy()
-                    )
-                } else {
-                    String::new()
-                };
-
-                let content = format!(
-                    "{} {} [{}] {}{}!",
-                    activity.status.symbol(),
-                    activity.timestamp,
-                    activity.agent_name,
-                    activity.activity,
-                    file_info
-                );
-
-                ListItem::new(Line::from(Span::styled(
-                    content,
-                    style.fg(activity.status.color()),
-                )))
-            })
-            .collect();
-
-        let activities_list = List::new(activity_items)
-            .block(
-                Block::default()
-                    .title("Recent Activity")
-                    .borders(Borders::ALL),
-            )
-            .highlight_style(Style::default().add_modifier(Modifier::REVERSED))
-            .highlight_symbol(">> ");
-
-        let mut list_state = ListState::default();
-        list_state.select(Some(self.selected_index));
-        f.render_stateful_widget(activities_list, chunks[1], &mut list_state);
-
-        // Stats section
-        let stats_chunks = Layout::default()
-            .direction(Direction::Horizontal)
-            .constraints([
-                Constraint::Percentage(33),
-                Constraint::Percentage(33),
-                Constraint::Percentage(34),
-            ])
-            .split(chunks[2]);
-
-        let active_count = activities
-            .iter()
-            .filter(|a| matches!(a.status, AgentStatus::Active))
-            .count();
-        let total_count = activities.len();
-        let completed_count = activities
-            .iter()
-            .filter(|a| matches!(a.status, AgentStatus::Completed))
-            .count();
-
-        // Active agents gauge
-        let active_ratio = if total_count > 0 {
-            active_count as f64 / total_count as f64
-        } else {
-            0.0
-        };
-        let active_gauge = Gauge::default()
-            .block(Block::default().title("Active").borders(Borders::ALL))
-            .gauge_style(Style::default().fg(Color::Green))
-            .ratio(active_ratio)
-            .label(format!("{}/{}", active_count, total_count));
-        f.render_widget(active_gauge, stats_chunks[0]);
-
-        // Completion rate
-        let completion_ratio = if total_count > 0 {
-            completed_count as f64 / total_count as f64
-        } else {
-            0.0
-        };
-        let completion_gauge = Gauge::default()
-            .block(Block::default().title("Completed").borders(Borders::ALL))
-            .gauge_style(Style::default().fg(Color::Blue))
-            .ratio(completion_ratio)
-            .label(format!("{:.1}%", completion_ratio * 100.0));
-        f.render_widget(completion_gauge, stats_chunks[1]);
-
-        // Uptime
-        let uptime = self.last_update.elapsed().as_secs();
-        let uptime_display = Paragraph::new(format!("{}m {}s", uptime / 60, uptime % 60))
-            .block(Block::default().title("Uptime").borders(Borders::ALL))
-            .alignment(Alignment::Center)
-            .style(Style::default().fg(Color::Yellow));
-        f.render_widget(uptime_display, stats_chunks[2]);
+            if let Some(selected_row) = model.rows.get(self.selected_index) {
+                let details =
+                    Paragraph::new(session_detail_lines(&selected_row.session).join("\n"))
+                        .block(Block::default().title("Details").borders(Borders::ALL))
+                        .style(Style::default().fg(Color::White))
+                        .wrap(Wrap { trim: false });
+                f.render_widget(details, content_chunks[1]);
+            }
+        }
 
         // Help
-        let help_text = "↑↓: Navigate | r: Refresh | q: Quit | Esc: Exit";
+        let help_text = "↑↓: Navigate | r: Refresh | q/Esc: Quit";
         let help = Paragraph::new(help_text)
             .style(Style::default().fg(Color::Gray))
             .alignment(Alignment::Center)
             .block(Block::default().borders(Borders::ALL).title("Help"));
-        f.render_widget(help, chunks[3]);
+        f.render_widget(help, chunks[2]);
     }
 }
 
-pub struct AgentsDashboard;
+pub fn build_dashboard_model(
+    sessions: &[AgentSessionSummary],
+    now: DateTime<Local>,
+) -> DashboardModel {
+    let mut ordered_sessions = sessions.to_vec();
+    sort_session_summaries(&mut ordered_sessions);
+
+    let rows = ordered_sessions
+        .into_iter()
+        .map(|session| DashboardRow {
+            state_symbol: session_state_symbol(session.state),
+            runtime_label: runtime_label(session.runtime),
+            location_label: session_location_label(&session),
+            agent_label: session.agent_label.clone(),
+            relative_time: relative_time_label(session.last_activity, now),
+            session,
+        })
+        .collect::<Vec<_>>();
+
+    let empty_state_lines = if rows.is_empty() {
+        vec![
+            "No live or recent Claude/Codex sessions found for this repo in the last 7 days."
+                .to_string(),
+            "Hint: run `warp hooks-install --runtime all --level user` to enable live monitoring."
+                .to_string(),
+        ]
+    } else {
+        Vec::new()
+    };
+
+    DashboardModel {
+        rows,
+        empty_state_lines,
+    }
+}
+
+pub fn session_detail_lines(session: &AgentSessionSummary) -> Vec<String> {
+    vec![
+        format!("Agent: {}", session.agent_label),
+        format!("CWD: {}", session.cwd.display()),
+        format!(
+            "Session ID: {}",
+            session.session_id.as_deref().unwrap_or("-")
+        ),
+        format!("Runtime: {}", runtime_label(session.runtime)),
+        format!("Branch: {}", session.branch.as_deref().unwrap_or("-")),
+        format!(
+            "Presence: {}",
+            if session.is_live { "live" } else { "recent" }
+        ),
+        format!("Last Activity: {}", session.last_activity.to_rfc3339()),
+        format!("Source: {}", source_label(session.source)),
+    ]
+}
+
+fn session_state_symbol(state: AgentSessionState) -> &'static str {
+    match state {
+        AgentSessionState::Working => "●",
+        AgentSessionState::Processing => "◔",
+        AgentSessionState::Waiting => "⏳",
+        AgentSessionState::Completed => "✓",
+        AgentSessionState::Recent => "○",
+        AgentSessionState::Unknown => "?",
+    }
+}
+
+fn session_state_color(state: AgentSessionState) -> Color {
+    match state {
+        AgentSessionState::Working => Color::Green,
+        AgentSessionState::Processing => Color::Cyan,
+        AgentSessionState::Waiting => Color::Yellow,
+        AgentSessionState::Completed => Color::Blue,
+        AgentSessionState::Recent => Color::Gray,
+        AgentSessionState::Unknown => Color::Red,
+    }
+}
+
+fn runtime_label(runtime: AgentRuntime) -> &'static str {
+    match runtime {
+        AgentRuntime::Claude => "Claude",
+        AgentRuntime::Codex => "Codex",
+    }
+}
+
+fn source_label(source: AgentSessionSource) -> &'static str {
+    match source {
+        AgentSessionSource::LiveStatus => "LiveStatus",
+        AgentSessionSource::SessionStore => "SessionStore",
+        AgentSessionSource::Merged => "Merged",
+    }
+}
+
+fn session_location_label(session: &AgentSessionSummary) -> String {
+    session
+        .branch
+        .clone()
+        .filter(|branch| !branch.trim().is_empty())
+        .unwrap_or_else(|| {
+            session
+                .cwd
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_else(|| session.cwd.display().to_string())
+        })
+}
+
+fn relative_time_label(last_activity: DateTime<Local>, now: DateTime<Local>) -> String {
+    let delta = now.signed_duration_since(last_activity);
+    if delta < ChronoDuration::minutes(1) {
+        "just now".to_string()
+    } else if delta < ChronoDuration::hours(1) {
+        format!("{}m ago", delta.num_minutes())
+    } else if delta < ChronoDuration::days(1) {
+        format!("{}h ago", delta.num_hours())
+    } else {
+        format!("{}d ago", delta.num_days())
+    }
+}
+
+fn truncate_label(value: &str, max_chars: usize) -> String {
+    let mut chars = value.chars();
+    let candidate: String = chars.by_ref().take(max_chars).collect();
+    if chars.next().is_some() && max_chars > 3 {
+        format!(
+            "{}...",
+            candidate.chars().take(max_chars - 3).collect::<String>()
+        )
+    } else {
+        candidate
+    }
+}
+
+pub struct AgentsDashboard {
+    discovery: AgentDiscovery,
+}
 
 impl AgentsDashboard {
-    pub fn new() -> Self {
-        Self
+    pub fn new(discovery: AgentDiscovery) -> Self {
+        Self { discovery }
     }
 
     pub fn run(&self) -> Result<()> {
-        let mut app = TuiApp::new();
+        let mut app = TuiApp::new(self.discovery.clone());
         app.run()
     }
 
     /// Start monitoring agents in a specific worktree
     pub fn monitor_worktree(&self, worktree_path: PathBuf) -> Result<()> {
-        println!(
-            "🔍 Starting agent monitoring for: {}",
-            worktree_path.display()
-        );
-
-        // TODO: In real implementation, set up file watchers here
-        // let (tx, rx) = mpsc::channel();
-        // let mut watcher: RecommendedWatcher = Watcher::new_immediate(move |res| {
-        //     tx.send(res).unwrap();
-        // })?;
-        // watcher.watch(&worktree_path, RecursiveMode::Recursive)?;
-
-        let mut app = TuiApp::new();
+        let mut app = TuiApp::new(AgentDiscovery::new(vec![worktree_path]));
         app.run()
     }
 }
@@ -414,7 +435,7 @@ impl CleanupTui {
         let mut should_quit = false;
         let mut confirmed = false;
 
-        let result = loop {
+        loop {
             terminal.draw(|f| {
                 let chunks = Layout::default()
                     .direction(Direction::Vertical)
@@ -519,7 +540,7 @@ impl CleanupTui {
                     }
                 }
             }
-        };
+        }
 
         // Cleanup terminal
         disable_raw_mode()?;
@@ -562,7 +583,7 @@ impl ConfigTui {
         println!("💡 Edit config file at: ~/.config/git-warp/config.toml");
 
         // Show current TUI for demonstration
-        let mut app = TuiApp::new();
+        let mut app = TuiApp::new(AgentDiscovery::new(Vec::new()));
         app.run()
     }
 }
@@ -570,34 +591,42 @@ impl ConfigTui {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::TimeZone;
 
     #[test]
     fn test_tui_creation() {
-        let dashboard = AgentsDashboard::new();
-        // Just test that we can create the TUI components
+        let _dashboard =
+            AgentsDashboard::new(AgentDiscovery::new(vec![PathBuf::from("/tmp/repo")]));
         let _cleanup_tui = CleanupTui::new();
         let _config_tui = ConfigTui::new();
     }
 
     #[test]
-    fn test_agent_status() {
-        assert_eq!(AgentStatus::Active.symbol(), "🔄");
-        assert_eq!(AgentStatus::Waiting.color(), Color::Yellow);
-        assert_eq!(AgentStatus::Completed.symbol(), "✅");
-        assert_eq!(AgentStatus::Error.color(), Color::Red);
+    fn test_build_dashboard_model_empty_state() {
+        let model =
+            build_dashboard_model(&[], Local.with_ymd_and_hms(2026, 4, 23, 12, 0, 0).unwrap());
+
+        assert!(model.rows.is_empty());
+        assert_eq!(model.empty_state_lines.len(), 2);
     }
 
     #[test]
-    fn test_agent_activity() {
-        let activity = AgentActivity {
-            timestamp: "12:34:56".to_string(),
-            agent_name: "TestAgent".to_string(),
-            activity: "Testing".to_string(),
-            file_path: Some(PathBuf::from("/test/file.rs")),
-            status: AgentStatus::Active,
+    fn test_session_detail_lines() {
+        let session = AgentSessionSummary {
+            runtime: AgentRuntime::Codex,
+            session_id: Some("session-123".to_string()),
+            cwd: PathBuf::from("/tmp/repo/.worktrees/agents"),
+            branch: Some("feat/agents".to_string()),
+            agent_label: "Parfit (worker)".to_string(),
+            state: AgentSessionState::Working,
+            last_activity: Local.with_ymd_and_hms(2026, 4, 23, 11, 0, 0).unwrap(),
+            is_live: true,
+            source: AgentSessionSource::Merged,
         };
 
-        assert_eq!(activity.agent_name, "TestAgent");
-        assert!(activity.file_path.is_some());
+        let lines = session_detail_lines(&session);
+
+        assert!(lines.iter().any(|line| line == "Runtime: Codex"));
+        assert!(lines.iter().any(|line| line == "Source: Merged"));
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -36,37 +36,26 @@ impl TuiTerminalGuard {
         enable_raw_mode()?;
         let mut stdout = io::stdout();
         if let Err(err) = execute!(stdout, EnterAlternateScreen, EnableMouseCapture) {
-            let _ = disable_raw_mode();
-            return Err(err.into());
+            return Err(rollback_terminal_entry(
+                err.into(),
+                disable_raw_mode,
+                || {
+                    let mut rollback_stdout = io::stdout();
+                    execute!(rollback_stdout, LeaveAlternateScreen, DisableMouseCapture)
+                },
+            ));
         }
 
         Ok(Self { active: true })
     }
 
     fn restore(&mut self) -> Result<()> {
-        if !self.active {
-            return Ok(());
-        }
-
-        let mut errors = Vec::new();
-
-        if let Err(err) = disable_raw_mode() {
-            errors.push(anyhow::Error::new(err));
-        }
-
-        let mut stdout = io::stdout();
-        if let Err(err) = execute!(stdout, LeaveAlternateScreen, DisableMouseCapture) {
-            errors.push(err.into());
-        }
-
-        self.active = false;
-
-        if errors.is_empty() {
-            Ok(())
-        } else {
-            let first = errors.remove(0);
-            Err(combine_errors(first, errors))
-        }
+        let (active, result) = terminal_cleanup_attempt(self.active, disable_raw_mode, || {
+            let mut stdout = io::stdout();
+            execute!(stdout, LeaveAlternateScreen, DisableMouseCapture)
+        });
+        self.active = active;
+        result
     }
 }
 
@@ -452,6 +441,53 @@ fn combine_errors(
     anyhow::anyhow!(message)
 }
 
+fn terminal_cleanup_attempt<FDisable, FCleanup>(
+    active: bool,
+    disable_raw: FDisable,
+    cleanup_terminal: FCleanup,
+) -> (bool, Result<()>)
+where
+    FDisable: FnOnce() -> io::Result<()>,
+    FCleanup: FnOnce() -> io::Result<()>,
+{
+    if !active {
+        return (false, Ok(()));
+    }
+
+    let mut errors = Vec::new();
+
+    if let Err(err) = disable_raw() {
+        errors.push(anyhow::Error::new(err));
+    }
+
+    if let Err(err) = cleanup_terminal() {
+        errors.push(anyhow::Error::new(err));
+    }
+
+    if errors.is_empty() {
+        (false, Ok(()))
+    } else {
+        let first = errors.remove(0);
+        (true, Err(combine_errors(first, errors)))
+    }
+}
+
+fn rollback_terminal_entry<FDisable, FCleanup>(
+    primary: anyhow::Error,
+    disable_raw: FDisable,
+    cleanup_terminal: FCleanup,
+) -> anyhow::Error
+where
+    FDisable: FnOnce() -> io::Result<()>,
+    FCleanup: FnOnce() -> io::Result<()>,
+{
+    let (_, rollback_result) = terminal_cleanup_attempt(true, disable_raw, cleanup_terminal);
+    match rollback_result {
+        Ok(()) => primary,
+        Err(rollback_error) => combine_errors(primary, [rollback_error]),
+    }
+}
+
 pub struct AgentsDashboard {
     discovery: AgentDiscovery,
 }
@@ -678,6 +714,7 @@ impl ConfigTui {
 mod tests {
     use super::*;
     use chrono::TimeZone;
+    use std::io;
 
     #[test]
     fn test_tui_creation() {
@@ -714,5 +751,37 @@ mod tests {
 
         assert!(lines.iter().any(|line| line == "Runtime: Codex"));
         assert!(lines.iter().any(|line| line == "Source: Merged"));
+    }
+
+    #[test]
+    fn test_terminal_cleanup_attempt_keeps_guard_active_on_failure() {
+        let (active, result) =
+            terminal_cleanup_attempt(true, || Err(io::Error::other("disable failed")), || Ok(()));
+
+        assert!(active);
+        let message = result.expect_err("cleanup should fail").to_string();
+        assert!(message.contains("disable failed"));
+    }
+
+    #[test]
+    fn test_terminal_cleanup_attempt_deactivates_guard_on_success() {
+        let (active, result) = terminal_cleanup_attempt(true, || Ok(()), || Ok(()));
+
+        assert!(!active);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_rollback_terminal_entry_combines_primary_and_cleanup_failures() {
+        let error = rollback_terminal_entry(
+            anyhow::anyhow!("enter failed"),
+            || Err(io::Error::other("disable failed")),
+            || Err(io::Error::other("leave failed")),
+        );
+
+        let message = error.to_string();
+        assert!(message.contains("enter failed"));
+        assert!(message.contains("disable failed"));
+        assert!(message.contains("leave failed"));
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -27,6 +27,47 @@ use std::{
 
 const REFRESH_INTERVAL: Duration = Duration::from_secs(2);
 
+struct TuiTerminalGuard {
+    active: bool,
+}
+
+impl TuiTerminalGuard {
+    fn enter() -> Result<Self> {
+        enable_raw_mode()?;
+        let mut stdout = io::stdout();
+        if let Err(err) = execute!(stdout, EnterAlternateScreen, EnableMouseCapture) {
+            let _ = disable_raw_mode();
+            return Err(err.into());
+        }
+
+        Ok(Self { active: true })
+    }
+
+    fn restore(&mut self) -> Result<()> {
+        if !self.active {
+            return Ok(());
+        }
+
+        disable_raw_mode()?;
+        let mut stdout = io::stdout();
+        execute!(stdout, LeaveAlternateScreen, DisableMouseCapture)?;
+        self.active = false;
+        Ok(())
+    }
+}
+
+impl Drop for TuiTerminalGuard {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+
+        let _ = disable_raw_mode();
+        let mut stdout = io::stdout();
+        let _ = execute!(stdout, LeaveAlternateScreen, DisableMouseCapture);
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct DashboardRow {
     pub session: AgentSessionSummary,
@@ -63,26 +104,20 @@ impl TuiApp {
     }
 
     pub fn run(&mut self) -> Result<()> {
-        // Setup terminal
-        enable_raw_mode()?;
-        let mut stdout = io::stdout();
-        execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-        let backend = CrosstermBackend::new(stdout);
+        let mut terminal_guard = TuiTerminalGuard::enter()?;
+        let backend = CrosstermBackend::new(io::stdout());
         let mut terminal = RatatuiTerminal::new(backend)?;
 
-        self.refresh_sessions()?;
-        let res = self.run_app(&mut terminal);
+        let run_result = self
+            .refresh_sessions()
+            .and_then(|_| self.run_app(&mut terminal));
+        let cursor_result: Result<()> = terminal.show_cursor().map_err(Into::into);
+        drop(terminal);
+        let cleanup_result = terminal_guard.restore();
 
-        // Restore terminal
-        disable_raw_mode()?;
-        execute!(
-            terminal.backend_mut(),
-            LeaveAlternateScreen,
-            DisableMouseCapture
-        )?;
-        terminal.show_cursor()?;
-
-        res
+        run_result?;
+        cursor_result?;
+        cleanup_result
     }
 
     fn run_app(
@@ -183,8 +218,7 @@ impl TuiApp {
             let session_items: Vec<ListItem> = model
                 .rows
                 .iter()
-                .enumerate()
-                .map(|(index, row)| {
+                .map(|row| {
                     let text = format!(
                         "{} {:<6} {:<18} {:<20} {}",
                         row.state_symbol,
@@ -193,11 +227,7 @@ impl TuiApp {
                         truncate_label(&row.agent_label, 20),
                         row.relative_time
                     );
-                    let style = if index == self.selected_index {
-                        Style::default().fg(session_state_color(row.session.state))
-                    } else {
-                        Style::default().fg(session_state_color(row.session.state))
-                    };
+                    let style = Style::default().fg(session_state_color(row.session.state));
                     ListItem::new(Line::from(text)).style(style)
                 })
                 .collect();
@@ -342,7 +372,18 @@ fn session_location_label(session: &AgentSessionSummary) -> String {
 
 fn relative_time_label(last_activity: DateTime<Local>, now: DateTime<Local>) -> String {
     let delta = now.signed_duration_since(last_activity);
-    if delta < ChronoDuration::minutes(1) {
+    if delta < ChronoDuration::zero() {
+        let future_delta = last_activity.signed_duration_since(now);
+        if future_delta < ChronoDuration::minutes(1) {
+            "in <1m".to_string()
+        } else if future_delta < ChronoDuration::hours(1) {
+            format!("in {}m", future_delta.num_minutes())
+        } else if future_delta < ChronoDuration::days(1) {
+            format!("in {}h", future_delta.num_hours())
+        } else {
+            format!("in {}d", future_delta.num_days())
+        }
+    } else if delta < ChronoDuration::minutes(1) {
         "just now".to_string()
     } else if delta < ChronoDuration::hours(1) {
         format!("{}m ago", delta.num_minutes())

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -764,6 +764,19 @@ mod tests {
     }
 
     #[test]
+    fn test_terminal_cleanup_attempt_keeps_guard_active_when_cleanup_fails() {
+        let (active, result) = terminal_cleanup_attempt(
+            true,
+            || Ok(()),
+            || Err(io::Error::other("cleanup failed")),
+        );
+
+        assert!(active);
+        let message = result.expect_err("cleanup should fail").to_string();
+        assert!(message.contains("cleanup failed"));
+    }
+
+    #[test]
     fn test_terminal_cleanup_attempt_deactivates_guard_on_success() {
         let (active, result) = terminal_cleanup_attempt(true, || Ok(()), || Ok(()));
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -48,11 +48,25 @@ impl TuiTerminalGuard {
             return Ok(());
         }
 
-        disable_raw_mode()?;
+        let mut errors = Vec::new();
+
+        if let Err(err) = disable_raw_mode() {
+            errors.push(anyhow::Error::new(err));
+        }
+
         let mut stdout = io::stdout();
-        execute!(stdout, LeaveAlternateScreen, DisableMouseCapture)?;
+        if let Err(err) = execute!(stdout, LeaveAlternateScreen, DisableMouseCapture) {
+            errors.push(err.into());
+        }
+
         self.active = false;
-        Ok(())
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            let first = errors.remove(0);
+            Err(combine_errors(first, errors))
+        }
     }
 }
 
@@ -111,13 +125,31 @@ impl TuiApp {
         let run_result = self
             .refresh_sessions()
             .and_then(|_| self.run_app(&mut terminal));
+        let cleanup_result = terminal_guard.restore();
         let cursor_result: Result<()> = terminal.show_cursor().map_err(Into::into);
         drop(terminal);
-        let cleanup_result = terminal_guard.restore();
 
-        run_result?;
-        cursor_result?;
-        cleanup_result
+        match run_result {
+            Err(err) => {
+                let mut follow_on_errors = Vec::new();
+                if let Err(cleanup_err) = cleanup_result {
+                    follow_on_errors.push(cleanup_err);
+                }
+                if let Err(cursor_err) = cursor_result {
+                    follow_on_errors.push(cursor_err);
+                }
+
+                if follow_on_errors.is_empty() {
+                    Err(err)
+                } else {
+                    Err(combine_errors(err, follow_on_errors))
+                }
+            }
+            Ok(()) => {
+                cleanup_result?;
+                cursor_result
+            }
+        }
     }
 
     fn run_app(
@@ -405,6 +437,19 @@ fn truncate_label(value: &str, max_chars: usize) -> String {
     } else {
         candidate
     }
+}
+
+fn combine_errors(
+    primary: anyhow::Error,
+    additional: impl IntoIterator<Item = anyhow::Error>,
+) -> anyhow::Error {
+    let mut message = primary.to_string();
+    for err in additional {
+        message.push_str("; ");
+        message.push_str(&err.to_string());
+    }
+
+    anyhow::anyhow!(message)
 }
 
 pub struct AgentsDashboard {

--- a/tests/unit/agents_tests.rs
+++ b/tests/unit/agents_tests.rs
@@ -152,16 +152,14 @@ fn test_parse_claude_session_event_line() {
 }
 
 #[test]
-fn test_merge_prefers_live_state_and_newest_timestamp() {
+fn test_merge_keeps_recent_session_rows_with_distinct_ids() {
     let merged = merge_session_summaries(vec![
         AgentSessionSummary {
             session_id: Some("session-1".to_string()),
             branch: Some("feat".to_string()),
             agent_label: "Parfit (worker)".to_string(),
             state: AgentSessionState::Recent,
-            last_activity: Local
-                .with_ymd_and_hms(2026, 4, 23, 9, 0, 0)
-                .unwrap(),
+            last_activity: Local.with_ymd_and_hms(2026, 4, 23, 9, 0, 0).unwrap(),
             is_live: false,
             source: AgentSessionSource::SessionStore,
             ..sample_summary(
@@ -175,31 +173,36 @@ fn test_merge_prefers_live_state_and_newest_timestamp() {
             )
         },
         AgentSessionSummary {
-            session_id: None,
-            branch: None,
-            agent_label: "Codex".to_string(),
-            state: AgentSessionState::Working,
+            session_id: Some("session-2".to_string()),
+            branch: Some("feat-2".to_string()),
+            agent_label: "Parfit (worker)".to_string(),
+            state: AgentSessionState::Recent,
             last_activity: Local.with_ymd_and_hms(2026, 4, 23, 10, 0, 0).unwrap(),
-            is_live: true,
-            source: AgentSessionSource::LiveStatus,
+            is_live: false,
+            source: AgentSessionSource::SessionStore,
             ..sample_summary(
                 AgentRuntime::Codex,
-                None,
+                Some("session-2"),
                 "/repo/.worktrees/feat",
-                AgentSessionState::Working,
+                AgentSessionState::Recent,
                 10,
-                true,
-                AgentSessionSource::LiveStatus,
+                false,
+                AgentSessionSource::SessionStore,
             )
         },
     ]);
 
-    assert_eq!(merged.len(), 1);
-    assert_eq!(merged[0].session_id.as_deref(), Some("session-1"));
-    assert_eq!(merged[0].state, AgentSessionState::Working);
-    assert!(merged[0].is_live);
-    assert_eq!(merged[0].source, AgentSessionSource::Merged);
-    assert_eq!(merged[0].branch.as_deref(), Some("feat"));
+    assert_eq!(merged.len(), 2);
+    assert!(
+        merged
+            .iter()
+            .any(|item| item.session_id.as_deref() == Some("session-1"))
+    );
+    assert!(
+        merged
+            .iter()
+            .any(|item| item.session_id.as_deref() == Some("session-2"))
+    );
 }
 
 #[test]
@@ -273,7 +276,50 @@ fn test_discover_for_repo_filters_by_worktree_and_recency() {
 }
 
 #[test]
-fn test_discover_merges_live_rows_before_cutoff_filtering() {
+fn test_discover_merges_live_row_with_single_recent_history_row() {
+    let _guard = home_guard();
+    let temp_home = tempfile::tempdir().unwrap();
+    let repo_root = tempfile::tempdir().unwrap();
+    let worktree_root = repo_root.path().join(".worktrees").join("feat");
+    let live_status = worktree_root.join(".codex").join("git-warp").join("status");
+    let codex_sessions = temp_home.path().join(".codex").join("sessions");
+
+    fs::create_dir_all(&live_status.parent().unwrap()).unwrap();
+    fs::create_dir_all(&codex_sessions).unwrap();
+
+    fs::write(
+        &live_status,
+        r#"{"status":"working","last_activity":"2026-04-23T10:00:00+00:00"}"#,
+    )
+    .unwrap();
+    fs::write(
+        codex_sessions.join("sessions.jsonl"),
+        format!(
+            r#"{{"timestamp":"2026-04-19T10:00:00.000Z","type":"session_meta","payload":{{"id":"session-1","timestamp":"2026-04-19T10:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker","gitBranch":"feat"}}}}"#,
+            worktree_root.display()
+        ),
+    )
+    .unwrap();
+
+    let _home_override = HomeOverride::set(&temp_home.path().to_path_buf());
+
+    let discovery =
+        AgentDiscovery::new(vec![repo_root.path().to_path_buf(), worktree_root.clone()]);
+    let now = Local.with_ymd_and_hms(2026, 4, 23, 12, 0, 0).unwrap();
+    let sessions = discovery.discover(now).unwrap();
+
+    assert_eq!(sessions.len(), 1);
+    let session = &sessions[0];
+    assert_eq!(session.state, AgentSessionState::Working);
+    assert!(session.is_live);
+    assert_eq!(session.source, AgentSessionSource::Merged);
+    assert_eq!(session.branch.as_deref(), Some("feat"));
+    assert_eq!(session.session_id.as_deref(), Some("session-1"));
+    assert_eq!(session.agent_label, "Parfit (worker)");
+}
+
+#[test]
+fn test_discover_does_not_backfill_from_old_history() {
     let _guard = home_guard();
     let temp_home = tempfile::tempdir().unwrap();
     let repo_root = tempfile::tempdir().unwrap();
@@ -300,7 +346,8 @@ fn test_discover_merges_live_rows_before_cutoff_filtering() {
 
     let _home_override = HomeOverride::set(&temp_home.path().to_path_buf());
 
-    let discovery = AgentDiscovery::new(vec![repo_root.path().to_path_buf(), worktree_root.clone()]);
+    let discovery =
+        AgentDiscovery::new(vec![repo_root.path().to_path_buf(), worktree_root.clone()]);
     let now = Local.with_ymd_and_hms(2026, 4, 23, 12, 0, 0).unwrap();
     let sessions = discovery.discover(now).unwrap();
 
@@ -308,8 +355,8 @@ fn test_discover_merges_live_rows_before_cutoff_filtering() {
     let session = &sessions[0];
     assert_eq!(session.state, AgentSessionState::Working);
     assert!(session.is_live);
-    assert_eq!(session.source, AgentSessionSource::Merged);
-    assert_eq!(session.branch.as_deref(), Some("feat"));
-    assert_eq!(session.session_id.as_deref(), Some("session-1"));
-    assert_eq!(session.agent_label, "Parfit (worker)");
+    assert_eq!(session.source, AgentSessionSource::LiveStatus);
+    assert_eq!(session.branch.as_deref(), None);
+    assert_eq!(session.session_id.as_deref(), None);
+    assert_eq!(session.agent_label, "Codex");
 }

--- a/tests/unit/agents_tests.rs
+++ b/tests/unit/agents_tests.rs
@@ -4,8 +4,6 @@ use git_warp::agents::{
     parse_codex_session_meta_line, parse_live_status_file,
 };
 use std::fs;
-use std::thread::sleep;
-use std::time::Duration;
 
 #[test]
 fn test_parse_live_status_file() {
@@ -32,14 +30,27 @@ fn test_parse_live_status_file_falls_back_to_modified_time() {
     let status_path = temp_dir.path().join("status");
     fs::write(&status_path, r#"{"status":"working","last_activity":"not-a-time"}"#).unwrap();
 
-    sleep(Duration::from_millis(1100));
-
     let summary = parse_live_status_file(AgentRuntime::Codex, &status_path)
         .unwrap()
         .expect("status file should parse");
     let modified = DateTime::<Local>::from(fs::metadata(&status_path).unwrap().modified().unwrap());
 
     assert_eq!(summary.last_activity, modified);
+}
+
+#[test]
+fn test_parse_live_status_file_malformed_json_returns_none() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let status_path = temp_dir.path().join("status");
+
+    for content in ["", "{", r#"{"status":"working""#] {
+        fs::write(&status_path, content).unwrap();
+
+        assert_eq!(
+            parse_live_status_file(AgentRuntime::Codex, &status_path).unwrap(),
+            None
+        );
+    }
 }
 
 #[test]

--- a/tests/unit/agents_tests.rs
+++ b/tests/unit/agents_tests.rs
@@ -4,6 +4,8 @@ use git_warp::agents::{
     parse_codex_session_meta_line, parse_live_status_file,
 };
 use std::fs;
+use std::thread::sleep;
+use std::time::Duration;
 
 #[test]
 fn test_parse_live_status_file() {
@@ -22,6 +24,22 @@ fn test_parse_live_status_file() {
     assert_eq!(summary.runtime, AgentRuntime::Codex);
     assert_eq!(summary.state, AgentSessionState::Working);
     assert!(summary.is_live);
+}
+
+#[test]
+fn test_parse_live_status_file_falls_back_to_modified_time() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let status_path = temp_dir.path().join("status");
+    fs::write(&status_path, r#"{"status":"working","last_activity":"not-a-time"}"#).unwrap();
+
+    sleep(Duration::from_millis(1100));
+
+    let summary = parse_live_status_file(AgentRuntime::Codex, &status_path)
+        .unwrap()
+        .expect("status file should parse");
+    let modified = DateTime::<Local>::from(fs::metadata(&status_path).unwrap().modified().unwrap());
+
+    assert_eq!(summary.last_activity, modified);
 }
 
 #[test]

--- a/tests/unit/agents_tests.rs
+++ b/tests/unit/agents_tests.rs
@@ -317,6 +317,56 @@ fn test_discover_keeps_distinct_recent_history_rows_without_live_status() {
 }
 
 #[test]
+fn test_discover_merges_live_row_with_newest_of_multiple_history_rows() {
+    let _guard = home_guard();
+    let temp_home = tempfile::tempdir().unwrap();
+    let repo_root = tempfile::tempdir().unwrap();
+    let worktree_root = repo_root.path().join(".worktrees").join("feat");
+    let live_status = worktree_root.join(".codex").join("git-warp").join("status");
+    let codex_sessions = temp_home.path().join(".codex").join("sessions");
+
+    fs::create_dir_all(&live_status.parent().unwrap()).unwrap();
+    fs::create_dir_all(&codex_sessions).unwrap();
+
+    fs::write(
+        &live_status,
+        r#"{"status":"working","last_activity":"2026-04-23T10:00:00+00:00"}"#,
+    )
+    .unwrap();
+    fs::write(
+        codex_sessions.join("sessions.jsonl"),
+        format!(
+            r#"{{"timestamp":"2026-04-22T09:00:00.000Z","type":"session_meta","payload":{{"id":"session-1","timestamp":"2026-04-22T09:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker","gitBranch":"feat"}}}}
+{{"timestamp":"2026-04-22T10:00:00.000Z","type":"session_meta","payload":{{"id":"session-2","timestamp":"2026-04-22T10:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker","gitBranch":"feat-2"}}}}"#,
+            worktree_root.display(),
+            worktree_root.display()
+        ),
+    )
+    .unwrap();
+
+    let _home_override = HomeOverride::set(&temp_home.path().to_path_buf());
+
+    let discovery =
+        AgentDiscovery::new(vec![repo_root.path().to_path_buf(), worktree_root.clone()]);
+    let now = Local.with_ymd_and_hms(2026, 4, 23, 12, 0, 0).unwrap();
+    let sessions = discovery.discover(now).unwrap();
+
+    assert_eq!(sessions.len(), 2);
+    assert!(sessions.iter().any(|session| {
+        session.is_live
+            && session.source == AgentSessionSource::Merged
+            && session.session_id.as_deref() == Some("session-2")
+            && session.branch.as_deref() == Some("feat-2")
+    }));
+    assert!(sessions.iter().any(|session| {
+        !session.is_live
+            && session.source == AgentSessionSource::SessionStore
+            && session.session_id.as_deref() == Some("session-1")
+            && session.branch.as_deref() == Some("feat")
+    }));
+}
+
+#[test]
 fn test_discover_keeps_live_row_even_when_older_than_cutoff() {
     let _guard = home_guard();
     let temp_home = tempfile::tempdir().unwrap();

--- a/tests/unit/agents_tests.rs
+++ b/tests/unit/agents_tests.rs
@@ -4,8 +4,39 @@ use git_warp::agents::{
     merge_session_summaries, parse_claude_session_event_line, parse_codex_session_meta_line,
     parse_live_status_file, sort_session_summaries,
 };
+use std::env;
 use std::fs;
 use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
+static HOME_GUARD: OnceLock<Mutex<()>> = OnceLock::new();
+
+struct HomeOverride {
+    original_home: Option<std::ffi::OsString>,
+}
+
+impl HomeOverride {
+    fn set(temp_home: &PathBuf) -> Self {
+        let original_home = env::var_os("HOME");
+        unsafe {
+            env::set_var("HOME", temp_home);
+        }
+        Self { original_home }
+    }
+}
+
+impl Drop for HomeOverride {
+    fn drop(&mut self) {
+        match self.original_home.take() {
+            Some(value) => unsafe {
+                env::set_var("HOME", value);
+            },
+            None => unsafe {
+                env::remove_var("HOME");
+            },
+        }
+    }
+}
 
 fn sample_summary(
     runtime: AgentRuntime,
@@ -29,6 +60,10 @@ fn sample_summary(
         is_live,
         source,
     }
+}
+
+fn home_guard() -> std::sync::MutexGuard<'static, ()> {
+    HOME_GUARD.get_or_init(|| Mutex::new(())).lock().unwrap()
 }
 
 #[test]
@@ -119,30 +154,52 @@ fn test_parse_claude_session_event_line() {
 #[test]
 fn test_merge_prefers_live_state_and_newest_timestamp() {
     let merged = merge_session_summaries(vec![
-        sample_summary(
-            AgentRuntime::Codex,
-            Some("session-1"),
-            "/repo/.worktrees/feat",
-            AgentSessionState::Recent,
-            9,
-            false,
-            AgentSessionSource::SessionStore,
-        ),
-        sample_summary(
-            AgentRuntime::Codex,
-            Some("session-1"),
-            "/repo/.worktrees/feat",
-            AgentSessionState::Working,
-            10,
-            true,
-            AgentSessionSource::LiveStatus,
-        ),
+        AgentSessionSummary {
+            session_id: Some("session-1".to_string()),
+            branch: Some("feat".to_string()),
+            agent_label: "Parfit (worker)".to_string(),
+            state: AgentSessionState::Recent,
+            last_activity: Local
+                .with_ymd_and_hms(2026, 4, 23, 9, 0, 0)
+                .unwrap(),
+            is_live: false,
+            source: AgentSessionSource::SessionStore,
+            ..sample_summary(
+                AgentRuntime::Codex,
+                Some("session-1"),
+                "/repo/.worktrees/feat",
+                AgentSessionState::Recent,
+                9,
+                false,
+                AgentSessionSource::SessionStore,
+            )
+        },
+        AgentSessionSummary {
+            session_id: None,
+            branch: None,
+            agent_label: "Codex".to_string(),
+            state: AgentSessionState::Working,
+            last_activity: Local.with_ymd_and_hms(2026, 4, 23, 10, 0, 0).unwrap(),
+            is_live: true,
+            source: AgentSessionSource::LiveStatus,
+            ..sample_summary(
+                AgentRuntime::Codex,
+                None,
+                "/repo/.worktrees/feat",
+                AgentSessionState::Working,
+                10,
+                true,
+                AgentSessionSource::LiveStatus,
+            )
+        },
     ]);
 
     assert_eq!(merged.len(), 1);
+    assert_eq!(merged[0].session_id.as_deref(), Some("session-1"));
     assert_eq!(merged[0].state, AgentSessionState::Working);
     assert!(merged[0].is_live);
     assert_eq!(merged[0].source, AgentSessionSource::Merged);
+    assert_eq!(merged[0].branch.as_deref(), Some("feat"));
 }
 
 #[test]
@@ -213,4 +270,46 @@ fn test_discover_for_repo_filters_by_worktree_and_recency() {
 
     assert!(kept);
     assert!(!rejected);
+}
+
+#[test]
+fn test_discover_merges_live_rows_before_cutoff_filtering() {
+    let _guard = home_guard();
+    let temp_home = tempfile::tempdir().unwrap();
+    let repo_root = tempfile::tempdir().unwrap();
+    let worktree_root = repo_root.path().join(".worktrees").join("feat");
+    let live_status = worktree_root.join(".codex").join("git-warp").join("status");
+    let codex_sessions = temp_home.path().join(".codex").join("sessions");
+
+    fs::create_dir_all(&live_status.parent().unwrap()).unwrap();
+    fs::create_dir_all(&codex_sessions).unwrap();
+
+    fs::write(
+        &live_status,
+        r#"{"status":"working","last_activity":"2026-04-23T10:00:00+00:00"}"#,
+    )
+    .unwrap();
+    fs::write(
+        codex_sessions.join("sessions.jsonl"),
+        format!(
+            r#"{{"timestamp":"2026-04-15T10:00:00.000Z","type":"session_meta","payload":{{"id":"session-1","timestamp":"2026-04-15T10:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker","gitBranch":"feat"}}}}"#,
+            worktree_root.display()
+        ),
+    )
+    .unwrap();
+
+    let _home_override = HomeOverride::set(&temp_home.path().to_path_buf());
+
+    let discovery = AgentDiscovery::new(vec![repo_root.path().to_path_buf(), worktree_root.clone()]);
+    let now = Local.with_ymd_and_hms(2026, 4, 23, 12, 0, 0).unwrap();
+    let sessions = discovery.discover(now).unwrap();
+
+    assert_eq!(sessions.len(), 1);
+    let session = &sessions[0];
+    assert_eq!(session.state, AgentSessionState::Working);
+    assert!(session.is_live);
+    assert_eq!(session.source, AgentSessionSource::Merged);
+    assert_eq!(session.branch.as_deref(), Some("feat"));
+    assert_eq!(session.session_id.as_deref(), Some("session-1"));
+    assert_eq!(session.agent_label, "Parfit (worker)");
 }

--- a/tests/unit/agents_tests.rs
+++ b/tests/unit/agents_tests.rs
@@ -135,6 +135,15 @@ fn test_parse_codex_session_meta_line() {
 }
 
 #[test]
+fn test_parse_codex_session_meta_line_legacy_branch_fallback() {
+    let line = r#"{"timestamp":"2026-04-23T05:35:14.983Z","type":"session_meta","payload":{"id":"019db8d5-cf8c-7c10-ab48-7f495e8dc54b","timestamp":"2026-04-23T05:35:13.308Z","cwd":"/tmp/repo/.worktrees/feat","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker","gitBranch":"legacy-feat"}}"#;
+
+    let summary = parse_codex_session_meta_line(line).expect("codex session should parse");
+
+    assert_eq!(summary.branch.as_deref(), Some("legacy-feat"));
+}
+
+#[test]
 fn test_parse_claude_session_event_line() {
     let line = r#"{"type":"user","timestamp":"2026-04-23T04:10:00.000Z","cwd":"/tmp/repo","sessionId":"claude-session-1","gitBranch":"main"}"#;
 
@@ -430,14 +439,14 @@ fn test_discover_merges_live_row_deterministically_on_equal_history_timestamps()
     assert!(sessions.iter().any(|session| {
         session.is_live
             && session.source == AgentSessionSource::Merged
-            && session.session_id.as_deref() == Some("session-1")
-            && session.branch.as_deref() == Some("feat-a")
+            && session.session_id.as_deref() == Some("session-2")
+            && session.branch.as_deref() == Some("feat-z")
     }));
     assert!(sessions.iter().any(|session| {
         !session.is_live
             && session.source == AgentSessionSource::SessionStore
-            && session.session_id.as_deref() == Some("session-2")
-            && session.branch.as_deref() == Some("feat-z")
+            && session.session_id.as_deref() == Some("session-1")
+            && session.branch.as_deref() == Some("feat-a")
     }));
 }
 

--- a/tests/unit/agents_tests.rs
+++ b/tests/unit/agents_tests.rs
@@ -120,7 +120,7 @@ fn test_parse_live_status_file_malformed_json_returns_none() {
 
 #[test]
 fn test_parse_codex_session_meta_line() {
-    let line = r#"{"timestamp":"2026-04-23T05:35:14.983Z","type":"session_meta","payload":{"id":"019db8d5-cf8c-7c10-ab48-7f495e8dc54b","timestamp":"2026-04-23T05:35:13.308Z","cwd":"/tmp/repo/.worktrees/feat","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker"}}"#;
+    let line = r#"{"timestamp":"2026-04-23T05:35:14.983Z","type":"session_meta","payload":{"id":"019db8d5-cf8c-7c10-ab48-7f495e8dc54b","timestamp":"2026-04-23T05:35:13.308Z","cwd":"/tmp/repo/.worktrees/feat","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker","git":{"branch":"feat"}}}"#;
 
     let summary = parse_codex_session_meta_line(line).expect("codex session should parse");
 
@@ -129,6 +129,7 @@ fn test_parse_codex_session_meta_line() {
         summary.session_id.as_deref(),
         Some("019db8d5-cf8c-7c10-ab48-7f495e8dc54b")
     );
+    assert_eq!(summary.branch.as_deref(), Some("feat"));
     assert_eq!(summary.agent_label, "Parfit (worker)");
     assert_eq!(summary.state, AgentSessionState::Recent);
 }
@@ -288,7 +289,7 @@ fn test_discover_keeps_distinct_recent_history_rows_without_live_status() {
     fs::write(
         codex_sessions.join("session-a.jsonl"),
         format!(
-            r#"{{"timestamp":"2026-04-22T09:00:00.000Z","type":"session_meta","payload":{{"id":"session-1","timestamp":"2026-04-22T09:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker","gitBranch":"feat"}}}}
+            r#"{{"timestamp":"2026-04-22T09:00:00.000Z","type":"session_meta","payload":{{"id":"session-1","timestamp":"2026-04-22T09:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker","git":{{"branch":"feat"}}}}}}
 {{"timestamp":"2026-04-22T11:00:00.000Z","type":"event","payload":{{"kind":"step"}}}}"#,
             worktree_root.display()
         ),
@@ -297,7 +298,7 @@ fn test_discover_keeps_distinct_recent_history_rows_without_live_status() {
     fs::write(
         codex_sessions.join("session-b.jsonl"),
         format!(
-            r#"{{"timestamp":"2026-04-22T10:00:00.000Z","type":"session_meta","payload":{{"id":"session-2","timestamp":"2026-04-22T10:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker","gitBranch":"feat-2"}}}}
+            r#"{{"timestamp":"2026-04-22T10:00:00.000Z","type":"session_meta","payload":{{"id":"session-2","timestamp":"2026-04-22T10:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker","git":{{"branch":"feat-2"}}}}}}
 {{"timestamp":"2026-04-22T10:30:00.000Z","type":"event","payload":{{"kind":"step"}}}}"#,
             worktree_root.display()
         ),
@@ -344,7 +345,7 @@ fn test_discover_merges_live_row_with_newest_of_multiple_history_rows() {
     fs::write(
         codex_sessions.join("session-a.jsonl"),
         format!(
-            r#"{{"timestamp":"2026-04-22T09:00:00.000Z","type":"session_meta","payload":{{"id":"session-1","timestamp":"2026-04-22T09:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker","gitBranch":"feat"}}}}
+            r#"{{"timestamp":"2026-04-22T09:00:00.000Z","type":"session_meta","payload":{{"id":"session-1","timestamp":"2026-04-22T09:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker","git":{{"branch":"feat"}}}}}}
 {{"timestamp":"2026-04-22T11:00:00.000Z","type":"event","payload":{{"kind":"step"}}}}"#,
             worktree_root.display()
         ),
@@ -353,7 +354,7 @@ fn test_discover_merges_live_row_with_newest_of_multiple_history_rows() {
     fs::write(
         codex_sessions.join("session-b.jsonl"),
         format!(
-            r#"{{"timestamp":"2026-04-22T10:00:00.000Z","type":"session_meta","payload":{{"id":"session-2","timestamp":"2026-04-22T10:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker","gitBranch":"feat-2"}}}}
+            r#"{{"timestamp":"2026-04-22T10:00:00.000Z","type":"session_meta","payload":{{"id":"session-2","timestamp":"2026-04-22T10:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker","git":{{"branch":"feat-2"}}}}}}
 {{"timestamp":"2026-04-22T10:30:00.000Z","type":"event","payload":{{"kind":"step"}}}}"#,
             worktree_root.display()
         ),
@@ -402,7 +403,7 @@ fn test_discover_merges_live_row_deterministically_on_equal_history_timestamps()
     fs::write(
         codex_sessions.join("session-b.jsonl"),
         format!(
-            r#"{{"timestamp":"2026-04-22T10:00:00.000Z","type":"session_meta","payload":{{"id":"session-2","timestamp":"2026-04-22T10:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Zulu","agent_role":"worker","gitBranch":"feat-z"}}}}
+            r#"{{"timestamp":"2026-04-22T10:00:00.000Z","type":"session_meta","payload":{{"id":"session-2","timestamp":"2026-04-22T10:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Zulu","agent_role":"worker","git":{{"branch":"feat-z"}}}}}}
 {{"timestamp":"2026-04-22T11:00:00.000Z","type":"event","payload":{{"kind":"step"}}}}"#,
             worktree_root.display()
         ),
@@ -411,7 +412,7 @@ fn test_discover_merges_live_row_deterministically_on_equal_history_timestamps()
     fs::write(
         codex_sessions.join("session-a.jsonl"),
         format!(
-            r#"{{"timestamp":"2026-04-22T09:00:00.000Z","type":"session_meta","payload":{{"id":"session-1","timestamp":"2026-04-22T09:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Alpha","agent_role":"worker","gitBranch":"feat-a"}}}}
+            r#"{{"timestamp":"2026-04-22T09:00:00.000Z","type":"session_meta","payload":{{"id":"session-1","timestamp":"2026-04-22T09:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Alpha","agent_role":"worker","git":{{"branch":"feat-a"}}}}}}
 {{"timestamp":"2026-04-22T11:00:00.000Z","type":"event","payload":{{"kind":"step"}}}}"#,
             worktree_root.display()
         ),

--- a/tests/unit/agents_tests.rs
+++ b/tests/unit/agents_tests.rs
@@ -383,6 +383,64 @@ fn test_discover_merges_live_row_with_newest_of_multiple_history_rows() {
 }
 
 #[test]
+fn test_discover_merges_live_row_deterministically_on_equal_history_timestamps() {
+    let _guard = home_guard();
+    let temp_home = tempfile::tempdir().unwrap();
+    let repo_root = tempfile::tempdir().unwrap();
+    let worktree_root = repo_root.path().join(".worktrees").join("feat");
+    let live_status = worktree_root.join(".codex").join("git-warp").join("status");
+    let codex_sessions = temp_home.path().join(".codex").join("sessions");
+
+    fs::create_dir_all(&live_status.parent().unwrap()).unwrap();
+    fs::create_dir_all(&codex_sessions).unwrap();
+
+    fs::write(
+        &live_status,
+        r#"{"status":"working","last_activity":"2026-04-23T10:00:00+00:00"}"#,
+    )
+    .unwrap();
+    fs::write(
+        codex_sessions.join("session-b.jsonl"),
+        format!(
+            r#"{{"timestamp":"2026-04-22T10:00:00.000Z","type":"session_meta","payload":{{"id":"session-2","timestamp":"2026-04-22T10:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Zulu","agent_role":"worker","gitBranch":"feat-z"}}}}
+{{"timestamp":"2026-04-22T11:00:00.000Z","type":"event","payload":{{"kind":"step"}}}}"#,
+            worktree_root.display()
+        ),
+    )
+    .unwrap();
+    fs::write(
+        codex_sessions.join("session-a.jsonl"),
+        format!(
+            r#"{{"timestamp":"2026-04-22T09:00:00.000Z","type":"session_meta","payload":{{"id":"session-1","timestamp":"2026-04-22T09:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Alpha","agent_role":"worker","gitBranch":"feat-a"}}}}
+{{"timestamp":"2026-04-22T11:00:00.000Z","type":"event","payload":{{"kind":"step"}}}}"#,
+            worktree_root.display()
+        ),
+    )
+    .unwrap();
+
+    let _home_override = HomeOverride::set(&temp_home.path().to_path_buf());
+
+    let discovery =
+        AgentDiscovery::new(vec![repo_root.path().to_path_buf(), worktree_root.clone()]);
+    let now = Local.with_ymd_and_hms(2026, 4, 23, 12, 0, 0).unwrap();
+    let sessions = discovery.discover(now).unwrap();
+
+    assert_eq!(sessions.len(), 2);
+    assert!(sessions.iter().any(|session| {
+        session.is_live
+            && session.source == AgentSessionSource::Merged
+            && session.session_id.as_deref() == Some("session-1")
+            && session.branch.as_deref() == Some("feat-a")
+    }));
+    assert!(sessions.iter().any(|session| {
+        !session.is_live
+            && session.source == AgentSessionSource::SessionStore
+            && session.session_id.as_deref() == Some("session-2")
+            && session.branch.as_deref() == Some("feat-z")
+    }));
+}
+
+#[test]
 fn test_discover_keeps_live_row_even_when_older_than_cutoff() {
     let _guard = home_guard();
     let temp_home = tempfile::tempdir().unwrap();

--- a/tests/unit/agents_tests.rs
+++ b/tests/unit/agents_tests.rs
@@ -1,0 +1,58 @@
+use chrono::{DateTime, Local};
+use git_warp::agents::{
+    AgentRuntime, AgentSessionState, parse_claude_session_event_line,
+    parse_codex_session_meta_line, parse_live_status_file,
+};
+use std::fs;
+
+#[test]
+fn test_parse_live_status_file() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let status_path = temp_dir.path().join("status");
+    fs::write(
+        &status_path,
+        r#"{"status":"working","last_activity":"2026-04-23T10:15:00+07:00"}"#,
+    )
+    .unwrap();
+
+    let summary = parse_live_status_file(AgentRuntime::Codex, &status_path)
+        .unwrap()
+        .expect("status file should parse");
+
+    assert_eq!(summary.runtime, AgentRuntime::Codex);
+    assert_eq!(summary.state, AgentSessionState::Working);
+    assert!(summary.is_live);
+}
+
+#[test]
+fn test_parse_codex_session_meta_line() {
+    let line = r#"{"timestamp":"2026-04-23T05:35:14.983Z","type":"session_meta","payload":{"id":"019db8d5-cf8c-7c10-ab48-7f495e8dc54b","timestamp":"2026-04-23T05:35:13.308Z","cwd":"/tmp/repo/.worktrees/feat","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker"}}"#;
+
+    let summary = parse_codex_session_meta_line(line).expect("codex session should parse");
+
+    assert_eq!(summary.runtime, AgentRuntime::Codex);
+    assert_eq!(
+        summary.session_id.as_deref(),
+        Some("019db8d5-cf8c-7c10-ab48-7f495e8dc54b")
+    );
+    assert_eq!(summary.agent_label, "Parfit (worker)");
+    assert_eq!(summary.state, AgentSessionState::Recent);
+}
+
+#[test]
+fn test_parse_claude_session_event_line() {
+    let line = r#"{"type":"user","timestamp":"2026-04-23T04:10:00.000Z","cwd":"/tmp/repo","sessionId":"claude-session-1","gitBranch":"main"}"#;
+
+    let summary = parse_claude_session_event_line(line).expect("claude event should parse");
+
+    assert_eq!(summary.runtime, AgentRuntime::Claude);
+    assert_eq!(summary.session_id.as_deref(), Some("claude-session-1"));
+    assert_eq!(summary.branch.as_deref(), Some("main"));
+    assert_eq!(
+        summary.last_activity.timestamp(),
+        DateTime::parse_from_rfc3339("2026-04-23T04:10:00Z")
+            .unwrap()
+            .with_timezone(&Local)
+            .timestamp()
+    );
+}

--- a/tests/unit/agents_tests.rs
+++ b/tests/unit/agents_tests.rs
@@ -276,26 +276,21 @@ fn test_discover_for_repo_filters_by_worktree_and_recency() {
 }
 
 #[test]
-fn test_discover_merges_live_row_with_single_recent_history_row() {
+fn test_discover_keeps_distinct_recent_history_rows_without_live_status() {
     let _guard = home_guard();
     let temp_home = tempfile::tempdir().unwrap();
     let repo_root = tempfile::tempdir().unwrap();
     let worktree_root = repo_root.path().join(".worktrees").join("feat");
-    let live_status = worktree_root.join(".codex").join("git-warp").join("status");
     let codex_sessions = temp_home.path().join(".codex").join("sessions");
 
-    fs::create_dir_all(&live_status.parent().unwrap()).unwrap();
     fs::create_dir_all(&codex_sessions).unwrap();
 
     fs::write(
-        &live_status,
-        r#"{"status":"working","last_activity":"2026-04-23T10:00:00+00:00"}"#,
-    )
-    .unwrap();
-    fs::write(
         codex_sessions.join("sessions.jsonl"),
         format!(
-            r#"{{"timestamp":"2026-04-19T10:00:00.000Z","type":"session_meta","payload":{{"id":"session-1","timestamp":"2026-04-19T10:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker","gitBranch":"feat"}}}}"#,
+            r#"{{"timestamp":"2026-04-22T09:00:00.000Z","type":"session_meta","payload":{{"id":"session-1","timestamp":"2026-04-22T09:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker","gitBranch":"feat"}}}}
+{{"timestamp":"2026-04-22T10:00:00.000Z","type":"session_meta","payload":{{"id":"session-2","timestamp":"2026-04-22T10:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker","gitBranch":"feat-2"}}}}"#,
+            worktree_root.display(),
             worktree_root.display()
         ),
     )
@@ -308,39 +303,31 @@ fn test_discover_merges_live_row_with_single_recent_history_row() {
     let now = Local.with_ymd_and_hms(2026, 4, 23, 12, 0, 0).unwrap();
     let sessions = discovery.discover(now).unwrap();
 
-    assert_eq!(sessions.len(), 1);
-    let session = &sessions[0];
-    assert_eq!(session.state, AgentSessionState::Working);
-    assert!(session.is_live);
-    assert_eq!(session.source, AgentSessionSource::Merged);
-    assert_eq!(session.branch.as_deref(), Some("feat"));
-    assert_eq!(session.session_id.as_deref(), Some("session-1"));
-    assert_eq!(session.agent_label, "Parfit (worker)");
+    assert_eq!(sessions.len(), 2);
+    assert!(sessions.iter().any(|session| {
+        session.session_id.as_deref() == Some("session-1")
+            && session.branch.as_deref() == Some("feat")
+            && session.source == AgentSessionSource::SessionStore
+    }));
+    assert!(sessions.iter().any(|session| {
+        session.session_id.as_deref() == Some("session-2")
+            && session.branch.as_deref() == Some("feat-2")
+            && session.source == AgentSessionSource::SessionStore
+    }));
 }
 
 #[test]
-fn test_discover_does_not_backfill_from_old_history() {
+fn test_discover_keeps_live_row_even_when_older_than_cutoff() {
     let _guard = home_guard();
     let temp_home = tempfile::tempdir().unwrap();
     let repo_root = tempfile::tempdir().unwrap();
     let worktree_root = repo_root.path().join(".worktrees").join("feat");
     let live_status = worktree_root.join(".codex").join("git-warp").join("status");
-    let codex_sessions = temp_home.path().join(".codex").join("sessions");
 
     fs::create_dir_all(&live_status.parent().unwrap()).unwrap();
-    fs::create_dir_all(&codex_sessions).unwrap();
-
     fs::write(
         &live_status,
-        r#"{"status":"working","last_activity":"2026-04-23T10:00:00+00:00"}"#,
-    )
-    .unwrap();
-    fs::write(
-        codex_sessions.join("sessions.jsonl"),
-        format!(
-            r#"{{"timestamp":"2026-04-15T10:00:00.000Z","type":"session_meta","payload":{{"id":"session-1","timestamp":"2026-04-15T10:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker","gitBranch":"feat"}}}}"#,
-            worktree_root.display()
-        ),
+        r#"{"status":"working","last_activity":"2026-04-10T10:00:00+00:00"}"#,
     )
     .unwrap();
 

--- a/tests/unit/agents_tests.rs
+++ b/tests/unit/agents_tests.rs
@@ -286,11 +286,19 @@ fn test_discover_keeps_distinct_recent_history_rows_without_live_status() {
     fs::create_dir_all(&codex_sessions).unwrap();
 
     fs::write(
-        codex_sessions.join("sessions.jsonl"),
+        codex_sessions.join("session-a.jsonl"),
         format!(
             r#"{{"timestamp":"2026-04-22T09:00:00.000Z","type":"session_meta","payload":{{"id":"session-1","timestamp":"2026-04-22T09:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker","gitBranch":"feat"}}}}
-{{"timestamp":"2026-04-22T10:00:00.000Z","type":"session_meta","payload":{{"id":"session-2","timestamp":"2026-04-22T10:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker","gitBranch":"feat-2"}}}}"#,
-            worktree_root.display(),
+{{"timestamp":"2026-04-22T11:00:00.000Z","type":"event","payload":{{"kind":"step"}}}}"#,
+            worktree_root.display()
+        ),
+    )
+    .unwrap();
+    fs::write(
+        codex_sessions.join("session-b.jsonl"),
+        format!(
+            r#"{{"timestamp":"2026-04-22T10:00:00.000Z","type":"session_meta","payload":{{"id":"session-2","timestamp":"2026-04-22T10:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker","gitBranch":"feat-2"}}}}
+{{"timestamp":"2026-04-22T10:30:00.000Z","type":"event","payload":{{"kind":"step"}}}}"#,
             worktree_root.display()
         ),
     )
@@ -334,11 +342,19 @@ fn test_discover_merges_live_row_with_newest_of_multiple_history_rows() {
     )
     .unwrap();
     fs::write(
-        codex_sessions.join("sessions.jsonl"),
+        codex_sessions.join("session-a.jsonl"),
         format!(
             r#"{{"timestamp":"2026-04-22T09:00:00.000Z","type":"session_meta","payload":{{"id":"session-1","timestamp":"2026-04-22T09:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker","gitBranch":"feat"}}}}
-{{"timestamp":"2026-04-22T10:00:00.000Z","type":"session_meta","payload":{{"id":"session-2","timestamp":"2026-04-22T10:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker","gitBranch":"feat-2"}}}}"#,
-            worktree_root.display(),
+{{"timestamp":"2026-04-22T11:00:00.000Z","type":"event","payload":{{"kind":"step"}}}}"#,
+            worktree_root.display()
+        ),
+    )
+    .unwrap();
+    fs::write(
+        codex_sessions.join("session-b.jsonl"),
+        format!(
+            r#"{{"timestamp":"2026-04-22T10:00:00.000Z","type":"session_meta","payload":{{"id":"session-2","timestamp":"2026-04-22T10:00:00.000Z","cwd":"{}","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker","gitBranch":"feat-2"}}}}
+{{"timestamp":"2026-04-22T10:30:00.000Z","type":"event","payload":{{"kind":"step"}}}}"#,
             worktree_root.display()
         ),
     )
@@ -355,14 +371,14 @@ fn test_discover_merges_live_row_with_newest_of_multiple_history_rows() {
     assert!(sessions.iter().any(|session| {
         session.is_live
             && session.source == AgentSessionSource::Merged
-            && session.session_id.as_deref() == Some("session-2")
-            && session.branch.as_deref() == Some("feat-2")
+            && session.session_id.as_deref() == Some("session-1")
+            && session.branch.as_deref() == Some("feat")
     }));
     assert!(sessions.iter().any(|session| {
         !session.is_live
             && session.source == AgentSessionSource::SessionStore
-            && session.session_id.as_deref() == Some("session-1")
-            && session.branch.as_deref() == Some("feat")
+            && session.session_id.as_deref() == Some("session-2")
+            && session.branch.as_deref() == Some("feat-2")
     }));
 }
 

--- a/tests/unit/agents_tests.rs
+++ b/tests/unit/agents_tests.rs
@@ -1,9 +1,35 @@
-use chrono::{DateTime, Local};
+use chrono::{DateTime, Local, TimeZone};
 use git_warp::agents::{
-    AgentRuntime, AgentSessionState, parse_claude_session_event_line,
-    parse_codex_session_meta_line, parse_live_status_file,
+    AgentDiscovery, AgentRuntime, AgentSessionSource, AgentSessionState, AgentSessionSummary,
+    merge_session_summaries, parse_claude_session_event_line, parse_codex_session_meta_line,
+    parse_live_status_file, sort_session_summaries,
 };
 use std::fs;
+use std::path::PathBuf;
+
+fn sample_summary(
+    runtime: AgentRuntime,
+    session_id: Option<&str>,
+    cwd: &str,
+    state: AgentSessionState,
+    last_activity_hour: u32,
+    is_live: bool,
+    source: AgentSessionSource,
+) -> AgentSessionSummary {
+    AgentSessionSummary {
+        runtime,
+        session_id: session_id.map(str::to_string),
+        cwd: PathBuf::from(cwd),
+        branch: Some("feat".to_string()),
+        agent_label: "agent".to_string(),
+        state,
+        last_activity: Local
+            .with_ymd_and_hms(2026, 4, 23, last_activity_hour, 0, 0)
+            .unwrap(),
+        is_live,
+        source,
+    }
+}
 
 #[test]
 fn test_parse_live_status_file() {
@@ -28,7 +54,11 @@ fn test_parse_live_status_file() {
 fn test_parse_live_status_file_falls_back_to_modified_time() {
     let temp_dir = tempfile::tempdir().unwrap();
     let status_path = temp_dir.path().join("status");
-    fs::write(&status_path, r#"{"status":"working","last_activity":"not-a-time"}"#).unwrap();
+    fs::write(
+        &status_path,
+        r#"{"status":"working","last_activity":"not-a-time"}"#,
+    )
+    .unwrap();
 
     let summary = parse_live_status_file(AgentRuntime::Codex, &status_path)
         .unwrap()
@@ -84,4 +114,103 @@ fn test_parse_claude_session_event_line() {
             .with_timezone(&Local)
             .timestamp()
     );
+}
+
+#[test]
+fn test_merge_prefers_live_state_and_newest_timestamp() {
+    let merged = merge_session_summaries(vec![
+        sample_summary(
+            AgentRuntime::Codex,
+            Some("session-1"),
+            "/repo/.worktrees/feat",
+            AgentSessionState::Recent,
+            9,
+            false,
+            AgentSessionSource::SessionStore,
+        ),
+        sample_summary(
+            AgentRuntime::Codex,
+            Some("session-1"),
+            "/repo/.worktrees/feat",
+            AgentSessionState::Working,
+            10,
+            true,
+            AgentSessionSource::LiveStatus,
+        ),
+    ]);
+
+    assert_eq!(merged.len(), 1);
+    assert_eq!(merged[0].state, AgentSessionState::Working);
+    assert!(merged[0].is_live);
+    assert_eq!(merged[0].source, AgentSessionSource::Merged);
+}
+
+#[test]
+fn test_sort_session_summaries_keeps_live_rows_first() {
+    let mut items = vec![
+        sample_summary(
+            AgentRuntime::Claude,
+            Some("claude-1"),
+            "/repo",
+            AgentSessionState::Recent,
+            11,
+            false,
+            AgentSessionSource::SessionStore,
+        ),
+        sample_summary(
+            AgentRuntime::Codex,
+            Some("codex-1"),
+            "/repo/.worktrees/feat",
+            AgentSessionState::Working,
+            10,
+            true,
+            AgentSessionSource::LiveStatus,
+        ),
+    ];
+
+    sort_session_summaries(&mut items);
+
+    assert_eq!(items[0].session_id.as_deref(), Some("codex-1"));
+    assert_eq!(items[1].session_id.as_deref(), Some("claude-1"));
+}
+
+#[test]
+fn test_discover_for_repo_filters_by_worktree_and_recency() {
+    let discovery = AgentDiscovery::new(vec![
+        PathBuf::from("/repo"),
+        PathBuf::from("/repo/.worktrees/feat"),
+    ]);
+
+    let kept = discovery.keep_session(
+        &sample_summary(
+            AgentRuntime::Codex,
+            Some("inside"),
+            "/repo/.worktrees/feat",
+            AgentSessionState::Recent,
+            10,
+            false,
+            AgentSessionSource::SessionStore,
+        ),
+        Local.with_ymd_and_hms(2026, 4, 23, 12, 0, 0).unwrap(),
+    );
+
+    let rejected = discovery.keep_session(
+        &AgentSessionSummary {
+            last_activity: Local.with_ymd_and_hms(2026, 4, 10, 12, 0, 0).unwrap(),
+            cwd: PathBuf::from("/other/repo"),
+            ..sample_summary(
+                AgentRuntime::Claude,
+                Some("outside"),
+                "/other/repo",
+                AgentSessionState::Recent,
+                9,
+                false,
+                AgentSessionSource::SessionStore,
+            )
+        },
+        Local.with_ymd_and_hms(2026, 4, 23, 12, 0, 0).unwrap(),
+    );
+
+    assert!(kept);
+    assert!(!rejected);
 }

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -1,4 +1,5 @@
 // Unit tests for individual components
+pub mod agents_tests;
 pub mod config_tests;
 pub mod cow_tests;
 pub mod git_tests;

--- a/tests/unit/tui_tests.rs
+++ b/tests/unit/tui_tests.rs
@@ -1,355 +1,143 @@
-use git_warp::tui::{AgentActivity, AgentStatus, AgentsDashboard, TuiApp};
+use chrono::{Local, TimeZone};
+use git_warp::agents::{
+    AgentDiscovery, AgentRuntime, AgentSessionSource, AgentSessionState, AgentSessionSummary,
+};
+use git_warp::tui::{AgentsDashboard, build_dashboard_model, session_detail_lines};
 use std::path::PathBuf;
-use std::time::Instant;
 
-#[test]
-fn test_tui_app_creation() {
-    let app = TuiApp::new();
-
-    assert!(!app.should_quit());
-    assert_eq!(app.get_selected_index(), 0);
-    assert!(app.get_last_update() <= Instant::now());
+fn sample_summary(
+    runtime: AgentRuntime,
+    session_id: &str,
+    cwd: &str,
+    state: AgentSessionState,
+    last_activity_hour: u32,
+    is_live: bool,
+    source: AgentSessionSource,
+) -> AgentSessionSummary {
+    AgentSessionSummary {
+        runtime,
+        session_id: Some(session_id.to_string()),
+        cwd: PathBuf::from(cwd),
+        branch: Some("feat/agents".to_string()),
+        agent_label: "Parfit (worker)".to_string(),
+        state,
+        last_activity: Local
+            .with_ymd_and_hms(2026, 4, 23, last_activity_hour, 0, 0)
+            .unwrap(),
+        is_live,
+        source,
+    }
 }
 
 #[test]
-fn test_agent_status_symbols() {
-    assert_eq!(AgentStatus::Active.symbol(), "🔄");
-    assert_eq!(AgentStatus::Waiting.symbol(), "⏳");
-    assert_eq!(AgentStatus::Completed.symbol(), "✅");
-    assert_eq!(AgentStatus::Error.symbol(), "❌");
-}
+fn test_build_dashboard_model_empty_state() {
+    let now = Local.with_ymd_and_hms(2026, 4, 23, 12, 0, 0).unwrap();
 
-#[test]
-fn test_agent_activity_creation() {
-    let activity = AgentActivity {
-        timestamp: "14:32:15".to_string(),
-        agent_name: "Claude-Code".to_string(),
-        activity: "Analyzing code structure".to_string(),
-        file_path: Some(PathBuf::from("/project/src/main.rs")),
-        status: AgentStatus::Active,
-    };
+    let model = build_dashboard_model(&[], now);
 
-    assert_eq!(activity.timestamp, "14:32:15");
-    assert_eq!(activity.agent_name, "Claude-Code");
-    assert_eq!(activity.activity, "Analyzing code structure");
-    assert!(activity.file_path.is_some());
+    assert!(model.rows.is_empty());
     assert_eq!(
-        activity.file_path.unwrap().to_string_lossy(),
-        "/project/src/main.rs"
+        model.empty_state_lines,
+        vec![
+            "No live or recent Claude/Codex sessions found for this repo in the last 7 days."
+                .to_string(),
+            "Hint: run `warp hooks-install --runtime all --level user` to enable live monitoring."
+                .to_string(),
+        ]
+    );
+}
+
+#[test]
+fn test_build_dashboard_model_orders_live_sessions_before_recent_sessions() {
+    let now = Local.with_ymd_and_hms(2026, 4, 23, 12, 0, 0).unwrap();
+    let sessions = vec![
+        sample_summary(
+            AgentRuntime::Codex,
+            "recent-newest",
+            "/repo/.worktrees/recent-newest",
+            AgentSessionState::Recent,
+            11,
+            false,
+            AgentSessionSource::SessionStore,
+        ),
+        sample_summary(
+            AgentRuntime::Claude,
+            "live-older",
+            "/repo/.worktrees/live-older",
+            AgentSessionState::Working,
+            9,
+            true,
+            AgentSessionSource::LiveStatus,
+        ),
+        sample_summary(
+            AgentRuntime::Codex,
+            "recent-older",
+            "/repo/.worktrees/recent-older",
+            AgentSessionState::Recent,
+            8,
+            false,
+            AgentSessionSource::SessionStore,
+        ),
+        sample_summary(
+            AgentRuntime::Codex,
+            "live-newest",
+            "/repo/.worktrees/live-newest",
+            AgentSessionState::Processing,
+            10,
+            true,
+            AgentSessionSource::Merged,
+        ),
+    ];
+
+    let model = build_dashboard_model(&sessions, now);
+    let ordered_ids: Vec<_> = model
+        .rows
+        .iter()
+        .map(|row| row.session.session_id.as_deref())
+        .collect();
+
+    assert_eq!(
+        ordered_ids,
+        vec![
+            Some("live-newest"),
+            Some("live-older"),
+            Some("recent-newest"),
+            Some("recent-older"),
+        ]
+    );
+}
+
+#[test]
+fn test_session_detail_lines_include_expected_fields() {
+    let summary = sample_summary(
+        AgentRuntime::Codex,
+        "session-123",
+        "/repo/.worktrees/agents",
+        AgentSessionState::Working,
+        11,
+        true,
+        AgentSessionSource::Merged,
     );
 
-    match activity.status {
-        AgentStatus::Active => {
-            assert_eq!(activity.status.symbol(), "🔄");
-        }
-        _ => panic!("Expected Active status"),
-    }
+    let lines = session_detail_lines(&summary);
+
+    assert_eq!(
+        lines,
+        vec![
+            "Agent: Parfit (worker)".to_string(),
+            "CWD: /repo/.worktrees/agents".to_string(),
+            "Session ID: session-123".to_string(),
+            "Runtime: Codex".to_string(),
+            "Branch: feat/agents".to_string(),
+            "Presence: live".to_string(),
+            format!("Last Activity: {}", summary.last_activity.to_rfc3339()),
+            "Source: Merged".to_string(),
+        ]
+    );
 }
 
 #[test]
-fn test_agent_activity_without_file() {
-    let activity = AgentActivity {
-        timestamp: "14:31:42".to_string(),
-        agent_name: "Claude-Code".to_string(),
-        activity: "Waiting for user input".to_string(),
-        file_path: None,
-        status: AgentStatus::Waiting,
-    };
-
-    assert!(activity.file_path.is_none());
-    assert_eq!(activity.status.symbol(), "⏳");
-}
-
-#[test]
-fn test_agents_dashboard_creation() {
-    let dashboard = AgentsDashboard::new();
-
-    // Dashboard should be created successfully
-    // In a real implementation, this would initialize the dashboard state
-    println!("AgentsDashboard created successfully");
-}
-
-#[test]
-fn test_multiple_agent_activities() {
-    let activities = vec![
-        AgentActivity {
-            timestamp: "14:35:00".to_string(),
-            agent_name: "Claude-Code".to_string(),
-            activity: "Writing tests".to_string(),
-            file_path: Some(PathBuf::from("/project/tests/mod.rs")),
-            status: AgentStatus::Active,
-        },
-        AgentActivity {
-            timestamp: "14:34:30".to_string(),
-            agent_name: "Claude-Code".to_string(),
-            activity: "Refactoring function".to_string(),
-            file_path: Some(PathBuf::from("/project/src/utils.rs")),
-            status: AgentStatus::Completed,
-        },
-        AgentActivity {
-            timestamp: "14:34:00".to_string(),
-            agent_name: "Claude-Code".to_string(),
-            activity: "Analyzing dependencies".to_string(),
-            file_path: Some(PathBuf::from("/project/Cargo.toml")),
-            status: AgentStatus::Completed,
-        },
-    ];
-
-    assert_eq!(activities.len(), 3);
-
-    // Test ordering by timestamp
-    let latest = &activities[0];
-    let oldest = &activities[2];
-
-    assert_eq!(latest.timestamp, "14:35:00");
-    assert_eq!(oldest.timestamp, "14:34:00");
-
-    // Test different statuses
-    let active_count = activities
-        .iter()
-        .filter(|a| matches!(a.status, AgentStatus::Active))
-        .count();
-    let completed_count = activities
-        .iter()
-        .filter(|a| matches!(a.status, AgentStatus::Completed))
-        .count();
-
-    assert_eq!(active_count, 1);
-    assert_eq!(completed_count, 2);
-}
-
-#[test]
-fn test_agent_status_transitions() {
-    // Test that agent statuses represent different states correctly
-    let mut activity = AgentActivity {
-        timestamp: "14:30:00".to_string(),
-        agent_name: "Claude-Code".to_string(),
-        activity: "Starting analysis".to_string(),
-        file_path: Some(PathBuf::from("/project/src/main.rs")),
-        status: AgentStatus::Waiting,
-    };
-
-    // Waiting -> Active
-    activity.status = AgentStatus::Active;
-    activity.activity = "Analyzing code".to_string();
-    assert_eq!(activity.status.symbol(), "🔄");
-
-    // Active -> Completed
-    activity.status = AgentStatus::Completed;
-    activity.activity = "Analysis complete".to_string();
-    assert_eq!(activity.status.symbol(), "✅");
-
-    // Test error state
-    activity.status = AgentStatus::Error;
-    activity.activity = "Analysis failed".to_string();
-    assert_eq!(activity.status.symbol(), "❌");
-}
-
-#[test]
-fn test_file_path_handling() {
-    // Test various file path scenarios
-    let activities = vec![
-        AgentActivity {
-            timestamp: "14:30:00".to_string(),
-            agent_name: "Claude-Code".to_string(),
-            activity: "Editing source file".to_string(),
-            file_path: Some(PathBuf::from("/project/src/main.rs")),
-            status: AgentStatus::Active,
-        },
-        AgentActivity {
-            timestamp: "14:30:10".to_string(),
-            agent_name: "Claude-Code".to_string(),
-            activity: "Waiting for input".to_string(),
-            file_path: None,
-            status: AgentStatus::Waiting,
-        },
-        AgentActivity {
-            timestamp: "14:30:20".to_string(),
-            agent_name: "Claude-Code".to_string(),
-            activity: "Updating config".to_string(),
-            file_path: Some(PathBuf::from("/project/config/settings.toml")),
-            status: AgentStatus::Active,
-        },
-    ];
-
-    let with_files: Vec<_> = activities
-        .iter()
-        .filter(|a| a.file_path.is_some())
-        .collect();
-    let without_files: Vec<_> = activities
-        .iter()
-        .filter(|a| a.file_path.is_none())
-        .collect();
-
-    assert_eq!(with_files.len(), 2);
-    assert_eq!(without_files.len(), 1);
-
-    // Test path display
-    for activity in with_files {
-        if let Some(path) = &activity.file_path {
-            assert!(!path.to_string_lossy().is_empty());
-            println!("File path: {}", path.display());
-        }
-    }
-}
-
-#[test]
-fn test_agent_dashboard_statistics() {
-    let activities = vec![
-        AgentActivity {
-            timestamp: "14:30:00".to_string(),
-            agent_name: "Claude-Code".to_string(),
-            activity: "Task 1".to_string(),
-            file_path: None,
-            status: AgentStatus::Active,
-        },
-        AgentActivity {
-            timestamp: "14:30:10".to_string(),
-            agent_name: "Claude-Code".to_string(),
-            activity: "Task 2".to_string(),
-            file_path: None,
-            status: AgentStatus::Completed,
-        },
-        AgentActivity {
-            timestamp: "14:30:20".to_string(),
-            agent_name: "Claude-Code".to_string(),
-            activity: "Task 3".to_string(),
-            file_path: None,
-            status: AgentStatus::Completed,
-        },
-        AgentActivity {
-            timestamp: "14:30:30".to_string(),
-            agent_name: "Claude-Code".to_string(),
-            activity: "Task 4".to_string(),
-            file_path: None,
-            status: AgentStatus::Error,
-        },
-    ];
-
-    // Calculate statistics
-    let total = activities.len();
-    let active = activities
-        .iter()
-        .filter(|a| matches!(a.status, AgentStatus::Active))
-        .count();
-    let completed = activities
-        .iter()
-        .filter(|a| matches!(a.status, AgentStatus::Completed))
-        .count();
-    let errors = activities
-        .iter()
-        .filter(|a| matches!(a.status, AgentStatus::Error))
-        .count();
-    let waiting = activities
-        .iter()
-        .filter(|a| matches!(a.status, AgentStatus::Waiting))
-        .count();
-
-    assert_eq!(total, 4);
-    assert_eq!(active, 1);
-    assert_eq!(completed, 2);
-    assert_eq!(errors, 1);
-    assert_eq!(waiting, 0);
-
-    // Test completion rate
-    let completion_rate = completed as f64 / total as f64;
-    assert!((completion_rate - 0.5).abs() < f64::EPSILON);
-}
-
-#[test]
-fn test_tui_navigation() {
-    let mut app = TuiApp::new();
-
-    // Test initial state
-    assert_eq!(app.get_selected_index(), 0);
-
-    // Simulate navigation (these would be triggered by keyboard events)
-    app.set_selected_index(1);
-    assert_eq!(app.get_selected_index(), 1);
-
-    app.set_selected_index(2);
-    assert_eq!(app.get_selected_index(), 2);
-
-    // Test bounds checking (would be implemented in event handlers)
-    let max_items = 5;
-    if app.get_selected_index() >= max_items {
-        app.set_selected_index(max_items - 1);
-    }
-    assert!(app.get_selected_index() < max_items);
-}
-
-#[test]
-fn test_refresh_functionality() {
-    let mut app = TuiApp::new();
-    let initial_time = app.get_last_update();
-
-    // Simulate time passing
-    std::thread::sleep(std::time::Duration::from_millis(1));
-
-    // Update timestamp (simulate refresh)
-    app.set_last_update(Instant::now());
-
-    assert!(app.get_last_update() > initial_time);
-}
-
-#[test]
-fn test_agent_name_variations() {
-    let agent_names = vec!["Claude-Code", "Claude", "Assistant", "AI-Agent"];
-
-    for name in agent_names {
-        let activity = AgentActivity {
-            timestamp: "14:30:00".to_string(),
-            agent_name: name.to_string(),
-            activity: "Testing".to_string(),
-            file_path: None,
-            status: AgentStatus::Active,
-        };
-
-        assert_eq!(activity.agent_name, name);
-        assert!(!activity.agent_name.is_empty());
-    }
-}
-
-#[test]
-fn test_worktree_monitoring() {
-    let dashboard = AgentsDashboard::new();
-    let worktree_path = PathBuf::from("/project/worktrees/feature-branch");
-
-    // Test that monitoring setup doesn't panic
-    let result = dashboard.monitor_worktree(worktree_path);
-
-    match result {
-        Ok(()) => {
-            println!("Worktree monitoring started successfully");
-        }
-        Err(e) => {
-            println!("Worktree monitoring failed (expected in test): {}", e);
-        }
-    }
-}
-
-#[test]
-fn test_cleanup_tui() {
-    use git_warp::tui::CleanupTui;
-
-    let cleanup_tui = CleanupTui::new();
-
-    // Test that cleanup TUI can be created
-    println!("CleanupTui created successfully");
-
-    // The run method would return selected branches for cleanup
-    // In a real test, we'd mock this interaction
-}
-
-#[test]
-fn test_config_tui() {
-    use git_warp::tui::ConfigTui;
-
-    let config_tui = ConfigTui::new();
-
-    // Test that config TUI can be created
-    println!("ConfigTui created successfully");
-
-    // The run method would handle configuration editing
-    // In a real test, we'd mock this interaction
+fn test_agents_dashboard_accepts_discovery() {
+    let discovery = AgentDiscovery::new(vec![PathBuf::from("/repo")]);
+    let _dashboard = AgentsDashboard::new(discovery);
 }

--- a/tests/unit/tui_tests.rs
+++ b/tests/unit/tui_tests.rs
@@ -120,20 +120,45 @@ fn test_session_detail_lines_include_expected_fields() {
     );
 
     let lines = session_detail_lines(&summary);
+    let cwd_line = lines
+        .iter()
+        .find(|line| line.starts_with("CWD: "))
+        .expect("CWD line should be present");
 
     assert_eq!(
-        lines,
-        vec![
-            "Agent: Parfit (worker)".to_string(),
-            "CWD: /repo/.worktrees/agents".to_string(),
-            "Session ID: session-123".to_string(),
-            "Runtime: Codex".to_string(),
-            "Branch: feat/agents".to_string(),
-            "Presence: live".to_string(),
-            format!("Last Activity: {}", summary.last_activity.to_rfc3339()),
-            "Source: Merged".to_string(),
-        ]
+        PathBuf::from(cwd_line.trim_start_matches("CWD: ")),
+        summary.cwd
     );
+    assert!(lines.iter().any(|line| line == "Agent: Parfit (worker)"));
+    assert!(lines.iter().any(|line| line == "Session ID: session-123"));
+    assert!(lines.iter().any(|line| line == "Runtime: Codex"));
+    assert!(lines.iter().any(|line| line == "Branch: feat/agents"));
+    assert!(lines.iter().any(|line| line == "Presence: live"));
+    assert!(
+        lines
+            .iter()
+            .any(|line| line == &format!("Last Activity: {}", summary.last_activity.to_rfc3339()))
+    );
+    assert!(lines.iter().any(|line| line == "Source: Merged"));
+}
+
+#[test]
+fn test_build_dashboard_model_renders_future_timestamps_explicitly() {
+    let now = Local.with_ymd_and_hms(2026, 4, 23, 12, 0, 0).unwrap();
+    let sessions = vec![sample_summary(
+        AgentRuntime::Codex,
+        "future-session",
+        "/repo/.worktrees/future",
+        AgentSessionState::Recent,
+        12,
+        false,
+        AgentSessionSource::SessionStore,
+    )];
+
+    let model = build_dashboard_model(&sessions, now - chrono::Duration::minutes(5));
+
+    assert_eq!(model.rows.len(), 1);
+    assert_eq!(model.rows[0].relative_time, "in 5m");
 }
 
 #[test]


### PR DESCRIPTION
Closes #1.

## Summary
- replace the demo `warp agents` monitor with a real unified Claude/Codex dashboard backed by hook status files plus recent local session history
- add repo-scoped discovery, parsing, filtering, merge, and ordering logic with focused tests for live and recent session handling
- harden the dashboard terminal lifecycle so startup, refresh, and shutdown cleanup are more resilient

## Test Plan
- [x] `cargo test unit::tui_tests -- --nocapture`
- [x] `cargo test tui::tests:: -- --nocapture`
- [x] `warp agents` opens the unified dashboard directly and exits cleanly on `q`
- [x] `cargo test` currently still fails in unrelated existing `git`, `process`, `rewrite`, and `full_workflow` tests outside this feature branch scope
