### PR TITLE
[codex] Run pnpm install for new worktrees

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -208,6 +208,7 @@ impl Cli {
         use crate::config::ConfigManager;
         use crate::cow;
         use crate::git::GitRepository;
+        use crate::post_create::{PostCreateSetupStatus, run_post_create_setup};
         use crate::rewrite::PathRewriter;
         use crate::terminal::{TerminalManager, TerminalMode};
         use std::path::PathBuf;
@@ -241,6 +242,8 @@ impl Cli {
             }
             return Ok(());
         }
+
+        let mut worktree_created = false;
 
         // Check if worktree already exists
         if worktree_path.exists() {
@@ -297,6 +300,21 @@ impl Cli {
             }
 
             println!("✅ Worktree created successfully!");
+            worktree_created = true;
+        }
+
+        match run_post_create_setup(&worktree_path, worktree_created) {
+            PostCreateSetupStatus::Installed => {
+                println!("📦 Detected pnpm repo, ran `pnpm install`");
+            }
+            PostCreateSetupStatus::Warned(reason) => {
+                println!(
+                    "⚠️  Detected pnpm repo but `pnpm install` failed: {}",
+                    reason
+                );
+            }
+            PostCreateSetupStatus::SkippedExistingWorktree
+            | PostCreateSetupStatus::SkippedNonPnpmRepo => {}
         }
 
         // Handle terminal switching

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod cow;
 pub mod error;
 pub mod git;
 pub mod hooks;
+pub mod post_create;
 pub mod process;
 pub mod rewrite;
 pub mod terminal;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod cow;
 mod error;
 mod git;
 mod hooks;
+mod post_create;
 mod process;
 mod rewrite;
 mod terminal;

