### PR TITLE
[codex] Remove or implement stubbed CLI affordances

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ warp ls
 warp switch feature/new-feature
 warp feature/new-feature  # Short form
 
+# Reopen the most recent or waiting agent branch
+warp switch --latest
+warp switch --waiting
+
 # Custom worktree location  
 warp switch --path /custom/location feature/branch
 
@@ -129,7 +133,7 @@ warp hooks-remove --level user
 # View current configuration
 warp config --show
 
-# Interactive configuration editor
+# Open the config file in your editor
 warp config --edit
 
 # Terminal mode options
@@ -208,7 +212,6 @@ kill_timeout = 5               # Timeout in seconds
 [terminal]
 app = "auto"                   # auto, terminal, iterm2, warp
 auto_activate = true           # Activate new terminal windows
-init_commands = []             # Commands to run in new terminals
 
 [agent]
 enabled = true                 # Enable Claude Code integration

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -126,6 +126,10 @@ warp ls
 # Switch to existing branch
 warp switch existing-branch
 
+# Switch to the most recent or waiting agent branch
+warp switch --latest
+warp switch --waiting
+
 # List worktrees with details
 warp ls --debug
 
@@ -272,10 +276,10 @@ warp config --show
 # Shows all configuration with current values
 ```
 
-**Generate Sample Config**:
+**Open the Config File**:
 ```bash
 warp config --edit
-# Shows sample configuration and creates default if needed
+# Creates the default config if needed, then opens it in your editor
 ```
 
 **Environment Variables** (Override any setting):
@@ -398,9 +402,6 @@ app = "auto"
 # Auto-activate new tabs/windows
 auto_activate = true
 
-# Custom commands to run in new worktrees
-# init_commands = ["npm install", "source .env"]
-
 [agent]
 # Enable agent monitoring
 enabled = true
@@ -518,9 +519,8 @@ git worktree remove --force broken-branch
 # Remove config file
 rm ~/.config/git-warp/config.toml
 
-# Regenerate default
+# Recreate and open the default config
 warp config --edit
-# Press 'y' when prompted
 ```
 
 ---

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -70,7 +70,13 @@ fn status_file_path(root: &Path, runtime: AgentRuntime) -> PathBuf {
     }
 }
 
