### PR TITLE
[codex] Add current terminal mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ warp config --edit
 # Terminal mode options
 warp --terminal tab switch feature/branch     # New tab (default)
 warp --terminal window switch feature/branch  # New window
-warp --terminal inplace switch feature/branch # Current terminal
+warp --terminal current switch feature/branch # Start a shell in this terminal
+warp --terminal inplace switch feature/branch # Print cd command
 warp --terminal echo switch feature/branch    # Just show path
 ```
 
@@ -195,7 +196,7 @@ warp shell-config zsh >> ~/.zshrc
 ### **Configuration File** (`~/.config/git-warp/config.toml`)
 ```toml
 # Terminal behavior
-terminal_mode = "tab"          # tab, window, inplace, echo
+terminal_mode = "tab"          # tab, window, current, inplace, echo
 use_cow = true                 # Enable CoW when available
 auto_confirm = false           # Skip confirmation prompts
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -245,7 +245,10 @@ warp switch --terminal window feature-branch
 # Echo commands instead of switching
 warp switch --terminal echo feature-branch
 
-# Stay in current location
+# Start a shell in the current terminal tab
+warp switch --terminal current feature-branch
+
+# Print a cd command for the worktree
 warp switch --terminal inplace feature-branch
 ```
 
@@ -363,7 +366,7 @@ Git-Warp uses a sophisticated configuration system with three layers:
 Located at: `~/.config/git-warp/config.toml`
 
 ```toml
-# Terminal mode: tab, window, inplace, echo
+# Terminal mode: tab, window, current, inplace, echo
 terminal_mode = "tab"
 
 # Use Copy-on-Write when available

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,7 +26,7 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub dry_run: bool,
 
-    /// Terminal mode: tab, window, inplace, echo
+    /// Terminal mode: tab, window, current, inplace, echo
     #[arg(long, global = true)]
     pub terminal: Option<String>,
 
@@ -314,6 +314,11 @@ impl Cli {
         } else {
             TerminalMode::from_str(&config.terminal_mode).unwrap_or(TerminalMode::Tab)
         };
