### PR TITLE
[codex] honor Warp terminal selection

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -307,7 +307,12 @@ impl Cli {
         };
 
         let terminal_manager = TerminalManager;
-        match terminal_manager.switch_to_worktree(&worktree_path, terminal_mode, None) {
+        match terminal_manager.switch_to_worktree_with_app(
+            &worktree_path,
+            terminal_mode,
+            None,
+            Some(config.terminal.app.as_str()),
+        ) {
             Ok(()) => {
                 println!("🔄 Switched to worktree: {}", worktree_path.display());
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,7 +74,7 @@ pub struct ProcessConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TerminalConfig {
-    /// Preferred terminal application (iterm2, terminal, auto)
+    /// Preferred terminal application (iterm2, terminal, warp, auto)
     #[serde(default = "default_terminal_app")]
     pub app: String,
 
@@ -262,7 +262,7 @@ auto_kill = {}
 kill_timeout = {}
 
 [terminal]
-# Terminal app: auto, iterm2, terminal
+# Terminal app: auto, iterm2, terminal, warp
 app = "{}"
 
 # Auto-activate new tabs/windows

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -30,6 +30,42 @@ pub trait Terminal {
     fn is_supported(&self) -> bool;
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminalPreference {
+    ITerm2,
+    AppleTerminal,
+    Warp,
+}
+
+fn parse_terminal_preference(value: &str) -> Option<TerminalPreference> {
+    match value.to_lowercase().as_str() {
+        "iterm" | "iterm2" => Some(TerminalPreference::ITerm2),
+        "terminal" => Some(TerminalPreference::AppleTerminal),
+        "warp" => Some(TerminalPreference::Warp),
+        _ => None,
+    }
+}
+
+pub fn resolve_terminal_preference(
+    preferred_app: &str,
+    term_program: Option<&str>,
+    iterm_supported: bool,
+    warp_supported: bool,
+) -> TerminalPreference {
+    if let Some(explicit) = parse_terminal_preference(preferred_app) {
+        return explicit;
+    }
+
+    match term_program {
+        Some("WarpTerminal") if warp_supported => TerminalPreference::Warp,
+        Some("iTerm.app") if iterm_supported => TerminalPreference::ITerm2,
+        Some("Apple_Terminal") => TerminalPreference::AppleTerminal,
+        _ if iterm_supported => TerminalPreference::ITerm2,
+        _ if warp_supported => TerminalPreference::Warp,
+        _ => TerminalPreference::AppleTerminal,
+    }
+}
+
 #[cfg(target_os = "macos")]
 pub struct ITerm2;
 
@@ -179,17 +215,116 @@ impl AppleTerminal {
     }
 }
 
+#[cfg(target_os = "macos")]
+pub struct WarpTerminal;
+
+#[cfg(target_os = "macos")]
+impl Terminal for WarpTerminal {
+    fn open_tab(&self, path: &Path, _session_id: Option<&str>) -> Result<()> {
+        self.open_uri("new_tab", path)
+    }
+
+    fn open_window(&self, path: &Path, _session_id: Option<&str>) -> Result<()> {
+        self.open_uri("new_window", path)
+    }
+
+    fn switch_to_directory(&self, path: &Path) -> Result<()> {
+        println!("cd '{}'", path.display());
+        Ok(())
+    }
+
+    fn echo_commands(&self, path: &Path) -> Result<()> {
+        println!("# Navigate to worktree:");
+        println!("cd '{}'", path.display());
+        Ok(())
+    }
+
+    fn is_supported(&self) -> bool {
+        Command::new("osascript")
+            .args(&["-e", "tell application \"Warp\" to get version"])
+            .output()
+            .map(|output| output.status.success())
+            .unwrap_or(false)
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl WarpTerminal {
+    fn open_uri(&self, action: &str, path: &Path) -> Result<()> {
+        let encoded_path = percent_encode(path.to_string_lossy().as_ref());
+        let uri = format!("warp://action/{action}?path={encoded_path}");
+
+        let output = Command::new("open")
+            .arg(&uri)
+            .output()
+            .map_err(|e| anyhow::anyhow!("Failed to open Warp URI: {}", e))?;
+
+        if !output.status.success() {
+            let error = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow::anyhow!("Warp URI open failed: {}", error).into());
+        }
+
+        Ok(())
+    }
+}
+
+fn percent_encode(input: &str) -> String {
+    let mut encoded = String::new();
+
+    for byte in input.as_bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' | b'/' => {
+                encoded.push(*byte as char)
+            }
+            _ => encoded.push_str(&format!("%{:02X}", byte)),
+        }
+    }
+
+    encoded
+}
+
 pub struct TerminalManager;
 
 impl TerminalManager {
     pub fn get_default_terminal() -> Result<Box<dyn Terminal>> {
+        Self::get_terminal(None)
+    }
+
+    pub fn get_terminal(preferred_app: Option<&str>) -> Result<Box<dyn Terminal>> {
         #[cfg(target_os = "macos")]
         {
             let iterm2 = ITerm2;
-            if iterm2.is_supported() {
-                Ok(Box::new(iterm2))
-            } else {
-                Ok(Box::new(AppleTerminal))
+            let warp = WarpTerminal;
+            let requested = preferred_app.unwrap_or("auto");
+
+            if matches!(
+                parse_terminal_preference(requested),
+                Some(TerminalPreference::ITerm2)
+            ) && !iterm2.is_supported()
+            {
+                return Err(GitWarpError::TerminalNotSupported.into());
+            }
+
+            if matches!(
+                parse_terminal_preference(requested),
+                Some(TerminalPreference::Warp)
+            ) && !warp.is_supported()
+            {
+                return Err(GitWarpError::TerminalNotSupported.into());
+            }
+
+            let term_program = std::env::var("TERM_PROGRAM").ok();
+            let resolved = resolve_terminal_preference(
+                requested,
+                term_program.as_deref(),
+                iterm2.is_supported(),
+                warp.is_supported(),
+            );
+
+            match resolved {
+                TerminalPreference::ITerm2 => Ok(Box::new(ITerm2)),
+                TerminalPreference::AppleTerminal => Ok(Box::new(AppleTerminal)),
+                TerminalPreference::Warp => Ok(Box::new(WarpTerminal)),
             }
         }
 
@@ -205,7 +340,17 @@ impl TerminalManager {
         mode: TerminalMode,
         session_id: Option<&str>,
     ) -> Result<()> {
-        let terminal = Self::get_default_terminal()?;
+        self.switch_to_worktree_with_app(path, mode, session_id, None)
+    }
+
+    pub fn switch_to_worktree_with_app<P: AsRef<Path>>(
+        &self,
+        path: P,
+        mode: TerminalMode,
+        session_id: Option<&str>,
+        preferred_app: Option<&str>,
+    ) -> Result<()> {
+        let terminal = Self::get_terminal(preferred_app)?;
         let path = path.as_ref();
 
         match mode {

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,3 +1,4 @@
 // Integration tests combining multiple components
 pub mod cow_git_integration_tests;
 pub mod full_workflow_tests;
+pub mod terminal_switch_tests;

--- a/tests/integration/terminal_switch_tests.rs
+++ b/tests/integration/terminal_switch_tests.rs
@@ -1,0 +1,198 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::tempdir;
+
+#[cfg(unix)]
+fn make_executable(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap();
+}
+
+fn setup_git_repo() -> tempfile::TempDir {
+    let temp_dir = tempdir().unwrap();
+    let repo_path = temp_dir.path();
+
+    Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    fs::write(repo_path.join("README.md"), "# Test Repository\n").unwrap();
+
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    Command::new("git")
+        .args(["commit", "-m", "Initial commit"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    temp_dir
+}
+
+fn create_fake_osascript(bin_dir: &Path, log_path: &Path) -> PathBuf {
+    let script_path = bin_dir.join("osascript");
+    fs::write(
+        &script_path,
+        format!(
+            "#!/bin/sh\nif [ \"$1\" = \"-e\" ]; then\n  printf '%s\\n---\\n' \"$2\" >> \"{}\"\nfi\nexit 0\n",
+            log_path.display()
+        ),
+    )
+    .unwrap();
+    #[cfg(unix)]
+    make_executable(&script_path);
+    script_path
+}
+
+fn create_fake_open(bin_dir: &Path, log_path: &Path) -> PathBuf {
+    let script_path = bin_dir.join("open");
+    fs::write(
+        &script_path,
+        format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\nexit 0\n",
+            log_path.display()
+        ),
+    )
+    .unwrap();
+    #[cfg(unix)]
+    make_executable(&script_path);
+    script_path
+}
+
+fn write_config(home_dir: &Path, app: &str) {
+    let config_dir = home_dir
+        .join("Library")
+        .join("Application Support")
+        .join("git-warp");
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(
+        config_dir.join("config.toml"),
+        format!(
+            r#"
+terminal_mode = "tab"
+use_cow = false
+
+[terminal]
+app = "{app}"
+auto_activate = true
+init_commands = []
+"#
+        ),
+    )
+    .unwrap();
+}
+
+fn run_warp_switch(
+    repo_path: &Path,
+    branch: &str,
+    home_dir: &Path,
+    path_env: &str,
+    term_program: &str,
+) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_warp"))
+        .args(["switch", "--no-cow", branch])
+        .current_dir(repo_path)
+        .env("HOME", home_dir)
+        .env("PATH", path_env)
+        .env("TERM_PROGRAM", term_program)
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn test_warp_switch_honors_explicit_warp_terminal_app() {
+    let repo_dir = setup_git_repo();
+    let repo_path = repo_dir.path();
+    let home_dir = tempdir().unwrap();
+    let bin_dir = tempdir().unwrap();
+    let osascript_log_dir = tempdir().unwrap();
+    let open_log_dir = tempdir().unwrap();
+    let osascript_log = osascript_log_dir.path().join("osascript.log");
+    let open_log = open_log_dir.path().join("open.log");
+
+    write_config(home_dir.path(), "warp");
+    create_fake_osascript(bin_dir.path(), &osascript_log);
+    create_fake_open(bin_dir.path(), &open_log);
+
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    let path_env = format!("{}:{}", bin_dir.path().display(), original_path);
+
+    let output = run_warp_switch(
+        repo_path,
+        "feature/warp-explicit",
+        home_dir.path(),
+        &path_env,
+        "iTerm.app",
+    );
+
+    assert!(output.status.success());
+
+    let osascript_contents = fs::read_to_string(&osascript_log).unwrap_or_default();
+    let open_contents = fs::read_to_string(&open_log).unwrap_or_default();
+    assert!(
+        open_contents.contains("warp://action/new_tab?path="),
+        "expected Warp URI open call, got open={}, osascript={}",
+        open_contents,
+        osascript_contents
+    );
+}
+
+#[test]
+fn test_warp_switch_auto_prefers_current_warp_terminal() {
+    let repo_dir = setup_git_repo();
+    let repo_path = repo_dir.path();
+    let home_dir = tempdir().unwrap();
+    let bin_dir = tempdir().unwrap();
+    let osascript_log_dir = tempdir().unwrap();
+    let open_log_dir = tempdir().unwrap();
+    let osascript_log = osascript_log_dir.path().join("osascript.log");
+    let open_log = open_log_dir.path().join("open.log");
+
+    write_config(home_dir.path(), "auto");
+    create_fake_osascript(bin_dir.path(), &osascript_log);
+    create_fake_open(bin_dir.path(), &open_log);
+
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    let path_env = format!("{}:{}", bin_dir.path().display(), original_path);
+
+    let output = run_warp_switch(
+        repo_path,
+        "feature/warp-auto",
+        home_dir.path(),
+        &path_env,
+        "WarpTerminal",
+    );
+
+    assert!(output.status.success());
+
+    let osascript_contents = fs::read_to_string(&osascript_log).unwrap_or_default();
+    let open_contents = fs::read_to_string(&open_log).unwrap_or_default();
+    assert!(
+        open_contents.contains("warp://action/new_tab?path="),
+        "expected Warp URI open call, got open={}, osascript={}",
+        open_contents,
+        osascript_contents
+    );
+}

--- a/tests/unit/terminal_tests.rs
+++ b/tests/unit/terminal_tests.rs
@@ -1,4 +1,6 @@
-use git_warp::terminal::{Terminal, TerminalManager, TerminalMode};
+use git_warp::terminal::{
+    Terminal, TerminalManager, TerminalMode, TerminalPreference, resolve_terminal_preference,
+};
 use tempfile::tempdir;
 
 #[test]
@@ -279,4 +281,16 @@ fn test_terminal_cleanup() {
         // - Clearing session state
         // - Handling graceful shutdown
     }
+}
+
+#[test]
+fn test_resolve_terminal_preference_prefers_warp_term_program() {
+    let resolved = resolve_terminal_preference("auto", Some("WarpTerminal"), true, true);
+    assert_eq!(resolved, TerminalPreference::Warp);
+}
+
+#[test]
+fn test_resolve_terminal_preference_honors_explicit_warp() {
+    let resolved = resolve_terminal_preference("warp", Some("iTerm.app"), true, true);
+    assert_eq!(resolved, TerminalPreference::Warp);
 }


### PR DESCRIPTION
## What changed
- honor `[terminal].app` during `warp switch` instead of always preferring iTerm when it is installed
- add a Warp terminal backend that opens tabs and windows through Warp's URI scheme
- add regression coverage for explicit `app = "warp"` and `auto` selection when `TERM_PROGRAM=WarpTerminal`

## Why
`warp <branch>` and `warp switch <branch>` ignored the configured terminal app. On macOS, `auto` effectively meant "use iTerm if present", so running Git-Warp from Warp still opened new tabs in iTerm.

## Impact
Users can keep worktree switching in Warp by setting `app = "warp"`, and `auto` now follows the active terminal when Git-Warp is launched from Warp.

## Validation
- `cargo fmt`
- `git diff --check`
- `cargo test terminal_switch_tests -- --nocapture`
- `cargo test terminal_tests -- --nocapture`