+fn normalize_path(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
 fn is_path_within_root(path: &Path, root: &Path) -> bool {
+    let path = normalize_path(path);
+    let root = normalize_path(root);
     path == root || path.starts_with(root)
 }
 
@@ -271,13 +277,12 @@ pub fn parse_live_status_file(
         .parent()
         .and_then(|p| p.parent())
         .and_then(|p| p.parent())
-        .unwrap_or_else(|| Path::new("."))
-        .to_path_buf();
+        .unwrap_or_else(|| Path::new("."));
 
     Ok(Some(AgentSessionSummary {
         runtime,
         session_id: None,
-        cwd,
+        cwd: normalize_path(cwd),
         branch: None,
         agent_label: match runtime {
             AgentRuntime::Claude => "Claude".to_string(),
@@ -312,7 +317,7 @@ pub fn parse_codex_session_meta_line(line: &str) -> Option<AgentSessionSummary> 
             .get("id")
             .and_then(|v| v.as_str())
             .map(str::to_string),
-        cwd: PathBuf::from(cwd),
+        cwd: normalize_path(Path::new(cwd)),
         branch: payload
             .get("git")
             .and_then(|git| git.get("branch"))
@@ -513,7 +518,7 @@ pub fn parse_claude_session_event_line(line: &str) -> Option<AgentSessionSummary
             .get("sessionId")
             .and_then(|v| v.as_str())
             .map(str::to_string),
-        cwd: PathBuf::from(cwd),
+        cwd: normalize_path(Path::new(cwd)),
         branch: value
             .get("gitBranch")
             .and_then(|v| v.as_str())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use clap::{CommandFactory, Parser, Subcommand};
 use log::info;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 #[derive(Parser)]
 #[command(
@@ -28,10 +30,6 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub terminal: Option<String>,
 
-    /// Always create new terminal session
-    #[arg(long, global = true)]
-    pub always_new: bool,
-
     /// Auto-confirm operations
     #[arg(long, short = 'y', global = true)]
     pub auto_confirm: bool,
@@ -42,17 +40,14 @@ pub enum Commands {
     /// Create or switch to a worktree
     Switch {
         /// Branch name
-        branch: String,
+        branch: Option<String>,
         /// Custom worktree path
         #[arg(long)]
         path: Option<String>,
-        /// Init script to run after creation
-        #[arg(long)]
-        init: Option<String>,
-        /// Skip to latest agent
+        /// Switch to the most recent agent branch
         #[arg(long)]
         latest: bool,
-        /// Skip to waiting agent
+        /// Switch to the most recent waiting agent branch
         #[arg(long)]
         waiting: bool,
         /// Force traditional worktree (skip CoW)
@@ -92,7 +87,7 @@ pub enum Commands {
         /// Show current configuration
         #[arg(long)]
         show: bool,
-        /// Edit configuration interactively
+        /// Open the configuration file in your editor
         #[arg(long)]
         edit: bool,
     },
@@ -147,7 +142,7 @@ impl Cli {
             None => {
                 if let Some(branch) = &self.branch {
                     // Dynamic branch command - same as switch
-                    self.handle_switch(branch, None, None, false, false, false)
+                    self.handle_switch(Some(branch), None, false, false, false)
                 } else {
                     // No command or branch - show help
                     let mut cmd = Self::command();
@@ -163,14 +158,12 @@ impl Cli {
             Commands::Switch {
                 branch,
                 path,
-                init,
                 latest,
                 waiting,
                 no_cow,
             } => self.handle_switch(
-                branch,
+                branch.as_deref(),
                 path.as_deref(),
-                init.as_deref(),
                 *latest,
                 *waiting,
                 *no_cow,
@@ -198,11 +191,10 @@ impl Cli {
 
     fn handle_switch(
         &self,
-        branch: &str,
+        branch: Option<&str>,
         path: Option<&str>,
-        _init: Option<&str>,
-        _latest: bool,
-        _waiting: bool,
+        latest: bool,
+        waiting: bool,
         no_cow: bool,
     ) -> Result<()> {
         use crate::config::ConfigManager;
@@ -211,13 +203,13 @@ impl Cli {
         use crate::post_create::{PostCreateSetupStatus, run_post_create_setup};
         use crate::rewrite::PathRewriter;
         use crate::terminal::{TerminalManager, TerminalMode};
-        use std::path::PathBuf;
-
-        info!("Switching to branch: {}", branch);
 
         // Find the Git repository
         let git_repo =
             GitRepository::find().map_err(|_| anyhow::anyhow!("Not in a Git repository"))?;
+        let branch = self.resolve_switch_branch(&git_repo, branch, latest, waiting)?;
+
+        info!("Switching to branch: {}", branch);
 
         let config_manager = ConfigManager::new()?;
         let config = config_manager.get();
@@ -226,7 +218,7 @@ impl Cli {
         let worktree_path = if let Some(path) = path {
             PathBuf::from(path)
         } else {
-            git_repo.get_worktree_path_with_base(branch, config.worktrees_path.as_deref())
+            git_repo.get_worktree_path_with_base(&branch, config.worktrees_path.as_deref())
         };
 
         if self.dry_run {
@@ -259,7 +251,7 @@ impl Cli {
                 println!("⚡ Using Copy-on-Write for instant creation...");
 
                 // Create worktree using traditional method first
-                git_repo.create_worktree_and_branch(branch, &worktree_path, None)?;
+                git_repo.create_worktree_and_branch(&branch, &worktree_path, None)?;
 
                 // If we have existing worktrees, try CoW enhancement
                 let worktrees = git_repo.list_worktrees()?;
@@ -273,7 +265,7 @@ impl Cli {
                     if let Err(e) = cow::clone_directory(&main_worktree.path, &worktree_path) {
                         log::warn!("CoW failed, falling back to traditional method: {}", e);
                         // Recreate using traditional method
-                        git_repo.create_worktree_and_branch(branch, &worktree_path, None)?;
+                        git_repo.create_worktree_and_branch(&branch, &worktree_path, None)?;
                     } else {
                         // Rewrite paths in the CoW copy
                         let rewriter = PathRewriter::new(&main_worktree.path, &worktree_path);
@@ -282,9 +274,8 @@ impl Cli {
                         }
 
                         // Switch to the correct branch
-                        use std::process::Command;
                         let output = Command::new("git")
-                            .args(&["checkout", branch])
+                            .args(["checkout", branch.as_str()])
                             .current_dir(&worktree_path)
                             .output()?;
 
@@ -296,7 +287,7 @@ impl Cli {
                 }
             } else {
                 println!("📦 Using traditional Git worktree creation...");
-                git_repo.create_worktree_and_branch(branch, &worktree_path, None)?;
+                git_repo.create_worktree_and_branch(&branch, &worktree_path, None)?;
             }
 
             println!("✅ Worktree created successfully!");
@@ -337,6 +328,77 @@ impl Cli {
         }
 
         Ok(())
+    }
+
+    fn resolve_switch_branch(
+        &self,
+        git_repo: &crate::git::GitRepository,
+        branch: Option<&str>,
+        latest: bool,
+        waiting: bool,
+    ) -> Result<String> {
+        let selector_count =
+            usize::from(branch.is_some()) + usize::from(latest) + usize::from(waiting);
+        if selector_count != 1 {
+            return Err(anyhow::anyhow!(
+                "Specify exactly one of [BRANCH], --latest, or --waiting"
+            ));
+        }
+
+        if let Some(branch) = branch {
+            return Ok(branch.to_string());
+        }
+
+        use crate::agents::{AgentDiscovery, AgentSessionState};
+        use chrono::Local;
+
+        let discovery = AgentDiscovery::new(Self::agent_monitored_paths(git_repo)?);
+        let sessions = discovery.discover(Local::now())?;
+
+        let branch = if waiting {
+            sessions
+                .into_iter()
+                .find(|session| {
+                    session.state == AgentSessionState::Waiting
+                        && session
+                            .branch
+                            .as_ref()
+                            .is_some_and(|branch| !branch.is_empty())
+                })
+                .and_then(|session| session.branch)
+        } else {
+            sessions
+                .into_iter()
+                .find(|session| {
+                    session.state != AgentSessionState::Completed
+                        && session
+                            .branch
+                            .as_ref()
+                            .is_some_and(|branch| !branch.is_empty())
+                })
+                .and_then(|session| session.branch)
+        };
+
+        branch.ok_or_else(|| {
+            if waiting {
+                anyhow::anyhow!("No waiting agent branches were found for this repository")
+            } else {
+                anyhow::anyhow!("No recent agent branches were found for this repository")
+            }
+        })
+    }
+
+    fn agent_monitored_paths(git_repo: &crate::git::GitRepository) -> Result<Vec<PathBuf>> {
+        let mut monitored_paths = vec![git_repo.root_path().to_path_buf()];
+        monitored_paths.extend(
+            git_repo
+                .list_worktrees()?
+                .into_iter()
+                .map(|worktree| worktree.path),
+        );
+        monitored_paths.sort();
+        monitored_paths.dedup();
+        Ok(monitored_paths)
     }
 
     fn handle_ls(&self, debug: bool) -> Result<()> {
@@ -648,9 +710,6 @@ impl Cli {
             println!("🖥️  Terminal Integration:");
             println!("  App: {}", config.terminal.app);
             println!("  Auto-activate: {}", config.terminal.auto_activate);
-            if !config.terminal.init_commands.is_empty() {
-                println!("  Init commands: {:?}", config.terminal.init_commands);
-            }
             println!();
 
             println!("🤖 Agent Settings:");
@@ -659,36 +718,22 @@ impl Cli {
             println!("  Max activities: {}", config.agent.max_activities);
             println!("  Claude hooks: {}", config.agent.claude_hooks);
         } else if edit {
-            // Interactive config editing (for now, show sample config)
-            println!("📝 Sample Configuration:");
-            println!("Copy this to: {}", config_manager.config_path().display());
-            println!();
-            config_manager.show_sample_config();
-
             if !config_manager.config_exists() {
-                println!();
-                println!("💡 No config file found. Create one? [y/N]: ");
-                use std::io::{self, Write};
-                io::stdout().flush()?;
-
-                let mut input = String::new();
-                io::stdin().read_line(&mut input)?;
-
-                if input.trim().to_lowercase().starts_with('y') {
-                    config_manager.create_default_config()?;
-                    println!(
-                        "✅ Created default configuration at: {}",
-                        config_manager.config_path().display()
-                    );
-                }
+                config_manager.create_default_config()?;
+                println!(
+                    "✅ Created default configuration at: {}",
+                    config_manager.config_path().display()
+                );
             }
+
+            Self::open_in_editor(config_manager.config_path())?;
         } else {
             // Show help for config command
             println!("⚙️  Configuration Management");
             println!();
             println!("Usage:");
             println!("  warp config --show     Show current configuration");
-            println!("  warp config --edit     Edit configuration interactively");
+            println!("  warp config --edit     Open configuration in your editor");
             println!();
             println!("Configuration file location:");
             println!("  {}", config_manager.config_path().display());
@@ -716,17 +761,8 @@ impl Cli {
 
         let git_repo =
             GitRepository::find().map_err(|_| anyhow::anyhow!("Not in a Git repository"))?;
-        let mut monitored_paths = vec![git_repo.root_path().to_path_buf()];
-        monitored_paths.extend(
-            git_repo
-                .list_worktrees()?
-                .into_iter()
-                .map(|worktree| worktree.path),
-        );
-        monitored_paths.sort();
-        monitored_paths.dedup();
-
-        let dashboard = AgentsDashboard::new(AgentDiscovery::new(monitored_paths));
+        let dashboard =
+            AgentsDashboard::new(AgentDiscovery::new(Self::agent_monitored_paths(&git_repo)?));
         dashboard.run()
     }
 
@@ -775,7 +811,96 @@ impl Cli {
 
     fn handle_shell_config(&self, shell: Option<&str>) -> Result<()> {
         info!("Generating shell config for: {:?}", shell);
-        println!("🚧 Shell config not yet implemented");
+        let detected_shell = shell
+            .map(str::to_string)
+            .or_else(|| {
+                std::env::var("SHELL").ok().and_then(|value| {
+                    value
+                        .rsplit('/')
+                        .next()
+                        .map(str::to_string)
+                        .filter(|value| !value.is_empty())
+                })
+            })
+            .unwrap_or_else(|| "bash".to_string());
+
+        match detected_shell.as_str() {
+            "bash" => {
+                println!("# Add to ~/.bashrc");
+                println!(
+                    "{}",
+                    r#"warp_cd() { eval "$(warp --terminal echo "$@")"; }"#
+                );
+            }
+            "zsh" => {
+                println!("# Add to ~/.zshrc");
+                println!(
+                    "{}",
+                    r#"warp_cd() { eval "$(warp --terminal echo "$@")"; }"#
+                );
+            }
+            "fish" => {
+                println!("# Add to ~/.config/fish/config.fish");
+                println!("function warp_cd");
+                println!("    eval (warp --terminal echo $argv)");
+                println!("end");
+            }
+            other => {
+                return Err(anyhow::anyhow!(
+                    "Unsupported shell '{other}'. Supported shells: bash, zsh, fish"
+                ));
+            }
+        }
         Ok(())
+    }
+
+    fn open_in_editor(path: &Path) -> Result<()> {
+        let editor = std::env::var("VISUAL")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .or_else(|| {
+                std::env::var("EDITOR")
+                    .ok()
+                    .filter(|value| !value.trim().is_empty())
+            });
+
+        if let Some(editor) = editor {
+            let mut parts = editor.split_whitespace();
+            let program = parts
+                .next()
+                .ok_or_else(|| anyhow::anyhow!("Invalid editor command"))?;
+            let status = Command::new(program)
+                .args(parts)
+                .arg(path)
+                .status()
+                .map_err(|err| anyhow::anyhow!("Failed to launch editor '{}': {}", editor, err))?;
+
+            if status.success() {
+                return Ok(());
+            }
+
+            return Err(anyhow::anyhow!(
+                "Editor '{}' exited with status {:?}",
+                editor,
+                status.code()
+            ));
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            let status = Command::new("open")
+                .args(["-t"])
+                .arg(path)
+                .status()
+                .map_err(|err| anyhow::anyhow!("Failed to open config file: {}", err))?;
+
+            if status.success() {
+                return Ok(());
+            }
+        }
+
+        Err(anyhow::anyhow!(
+            "No editor configured. Set $VISUAL or $EDITOR to use `warp config --edit`"
+        ))
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,7 @@ pub struct TerminalConfig {
 
     /// Custom init commands for new worktrees
     #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub init_commands: Vec<String>,
 }
 
@@ -267,9 +268,6 @@ app = "{}"
 
 # Auto-activate new tabs/windows
 auto_activate = {}
-
-# Custom commands to run in new worktrees
-# init_commands = ["npm install", "source .env"]
 
 [agent]
 # Enable agent monitoring

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -765,11 +765,8 @@ mod tests {
 
     #[test]
     fn test_terminal_cleanup_attempt_keeps_guard_active_when_cleanup_fails() {
-        let (active, result) = terminal_cleanup_attempt(
-            true,
-            || Ok(()),
-            || Err(io::Error::other("cleanup failed")),
-        );
+        let (active, result) =
+            terminal_cleanup_attempt(true, || Ok(()), || Err(io::Error::other("cleanup failed")));
 
         assert!(active);
         let message = result.expect_err("cleanup should fail").to_string();

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -1,0 +1,261 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::tempdir;
+
+fn run_git(repo_path: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn setup_test_repo() -> tempfile::TempDir {
+    let temp_dir = tempdir().unwrap();
+    let repo_path = temp_dir.path();
+
+    run_git(repo_path, &["init", "-b", "main"]);
+    run_git(repo_path, &["config", "user.email", "test@example.com"]);
+    run_git(repo_path, &["config", "user.name", "Test User"]);
+
+    fs::write(repo_path.join("README.md"), "# Test Repository\n").unwrap();
+    run_git(repo_path, &["add", "."]);
+    run_git(repo_path, &["commit", "-m", "Initial commit"]);
+
+    temp_dir
+}
+
+fn create_worktree(repo_path: &Path, branch: &str) -> PathBuf {
+    let worktree_path = repo_path.join(".worktrees").join(branch);
+    fs::create_dir_all(worktree_path.parent().unwrap()).unwrap();
+
+    let output = Command::new("git")
+        .args(["worktree", "add", "-b", branch])
+        .arg(&worktree_path)
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "git worktree add failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    worktree_path
+}
+
+fn write_codex_session(home: &Path, cwd: &Path, session_id: &str, branch: &str, timestamp: &str) {
+    let sessions_dir = home.join(".codex").join("sessions");
+    fs::create_dir_all(&sessions_dir).unwrap();
+    fs::write(
+        sessions_dir.join(format!("{session_id}.jsonl")),
+        format!(
+            r#"{{"timestamp":"{timestamp}","type":"session_meta","payload":{{"id":"{session_id}","timestamp":"{timestamp}","cwd":"{}","originator":"codex-tui","agent_nickname":"Parfit","agent_role":"worker","git":{{"branch":"{branch}"}}}}}}"#,
+            cwd.display()
+        ),
+    )
+    .unwrap();
+}
+
+fn write_live_status(worktree_path: &Path, status: &str, timestamp: &str) {
+    let status_path = worktree_path.join(".codex").join("git-warp").join("status");
+    fs::create_dir_all(status_path.parent().unwrap()).unwrap();
+    fs::write(
+        status_path,
+        format!(r#"{{"status":"{status}","last_activity":"{timestamp}"}}"#),
+    )
+    .unwrap();
+}
+
+fn warp_command(repo_path: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_warp"));
+    command.current_dir(repo_path);
+    command
+}
+
+fn expected_config_path(home: &Path) -> PathBuf {
+    if cfg!(target_os = "macos") {
+        home.join("Library")
+            .join("Application Support")
+            .join("git-warp")
+            .join("config.toml")
+    } else if cfg!(target_os = "windows") {
+        home.join("AppData")
+            .join("Roaming")
+            .join("git-warp")
+            .join("config.toml")
+    } else {
+        home.join(".config").join("git-warp").join("config.toml")
+    }
+}
+
+#[test]
+fn test_root_help_hides_removed_global_flag() {
+    let output = Command::new(env!("CARGO_BIN_EXE_warp"))
+        .arg("--help")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success());
+    assert!(!stdout.contains("--always-new"));
+    assert!(stdout.contains("shell-config"));
+}
+
+#[test]
+fn test_switch_help_hides_removed_flags_and_allows_selector_without_branch() {
+    let output = Command::new(env!("CARGO_BIN_EXE_warp"))
+        .args(["switch", "--help"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success());
+    assert!(stdout.contains("Usage: warp switch [OPTIONS] [BRANCH]"));
+    assert!(stdout.contains("--latest"));
+    assert!(stdout.contains("--waiting"));
+    assert!(!stdout.contains("--init"));
+    assert!(!stdout.contains("--always-new"));
+}
+
+#[test]
+fn test_switch_rejects_multiple_target_selectors() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+
+    let output = warp_command(repo_path)
+        .args(["switch", "feature/demo", "--latest"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success());
+    assert!(stderr.contains("exactly one of [BRANCH], --latest, or --waiting"));
+}
+
+#[test]
+fn test_switch_latest_resolves_branch_from_recent_agent_session() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+    let home_dir = tempdir().unwrap();
+    let worktree_path = create_worktree(repo_path, "agent-latest");
+
+    write_codex_session(
+        home_dir.path(),
+        &worktree_path,
+        "session-latest",
+        "agent-latest",
+        "2026-04-24T10:00:00.000Z",
+    );
+
+    let output = warp_command(repo_path)
+        .env("HOME", home_dir.path())
+        .args(["--dry-run", "switch", "--latest"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{stdout}");
+    assert!(stdout.contains("Would switch to branch 'agent-latest'"));
+}
+
+#[test]
+fn test_switch_waiting_resolves_branch_from_waiting_agent_session() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+    let home_dir = tempdir().unwrap();
+    let waiting_worktree = create_worktree(repo_path, "agent-waiting");
+    let recent_worktree = create_worktree(repo_path, "agent-recent");
+
+    write_codex_session(
+        home_dir.path(),
+        &waiting_worktree,
+        "session-waiting",
+        "agent-waiting",
+        "2026-04-24T09:00:00.000Z",
+    );
+    write_live_status(&waiting_worktree, "waiting", "2026-04-24T10:30:00+00:00");
+    write_codex_session(
+        home_dir.path(),
+        &recent_worktree,
+        "session-recent",
+        "agent-recent",
+        "2026-04-24T11:00:00.000Z",
+    );
+
+    let output = warp_command(repo_path)
+        .env("HOME", home_dir.path())
+        .args(["--dry-run", "switch", "--waiting"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{stdout}");
+    assert!(stdout.contains("Would switch to branch 'agent-waiting'"));
+}
+
+#[test]
+fn test_config_edit_creates_config_and_launches_editor() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+    let home_dir = tempdir().unwrap();
+    let config_path = expected_config_path(home_dir.path());
+    let marker_path = home_dir.path().join("editor-marker.txt");
+    let editor_path = home_dir.path().join("fake-editor.sh");
+
+    fs::write(
+        &editor_path,
+        format!(
+            "#!/bin/sh\nprintf '%s' \"$1\" > '{}'\n",
+            marker_path.display()
+        ),
+    )
+    .unwrap();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = fs::metadata(&editor_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&editor_path, permissions).unwrap();
+    }
+
+    let output = warp_command(repo_path)
+        .env("HOME", home_dir.path())
+        .env("EDITOR", &editor_path)
+        .env_remove("VISUAL")
+        .args(["config", "--edit"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{stdout}");
+    assert!(config_path.exists());
+    assert_eq!(
+        fs::read_to_string(&marker_path).unwrap(),
+        config_path.display().to_string()
+    );
+}
+
+#[test]
+fn test_shell_config_bash_outputs_reusable_function() {
+    let output = Command::new(env!("CARGO_BIN_EXE_warp"))
+        .args(["shell-config", "bash"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success());
+    assert!(stdout.contains("warp_cd()"));
+    assert!(stdout.contains("warp --terminal echo"));
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,4 +1,5 @@
 // Integration tests combining multiple components
+pub mod cli_surface_tests;
 pub mod cow_git_integration_tests;
 pub mod full_workflow_tests;
 pub mod switch_post_create_tests;


### PR DESCRIPTION
## Summary
- implement real `warp switch --latest` and `warp switch --waiting` branch resolution from Git-Warp's agent session data
- remove dead public CLI affordances for `--init` and `--always-new`, and make `config --edit` plus `shell-config` perform real work
- align README and user guide with the shipped CLI surface and add integration coverage for the supported commands

## Why
Issue #2 called out help-visible commands and flags that were placeholders or misleading. The main gaps were unresolved `switch` selectors, a no-op shell config command, and config editing/docs that advertised behavior the binary did not actually provide.

## Impact
- users can jump back to the most recent or waiting agent branch without guessing branch names
- `warp config --edit` now creates the config if needed and opens it in an editor instead of printing a placeholder flow
- `warp shell-config` now emits reusable shell snippets, and unsupported CLI flags are no longer advertised

## Root Cause
The CLI surface had accumulated partially wired options and placeholder commands, while agent session matching relied on raw paths that could diverge between canonical and non-canonical filesystem forms.

## Validation
- `cargo test cli_surface_tests --test mod -- --nocapture`
- `cargo test unit::agents_tests --test mod -- --nocapture`
- `cargo test unit::config_tests --test mod -- --nocapture`