+        let is_current_mode = matches!(terminal_mode, TerminalMode::Current);
+
+        if is_current_mode {
+            println!("🔄 Switched to worktree: {}", worktree_path.display());
+        }
 
         let terminal_manager = TerminalManager;
         match terminal_manager.switch_to_worktree_with_app(
@@ -323,7 +328,9 @@ impl Cli {
             Some(config.terminal.app.as_str()),
         ) {
             Ok(()) => {
-                println!("🔄 Switched to worktree: {}", worktree_path.display());
+                if !is_current_mode {
+                    println!("🔄 Switched to worktree: {}", worktree_path.display());
+                }
             }
             Err(e) => {
                 log::warn!("Terminal switching failed: {}", e);
@@ -744,7 +751,7 @@ impl Cli {
             println!("  {}", config_manager.config_path().display());
             println!();
             println!("Environment variables (GIT_WARP_ prefix):");
-            println!("  GIT_WARP_TERMINAL_MODE=tab|window|inplace|echo");
+            println!("  GIT_WARP_TERMINAL_MODE=tab|window|current|inplace|echo");
             println!("  GIT_WARP_USE_COW=true|false");
             println!("  GIT_WARP_AUTO_CONFIRM=true|false");
             println!("  GIT_WARP_WORKTREES_PATH=/custom/path");

--- a/src/config.rs
+++ b/src/config.rs
@@ -230,7 +230,7 @@ impl Config {
 # This file configures git-warp behavior
 # You can also set these values via environment variables with GIT_WARP_ prefix
 
-# Terminal mode: tab, window, inplace, echo
+# Terminal mode: tab, window, current, inplace, echo
 terminal_mode = "{}"
 
 # Use Copy-on-Write when available

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -2,12 +2,13 @@ use crate::error::{GitWarpError, Result};
 use std::path::Path;
 use std::process::Command;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum TerminalMode {
     Tab,
     Window,
     InPlace,
     Echo,
+    Current,
 }
 
 impl TerminalMode {
@@ -17,6 +18,7 @@ impl TerminalMode {
             "window" => Some(Self::Window),
             "inplace" => Some(Self::InPlace),
             "echo" => Some(Self::Echo),
+            "current" => Some(Self::Current),
             _ => None,
         }
     }
@@ -283,6 +285,31 @@ fn percent_encode(input: &str) -> String {
     encoded
 }
 
+fn enter_current_shell(path: &Path) -> Result<()> {
+    let shell = std::env::var("SHELL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "/bin/sh".to_string());
+
+    println!(
+        "🐚 Starting shell in current terminal at: {}",
+        path.display()
+    );
+
+    let status = Command::new(&shell)
+        .current_dir(path)
+        .status()
+        .map_err(|e| anyhow::anyhow!("Failed to start current terminal shell: {}", e))?;
+
+    if !status.success() {
+        return Err(
+            anyhow::anyhow!("Current terminal shell exited with status: {}", status).into(),
+        );
+    }
+
+    Ok(())
+}
+
 pub struct TerminalManager;
 
 impl TerminalManager {
@@ -350,14 +377,20 @@ impl TerminalManager {
         session_id: Option<&str>,
         preferred_app: Option<&str>,
     ) -> Result<()> {
-        let terminal = Self::get_terminal(preferred_app)?;
         let path = path.as_ref();
+
+        if matches!(mode, TerminalMode::Current) {
+            return enter_current_shell(path);
+        }
+
+        let terminal = Self::get_terminal(preferred_app)?;
 
         match mode {
             TerminalMode::Tab => terminal.open_tab(path, session_id),
             TerminalMode::Window => terminal.open_window(path, session_id),
             TerminalMode::InPlace => terminal.switch_to_directory(path),
             TerminalMode::Echo => terminal.echo_commands(path),
+            TerminalMode::Current => unreachable!("current mode is handled before terminal lookup"),
         }
     }
 }

--- a/tests/integration/terminal_switch_tests.rs
+++ b/tests/integration/terminal_switch_tests.rs
@@ -81,6 +81,21 @@ fn create_fake_open(bin_dir: &Path, log_path: &Path) -> PathBuf {
     script_path
 }
 
+fn create_fake_shell(bin_dir: &Path, log_path: &Path) -> PathBuf {
+    let script_path = bin_dir.join("fake-shell");
+    fs::write(
+        &script_path,
+        format!(
+            "#!/bin/sh\nprintf 'cwd=%s\\nargs=%s\\n' \"$(pwd)\" \"$*\" >> \"{}\"\nexit 0\n",
+            log_path.display()
+        ),
+    )
+    .unwrap();
+    #[cfg(unix)]
+    make_executable(&script_path);
+    script_path
+}
+
 fn write_config(home_dir: &Path, app: &str) {
     let config_dir = home_dir
         .join("Library")
@@ -156,6 +171,47 @@ fn test_warp_switch_honors_explicit_warp_terminal_app() {
         "expected Warp URI open call, got open={}, osascript={}",
         open_contents,
         osascript_contents
+    );
+}
+
+#[test]
+fn test_warp_switch_current_starts_shell_in_worktree() {
+    let repo_dir = setup_git_repo();
+    let repo_path = repo_dir.path();
+    let home_dir = tempdir().unwrap();
+    let bin_dir = tempdir().unwrap();
+    let shell_log_dir = tempdir().unwrap();
+    let shell_log = shell_log_dir.path().join("shell.log");
+
+    write_config(home_dir.path(), "auto");
+    let fake_shell = create_fake_shell(bin_dir.path(), &shell_log);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_warp"))
+        .args([
+            "--terminal",
+            "current",
+            "switch",
+            "--no-cow",
+            "feature/warp-current",
+        ])
+        .current_dir(repo_path)
+        .env("HOME", home_dir.path())
+        .env("SHELL", &fake_shell)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "expected current switch to succeed, stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let shell_contents = fs::read_to_string(&shell_log).unwrap_or_default();
+    assert!(
+        shell_contents.contains("worktrees/feature-warp-current"),
+        "expected fake shell to start in worktree, got {}",
+        shell_contents
     );
 }
 

--- a/tests/unit/terminal_tests.rs
+++ b/tests/unit/terminal_tests.rs
@@ -37,6 +37,10 @@ fn test_terminal_mode_enum() {
     assert_eq!(TerminalMode::Window as u8, 1);
     assert_eq!(TerminalMode::InPlace as u8, 2);
     assert_eq!(TerminalMode::Echo as u8, 3);
+    assert!(matches!(
+        TerminalMode::from_str("current"),
+        Some(TerminalMode::Current)
+    ));
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary
- add `--terminal current` for switching into a worktree without opening a new terminal tab
- start `$SHELL` with the worktree as the process working directory before returning to the previous shell after `exit`
- document the new terminal mode and cover it with a fake-shell integration test

## Validation
- `cargo fmt`
- `cargo test terminal_switch_tests -- --nocapture`
- `cargo test terminal_tests -- --nocapture`
- `git diff --check`