--- a/src/post_create.rs
+++ b/src/post_create.rs
@@ -1,0 +1,157 @@
+use std::path::Path;
+use std::process::Command;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PostCreateSetupStatus {
+    SkippedExistingWorktree,
+    SkippedNonPnpmRepo,
+    Installed,
+    Warned(String),
+}
+
+pub fn run_post_create_setup<P: AsRef<Path>>(
+    worktree_path: P,
+    newly_created: bool,
+) -> PostCreateSetupStatus {
+    run_post_create_setup_with_pnpm(worktree_path.as_ref(), newly_created, Path::new("pnpm"))
+}
+
+fn run_post_create_setup_with_pnpm(
+    worktree_path: &Path,
+    newly_created: bool,
+    pnpm_path: &Path,
+) -> PostCreateSetupStatus {
+    if !newly_created {
+        return PostCreateSetupStatus::SkippedExistingWorktree;
+    }
+
+    if !is_pnpm_repo(worktree_path) {
+        return PostCreateSetupStatus::SkippedNonPnpmRepo;
+    }
+
+    match Command::new(pnpm_path)
+        .arg("install")
+        .current_dir(worktree_path)
+        .output()
+    {
+        Ok(output) if output.status.success() => PostCreateSetupStatus::Installed,
+        Ok(output) => PostCreateSetupStatus::Warned(command_failure_message(&output)),
+        Err(error) => PostCreateSetupStatus::Warned(error.to_string()),
+    }
+}
+
+fn is_pnpm_repo(worktree_path: &Path) -> bool {
+    worktree_path.join("package.json").is_file() && worktree_path.join("pnpm-lock.yaml").is_file()
+}
+
+fn command_failure_message(output: &std::process::Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if !stderr.is_empty() {
+        return stderr;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !stdout.is_empty() {
+        return stdout;
+    }
+
+    match output.status.code() {
+        Some(code) => format!("pnpm install exited with status {}", code),
+        None => "pnpm install terminated by signal".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[cfg(unix)]
+    fn make_executable(path: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions).unwrap();
+    }
+
+    fn create_pnpm_repo(path: &Path) {
+        fs::write(path.join("package.json"), r#"{"name":"test-repo"}"#).unwrap();
+        fs::write(path.join("pnpm-lock.yaml"), "lockfileVersion: '9.0'").unwrap();
+    }
+
+    #[test]
+    fn test_run_post_create_setup_skips_existing_worktree() {
+        let temp_dir = tempdir().unwrap();
+        create_pnpm_repo(temp_dir.path());
+
+        let status =
+            run_post_create_setup_with_pnpm(temp_dir.path(), false, Path::new("/missing/pnpm"));
+
+        assert_eq!(status, PostCreateSetupStatus::SkippedExistingWorktree);
+    }
+
+    #[test]
+    fn test_run_post_create_setup_skips_non_pnpm_repo() {
+        let temp_dir = tempdir().unwrap();
+        fs::write(
+            temp_dir.path().join("package.json"),
+            r#"{"name":"test-repo"}"#,
+        )
+        .unwrap();
+
+        let status =
+            run_post_create_setup_with_pnpm(temp_dir.path(), true, Path::new("/missing/pnpm"));
+
+        assert_eq!(status, PostCreateSetupStatus::SkippedNonPnpmRepo);
+    }
+
+    #[test]
+    fn test_run_post_create_setup_runs_pnpm_install_for_new_pnpm_repo() {
+        let temp_dir = tempdir().unwrap();
+        create_pnpm_repo(temp_dir.path());
+
+        let pnpm_path = temp_dir.path().join("fake-pnpm");
+        let marker_path = temp_dir.path().join("pnpm-ran.txt");
+        fs::write(
+            &pnpm_path,
+            format!(
+                "#!/bin/sh\nprintf \"%s\" \"$PWD\" > \"{}\"\nexit 0\n",
+                marker_path.display()
+            ),
+        )
+        .unwrap();
+        #[cfg(unix)]
+        make_executable(&pnpm_path);
+
+        let status = run_post_create_setup_with_pnpm(temp_dir.path(), true, &pnpm_path);
+
+        assert_eq!(status, PostCreateSetupStatus::Installed);
+        let recorded_path = fs::canonicalize(fs::read_to_string(marker_path).unwrap()).unwrap();
+        let expected_path = fs::canonicalize(temp_dir.path()).unwrap();
+        assert_eq!(recorded_path, expected_path);
+    }
+
+    #[test]
+    fn test_run_post_create_setup_warns_on_failed_install() {
+        let temp_dir = tempdir().unwrap();
+        create_pnpm_repo(temp_dir.path());
+
+        let pnpm_path = temp_dir.path().join("fake-pnpm");
+        fs::write(
+            &pnpm_path,
+            "#!/bin/sh\necho \"install failed\" >&2\nexit 1\n",
+        )
+        .unwrap();
+        #[cfg(unix)]
+        make_executable(&pnpm_path);
+
+        let status = run_post_create_setup_with_pnpm(temp_dir.path(), true, &pnpm_path);
+
+        assert_eq!(
+            status,
+            PostCreateSetupStatus::Warned("install failed".to_string())
+        );
+    }
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,3 +1,4 @@
 // Integration tests combining multiple components
 pub mod cow_git_integration_tests;
 pub mod full_workflow_tests;
+pub mod switch_post_create_tests;

--- a/tests/integration/switch_post_create_tests.rs
+++ b/tests/integration/switch_post_create_tests.rs
@@ -1,0 +1,129 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::tempdir;
+
+#[cfg(unix)]
+fn make_executable(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap();
+}
+
+fn setup_git_repo() -> tempfile::TempDir {
+    let temp_dir = tempdir().unwrap();
+    let repo_path = temp_dir.path();
+
+    Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    fs::write(repo_path.join("README.md"), "# Test Repository\n").unwrap();
+    fs::write(repo_path.join("package.json"), r#"{"name":"test-repo"}"#).unwrap();
+    fs::write(repo_path.join("pnpm-lock.yaml"), "lockfileVersion: '9.0'\n").unwrap();
+
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    Command::new("git")
+        .args(["commit", "-m", "Initial commit"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    temp_dir
+}
+
+fn create_fake_pnpm(bin_dir: &Path, script_body: &str) -> PathBuf {
+    let pnpm_path = bin_dir.join("pnpm");
+    fs::write(&pnpm_path, script_body).unwrap();
+    #[cfg(unix)]
+    make_executable(&pnpm_path);
+    pnpm_path
+}
+
+fn run_warp_switch(repo_path: &Path, branch: &str, path_env: &str) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_warp"))
+        .args(["--terminal", "echo", "switch", "--no-cow", branch])
+        .current_dir(repo_path)
+        .env("PATH", path_env)
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn test_warp_switch_runs_pnpm_install_only_for_new_worktree() {
+    let temp_dir = setup_git_repo();
+    let repo_path = temp_dir.path();
+    let bin_dir = tempdir().unwrap();
+    let marker_path = temp_dir.path().join("pnpm-runs.txt");
+
+    create_fake_pnpm(
+        bin_dir.path(),
+        &format!(
+            "#!/bin/sh\nprintf \"%s\\n\" \"$PWD\" >> \"{}\"\nexit 0\n",
+            marker_path.display()
+        ),
+    );
+
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    let path_env = format!("{}:{}", bin_dir.path().display(), original_path);
+
+    let first_run = run_warp_switch(repo_path, "feature/pnpm-once", &path_env);
+    assert!(first_run.status.success());
+    assert!(
+        String::from_utf8_lossy(&first_run.stdout)
+            .contains("Detected pnpm repo, ran `pnpm install`")
+    );
+
+    let second_run = run_warp_switch(repo_path, "feature/pnpm-once", &path_env);
+    assert!(second_run.status.success());
+    assert!(
+        !String::from_utf8_lossy(&second_run.stdout)
+            .contains("Detected pnpm repo, ran `pnpm install`")
+    );
+
+    let marker_contents = fs::read_to_string(marker_path).unwrap();
+    assert_eq!(marker_contents.lines().count(), 1);
+}
+
+#[test]
+fn test_warp_switch_warns_when_pnpm_install_fails_but_still_succeeds() {
+    let temp_dir = setup_git_repo();
+    let repo_path = temp_dir.path();
+    let bin_dir = tempdir().unwrap();
+
+    create_fake_pnpm(
+        bin_dir.path(),
+        "#!/bin/sh\necho \"install failed\" >&2\nexit 1\n",
+    );
+
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    let path_env = format!("{}:{}", bin_dir.path().display(), original_path);
+
+    let output = run_warp_switch(repo_path, "feature/pnpm-warn", &path_env);
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Detected pnpm repo but `pnpm install` failed: install failed"));
+    assert!(stdout.contains("Worktree created successfully"));
+}


### PR DESCRIPTION
## What changed
- add a post-create setup step that runs `pnpm install` only for newly created worktrees that contain both `package.json` and `pnpm-lock.yaml`
- keep existing worktrees and non-pnpm repos unchanged
- warn in CLI output when `pnpm install` fails instead of failing `warp switch`
- add focused unit and integration coverage for the new post-create behavior

## Why
Creating a new worktree in a pnpm-based repository left dependencies uninstalled, which made testing changes in those worktree branches slower and more error-prone.

## Impact
For pnpm repos, a freshly created worktree is ready to use immediately after `warp switch`. Existing worktrees still behave the same, and install failures are surfaced as warnings without blocking the switch.

## Root cause
`warp switch` created the worktree and switched terminals, but it had no post-create setup step for dependency installation.

## Checks
- `cargo fmt --check`
- `cargo test post_create -- --nocapture`
- `cargo test switch_post_create_tests -- --nocapture`
