### PR TITLE
[codex] Make bare warp open an interactive switcher

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::{CommandFactory, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 use log::info;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -144,10 +144,7 @@ impl Cli {
                     // Dynamic branch command - same as switch
                     self.handle_switch(Some(branch), None, false, false, false)
                 } else {
-                    // No command or branch - show help
-                    let mut cmd = Self::command();
-                    cmd.print_help()?;
-                    Ok(())
+                    self.handle_default_switcher()
                 }
             }
         }
@@ -189,6 +186,112 @@ impl Cli {
         }
     }
 
+    fn handle_default_switcher(&self) -> Result<()> {
+        use crate::git::GitRepository;
+        use crate::process::ProcessManager;
+        use crate::tui::{WorktreeSwitchTui, build_worktree_switch_model};
+
+        info!("Starting default worktree switcher");
+
+        let git_repo =
+            GitRepository::find().map_err(|_| anyhow::anyhow!("Not in a Git repository"))?;
+        let worktrees = git_repo.list_worktrees()?;
+        let statuses =
+            Self::collect_worktree_runtime_statuses(&git_repo, &worktrees, ProcessManager::new());
+        let model = build_worktree_switch_model(&worktrees, &statuses);
+
+        if self.dry_run {
+            Self::print_switcher_preview(&model);
+            return Ok(());
+        }
+
+        let switcher = WorktreeSwitchTui::new(model);
+        match switcher.run()? {
+            Some(target) => self.handle_switcher_target(target),
+            None => {
+                println!("No worktree selected");
+                Ok(())
+            }
+        }
+    }
+
+    fn collect_worktree_runtime_statuses(
+        git_repo: &crate::git::GitRepository,
+        worktrees: &[crate::git::WorktreeInfo],
+        mut process_manager: crate::process::ProcessManager,
+    ) -> Vec<crate::tui::WorktreeRuntimeStatus> {
+        let current_dir = std::env::current_dir().unwrap_or_else(|_| git_repo.root_path().into());
+        let current_dir =
+            std::fs::canonicalize(&current_dir).unwrap_or_else(|_| current_dir.clone());
+        let worktree_paths = worktrees
+            .iter()
+            .map(|worktree| {
+                std::fs::canonicalize(&worktree.path).unwrap_or_else(|_| worktree.path.clone())
+            })
+            .collect::<Vec<_>>();
+        let current_worktree_index = worktree_paths
+            .iter()
+            .enumerate()
+            .filter(|(_, path)| current_dir.starts_with(path))
+            .max_by_key(|(_, path)| path.components().count())
+            .map(|(index, _)| index);
+
+        worktrees
+            .iter()
+            .enumerate()
+            .map(|(index, worktree)| crate::tui::WorktreeRuntimeStatus {
+                path: worktree.path.clone(),
+                is_current: current_worktree_index == Some(index),
+                is_dirty: git_repo
+                    .has_uncommitted_changes(&worktree.path)
+                    .unwrap_or(false),
+                is_occupied: process_manager
+                    .has_processes_in_directory(&worktree.path)
+                    .unwrap_or(false),
+            })
+            .collect()
+    }
+
+    fn print_switcher_preview(model: &crate::tui::WorktreeSwitchModel) {
+        println!(
+            "Would open interactive worktree switcher with {} worktrees:",
+            model.rows.len()
+        );
+
+        for row in &model.rows {
+            let badges = if row.badges.is_empty() {
+                String::new()
+            } else {
+                format!(" [{}]", row.badges.join(", "))
+            };
+            println!("  - {}{} {}", row.branch_label, badges, row.path_label);
+        }
+    }
+
+    fn handle_switcher_target(&self, target: crate::tui::WorktreeSwitchTarget) -> Result<()> {
+        if let Some(branch) = target.branch.as_deref() {
+            let path = target.path.to_string_lossy().into_owned();
+            self.handle_switch(Some(branch), Some(path.as_str()), false, false, false)
+        } else {
+            self.handle_existing_worktree_jump(&target.path)
+        }
+    }
+
+    fn handle_existing_worktree_jump(&self, worktree_path: &Path) -> Result<()> {
+        use crate::config::ConfigManager;
+        use crate::terminal::TerminalMode;
+
+        let config_manager = ConfigManager::new()?;
+        let config = config_manager.get();
+        let terminal_mode = if let Some(mode_str) = &self.terminal {
+            TerminalMode::from_str(mode_str).unwrap_or(TerminalMode::Tab)
+        } else {
+            TerminalMode::from_str(&config.terminal_mode).unwrap_or(TerminalMode::Tab)
+        };
+
+        self.switch_to_worktree_path(worktree_path, terminal_mode, config.terminal.app.as_str())
+    }
+
     fn handle_switch(
         &self,
         branch: Option<&str>,
@@ -202,7 +305,7 @@ impl Cli {
         use crate::git::GitRepository;
         use crate::post_create::{PostCreateSetupStatus, run_post_create_setup};
         use crate::rewrite::PathRewriter;
-        use crate::terminal::{TerminalManager, TerminalMode};
+        use crate::terminal::TerminalMode;
 
         // Find the Git repository
         let git_repo =
@@ -308,12 +411,23 @@ impl Cli {
             | PostCreateSetupStatus::SkippedNonPnpmRepo => {}
         }
 
-        // Handle terminal switching
         let terminal_mode = if let Some(mode_str) = &self.terminal {
             TerminalMode::from_str(mode_str).unwrap_or(TerminalMode::Tab)
         } else {
             TerminalMode::from_str(&config.terminal_mode).unwrap_or(TerminalMode::Tab)
         };
+
+        self.switch_to_worktree_path(&worktree_path, terminal_mode, config.terminal.app.as_str())
+    }
+
+    fn switch_to_worktree_path(
+        &self,
+        worktree_path: &Path,
+        terminal_mode: crate::terminal::TerminalMode,
+        terminal_app: &str,
+    ) -> Result<()> {
+        use crate::terminal::{TerminalManager, TerminalMode};
+
         let is_current_mode = matches!(terminal_mode, TerminalMode::Current);
 
         if is_current_mode {
@@ -325,7 +439,7 @@ impl Cli {
             &worktree_path,
             terminal_mode,
             None,
-            Some(config.terminal.app.as_str()),
+            Some(terminal_app),
         ) {
             Ok(()) => {
                 if !is_current_mode {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -4,10 +4,11 @@ use crate::{
         sort_session_summaries,
     },
     error::Result,
+    git::WorktreeInfo,
 };
 use chrono::{DateTime, Duration as ChronoDuration, Local};
 use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, poll},
+    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, poll},
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
@@ -85,6 +86,40 @@ pub struct DashboardRow {
 pub struct DashboardModel {
     pub rows: Vec<DashboardRow>,
     pub empty_state_lines: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct WorktreeRuntimeStatus {
+    pub path: PathBuf,
+    pub is_current: bool,
+    pub is_dirty: bool,
+    pub is_occupied: bool,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct WorktreeSwitchTarget {
+    pub branch: Option<String>,
+    pub path: PathBuf,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct WorktreeSwitchRow {
+    pub branch_label: String,
+    pub path_label: String,
+    pub badges: Vec<String>,
+    pub target: WorktreeSwitchTarget,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct WorktreeSwitchModel {
+    pub rows: Vec<WorktreeSwitchRow>,
+    pub empty_state_lines: Vec<String>,
+}
+
+impl WorktreeSwitchModel {
+    pub fn target_at(&self, index: usize) -> Option<WorktreeSwitchTarget> {
+        self.rows.get(index).map(|row| row.target.clone())
+    }
 }
 
 pub struct TuiApp {
@@ -282,6 +317,74 @@ impl TuiApp {
             .alignment(Alignment::Center)
             .block(Block::default().borders(Borders::ALL).title("Help"));
         f.render_widget(help, chunks[2]);
+    }
+}
+
+pub fn build_worktree_switch_model(
+    worktrees: &[WorktreeInfo],
+    statuses: &[WorktreeRuntimeStatus],
+) -> WorktreeSwitchModel {
+    let rows = worktrees
+        .iter()
+        .map(|worktree| {
+            let status = statuses.iter().find(|status| status.path == worktree.path);
+            let is_detached = worktree.branch.trim().is_empty();
+            let mut badges = Vec::new();
+
+            if worktree.is_primary {
+                badges.push("primary".to_string());
+            }
+            if is_detached {
+                badges.push("detached".to_string());
+            }
+            if status.is_some_and(|status| status.is_current) {
+                badges.push("current".to_string());
+            }
+            if status.is_some_and(|status| status.is_dirty) {
+                badges.push("dirty".to_string());
+            }
+            if status.is_some_and(|status| status.is_occupied) {
+                badges.push("occupied".to_string());
+            }
+
+            WorktreeSwitchRow {
+                branch_label: worktree_branch_label(worktree),
+                path_label: worktree.path.display().to_string(),
+                badges,
+                target: WorktreeSwitchTarget {
+                    branch: (!is_detached).then(|| worktree.branch.clone()),
+                    path: worktree.path.clone(),
+                },
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let empty_state_lines = if rows.is_empty() {
+        vec![
+            "No Git worktrees found for this repository.".to_string(),
+            "Run `warp switch <branch>` to create one.".to_string(),
+        ]
+    } else {
+        Vec::new()
+    };
+
+    WorktreeSwitchModel {
+        rows,
+        empty_state_lines,
+    }
+}
+
+fn worktree_branch_label(worktree: &WorktreeInfo) -> String {
+    if worktree.branch.trim().is_empty() {
+        let head = worktree.head.chars().take(8).collect::<String>();
+        let head = if head.is_empty() {
+            "unknown".to_string()
+        } else {
+            head
+        };
+        format!("(detached HEAD: {head})")
+    } else {
+        worktree.branch.clone()
     }
 }
 
@@ -507,6 +610,164 @@ impl AgentsDashboard {
         let mut app = TuiApp::new(AgentDiscovery::new(vec![worktree_path]));
         app.run()
     }
+}
+
+pub struct WorktreeSwitchTui {
+    model: WorktreeSwitchModel,
+}
+
+impl WorktreeSwitchTui {
+    pub fn new(model: WorktreeSwitchModel) -> Self {
+        Self { model }
+    }
+
+    pub fn run(&self) -> Result<Option<WorktreeSwitchTarget>> {
+        if self.model.rows.is_empty() {
+            for line in &self.model.empty_state_lines {
+                println!("{line}");
+            }
+            return Ok(None);
+        }
+
+        let mut terminal_guard = TuiTerminalGuard::enter()?;
+        let backend = CrosstermBackend::new(io::stdout());
+        let mut terminal = RatatuiTerminal::new(backend)?;
+
+        let run_result = self.run_app(&mut terminal);
+        let cleanup_result = terminal_guard.restore();
+        let cursor_result: Result<()> = terminal.show_cursor().map_err(Into::into);
+        drop(terminal);
+
+        match run_result {
+            Err(err) => {
+                let mut follow_on_errors = Vec::new();
+                if let Err(cleanup_err) = cleanup_result {
+                    follow_on_errors.push(cleanup_err);
+                }
+                if let Err(cursor_err) = cursor_result {
+                    follow_on_errors.push(cursor_err);
+                }
+
+                if follow_on_errors.is_empty() {
+                    Err(err)
+                } else {
+                    Err(combine_errors(err, follow_on_errors))
+                }
+            }
+            Ok(target) => {
+                cleanup_result?;
+                cursor_result?;
+                Ok(target)
+            }
+        }
+    }
+
+    fn run_app(
+        &self,
+        terminal: &mut RatatuiTerminal<CrosstermBackend<io::Stdout>>,
+    ) -> Result<Option<WorktreeSwitchTarget>> {
+        let mut selected_index = 0;
+
+        loop {
+            terminal.draw(|f| draw_worktree_switcher(f, &self.model, selected_index))?;
+
+            if let Event::Key(key) = event::read()? {
+                if key.kind != KeyEventKind::Press {
+                    continue;
+                }
+
+                match key.code {
+                    KeyCode::Char('q') | KeyCode::Esc => return Ok(None),
+                    KeyCode::Up => {
+                        selected_index = selected_index.saturating_sub(1);
+                    }
+                    KeyCode::Down => {
+                        selected_index =
+                            (selected_index + 1).min(self.model.rows.len().saturating_sub(1));
+                    }
+                    KeyCode::Enter => return Ok(self.model.target_at(selected_index)),
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+fn draw_worktree_switcher(f: &mut Frame, model: &WorktreeSwitchModel, selected_index: usize) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(1)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(8),
+            Constraint::Length(6),
+            Constraint::Length(3),
+        ])
+        .split(f.size());
+
+    let header = Paragraph::new(format!("Warp Worktrees ({})", model.rows.len()))
+        .style(
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )
+        .alignment(Alignment::Center)
+        .block(Block::default().borders(Borders::ALL));
+    f.render_widget(header, chunks[0]);
+
+    let items = model
+        .rows
+        .iter()
+        .map(|row| {
+            let badges = if row.badges.is_empty() {
+                String::new()
+            } else {
+                format!(" [{}]", row.badges.join(", "))
+            };
+            ListItem::new(Line::from(format!(
+                "{:<30} {:<28} {}",
+                truncate_label(&row.branch_label, 30),
+                truncate_label(&badges, 28),
+                row.path_label
+            )))
+        })
+        .collect::<Vec<_>>();
+    let list = List::new(items)
+        .block(Block::default().title("Branches").borders(Borders::ALL))
+        .highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol(">> ");
+    let mut list_state = ListState::default();
+    list_state.select(Some(selected_index));
+    f.render_stateful_widget(list, chunks[1], &mut list_state);
+
+    if let Some(row) = model.rows.get(selected_index) {
+        let branch = row.target.branch.as_deref().unwrap_or("-");
+        let status = if row.badges.is_empty() {
+            "-".to_string()
+        } else {
+            row.badges.join(", ")
+        };
+        let details = Paragraph::new(format!(
+            "Branch: {}\nPath: {}\nStatus: {}",
+            branch,
+            row.target.path.display(),
+            status
+        ))
+        .block(Block::default().title("Details").borders(Borders::ALL))
+        .style(Style::default().fg(Color::White))
+        .wrap(Wrap { trim: false });
+        f.render_widget(details, chunks[2]);
+    }
+
+    let help = Paragraph::new("↑↓: Navigate | Enter: Switch | q/Esc: Quit")
+        .style(Style::default().fg(Color::Gray))
+        .alignment(Alignment::Center)
+        .block(Block::default().borders(Borders::ALL).title("Help"));
+    f.render_widget(help, chunks[3]);
 }
 
 pub struct CleanupTui;

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -204,6 +204,38 @@ fn test_switch_waiting_resolves_branch_from_waiting_agent_session() {
 }
 
 #[test]
+fn test_bare_warp_dry_run_previews_interactive_switcher() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+    create_worktree(repo_path, "feature/default-picker");
+
+    let output = warp_command(repo_path).arg("--dry-run").output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{stdout}");
+    assert!(stdout.contains("Would open interactive worktree switcher"));
+    assert!(stdout.contains("main"));
+    assert!(stdout.contains("feature/default-picker"));
+}
+
+#[test]
+fn test_bare_warp_dry_run_marks_only_nested_worktree_current() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+    let worktree_path = create_worktree(repo_path, "feature/default-picker");
+
+    let output = warp_command(&worktree_path)
+        .arg("--dry-run")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{stdout}");
+    assert!(!stdout.contains("main [current"));
+    assert!(stdout.contains("feature/default-picker [current"));
+}
+
+#[test]
 fn test_config_edit_creates_config_and_launches_editor() {
     let temp_dir = setup_test_repo();
     let repo_path = temp_dir.path();

--- a/tests/unit/tui_tests.rs
+++ b/tests/unit/tui_tests.rs
@@ -2,7 +2,11 @@ use chrono::{Local, TimeZone};
 use git_warp::agents::{
     AgentDiscovery, AgentRuntime, AgentSessionSource, AgentSessionState, AgentSessionSummary,
 };
-use git_warp::tui::{AgentsDashboard, build_dashboard_model, session_detail_lines};
+use git_warp::git::WorktreeInfo;
+use git_warp::tui::{
+    AgentsDashboard, WorktreeRuntimeStatus, build_dashboard_model, build_worktree_switch_model,
+    session_detail_lines,
+};
 use std::path::PathBuf;
 
 fn sample_summary(
@@ -165,4 +169,63 @@ fn test_build_dashboard_model_renders_future_timestamps_explicitly() {
 fn test_agents_dashboard_accepts_discovery() {
     let discovery = AgentDiscovery::new(vec![PathBuf::from("/repo")]);
     let _dashboard = AgentsDashboard::new(discovery);
+}
+
+#[test]
+fn test_build_worktree_switch_model_marks_state_and_detached_rows() {
+    let worktrees = vec![
+        WorktreeInfo {
+            path: PathBuf::from("/repo"),
+            branch: "main".to_string(),
+            head: "0123456789abcdef".to_string(),
+            is_primary: true,
+        },
+        WorktreeInfo {
+            path: PathBuf::from("/repo/.worktrees/detached"),
+            branch: String::new(),
+            head: "abcdef0123456789".to_string(),
+            is_primary: false,
+        },
+    ];
+    let statuses = vec![
+        WorktreeRuntimeStatus {
+            path: PathBuf::from("/repo"),
+            is_current: true,
+            is_dirty: true,
+            is_occupied: false,
+        },
+        WorktreeRuntimeStatus {
+            path: PathBuf::from("/repo/.worktrees/detached"),
+            is_current: false,
+            is_dirty: false,
+            is_occupied: true,
+        },
+    ];
+
+    let model = build_worktree_switch_model(&worktrees, &statuses);
+
+    assert_eq!(model.rows.len(), 2);
+    assert_eq!(model.rows[0].branch_label, "main");
+    assert_eq!(model.rows[0].badges, vec!["primary", "current", "dirty"]);
+    assert_eq!(model.rows[1].branch_label, "(detached HEAD: abcdef01)");
+    assert_eq!(model.rows[1].badges, vec!["detached", "occupied"]);
+}
+
+#[test]
+fn test_worktree_switch_model_returns_selected_target() {
+    let worktrees = vec![WorktreeInfo {
+        path: PathBuf::from("/repo/.worktrees/feature"),
+        branch: "feature/default-picker".to_string(),
+        head: "0123456789abcdef".to_string(),
+        is_primary: false,
+    }];
+
+    let model = build_worktree_switch_model(&worktrees, &[]);
+    let target = model
+        .target_at(0)
+        .expect("selected row should have a target");
+
+    assert_eq!(target.branch.as_deref(), Some("feature/default-picker"));
+    assert_eq!(target.path, PathBuf::from("/repo/.worktrees/feature"));
+    assert!(model.target_at(1).is_none());
 }


### PR DESCRIPTION
## Summary
- make bare `warp` open a worktree switcher instead of printing help
- show branch, path, and state badges for current/dirty/occupied/detached worktrees
- route selected entries through the existing terminal switch flow, preserving `warp --help` and explicit subcommands

Closes #16

## Validation
- `cargo fmt --check`
- `cargo test cli_surface_tests --test mod -- --nocapture`
- `cargo test tui_tests --test mod -- --nocapture`
- `cargo test terminal_switch_tests --test mod -- --nocapture`
- `cargo run -- --dry-run`
- `cargo run -- --help | sed -n '1,80p'`
