### PR TITLE
Fix primary worktree detection and enrich warp ls

### DIFF
--- a/docs/superpowers/plans/2026-04-24-primary-worktree-ls.md
+++ b/docs/superpowers/plans/2026-04-24-primary-worktree-ls.md
@@ -1,0 +1,348 @@
+# Primary Worktree Ls Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix primary/current worktree detection and make `warp ls` show compact status labels for daily worktree decisions.
+
+**Architecture:** Keep structural worktree facts in `src/git.rs` by enriching `WorktreeInfo`. Keep command-specific formatting and volatile dirty/process checks in `src/cli.rs`, so cleanup and switching can reuse accurate primary/current data without inheriting `ls` formatting concerns.
+
+**Tech Stack:** Rust, clap CLI, git porcelain commands, sysinfo process discovery, cargo unit and integration tests.
+
+---
+
+### Task 1: Add regression tests for worktree identity
+
+**Files:**
+- Modify: `tests/unit/git_tests.rs`
+
+- [ ] **Step 1: Update `test_list_worktrees_single` expectations**
+
+Add assertions after the existing path assertion:
+
+```rust
+assert!(worktrees[0].is_primary);
+assert!(worktrees[0].is_current);
+assert!(!worktrees[0].is_detached);
+```
+
+- [ ] **Step 2: Add linked-worktree primary/current regression test**
+
+Add this test near the other worktree list tests:
+
+```rust
+#[test]
+fn test_list_worktrees_marks_main_primary_and_linked_current() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+    let linked_path = repo_path.join("worktrees").join("feature-current");
+
+    std::env::set_current_dir(repo_path).unwrap();
+    let main_repo = GitRepository::find().unwrap();
+    main_repo
+        .create_worktree_and_branch("feature-current", &linked_path, None)
+        .unwrap();
+
+    std::env::set_current_dir(&linked_path).unwrap();
+    let linked_repo = GitRepository::find().unwrap();
+    let worktrees = linked_repo.list_worktrees().unwrap();
+
+    let main = worktrees.iter().find(|w| w.path == repo_path).unwrap();
+    let linked = worktrees.iter().find(|w| w.path == linked_path).unwrap();
+
+    assert!(main.is_primary);
+    assert!(!main.is_current);
+    assert!(!linked.is_primary);
+    assert!(linked.is_current);
+}
+```
+
+- [ ] **Step 3: Run tests and confirm RED**
+
+Run:
+
+```bash
+cargo test test_list_worktrees -- --nocapture
+```
+
+Expected: compile failure or test failure because `WorktreeInfo` does not yet expose `is_current` and `is_detached`, and primary detection is still wrong.
+
+### Task 2: Add CLI output regression coverage
+
+**Files:**
+- Modify: `tests/integration/cli_surface_tests.rs`
+
+- [ ] **Step 1: Add detached worktree helper**
+
+Add below `create_worktree`:
+
+```rust
+fn create_detached_worktree(repo_path: &Path, name: &str) -> PathBuf {
+    let worktree_path = repo_path.join(".worktrees").join(name);
+    fs::create_dir_all(worktree_path.parent().unwrap()).unwrap();
+
+    let output = Command::new("git")
+        .args(["worktree", "add", "--detach"])
+        .arg(&worktree_path)
+        .arg("HEAD")
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "git worktree add --detach failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    worktree_path
+}
+```
+
+- [ ] **Step 2: Add `warp ls` status-label test**
+
+Add this test near the other CLI surface tests:
+
+```rust
+#[test]
+fn test_ls_shows_primary_current_dirty_and_detached_statuses() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+    let feature_path = create_worktree(repo_path, "feature-status");
+    let detached_path = create_detached_worktree(repo_path, "detached-status");
+
+    fs::write(feature_path.join("dirty.txt"), "changed\n").unwrap();
+
+    let output = warp_command(&feature_path).args(["ls"]).output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{stdout}");
+    assert!(stdout.contains("main [primary]"));
+    assert!(stdout.contains("feature-status [current dirty]"));
+    assert!(stdout.contains("[detached]"));
+    assert!(stdout.contains(&repo_path.display().to_string()));
+    assert!(stdout.contains(&detached_path.display().to_string()));
+}
+```
+
+- [ ] **Step 3: Run integration test and confirm RED**
+
+Run:
+
+```bash
+cargo test test_ls_shows_primary_current_dirty_and_detached_statuses -- --nocapture
+```
+
+Expected: compile failure until `WorktreeInfo` and output formatting are implemented, or assertion failure because current output lacks labels.
+
+### Task 3: Implement accurate worktree identity
+
+**Files:**
+- Modify: `src/git.rs`
+
+- [ ] **Step 1: Extend `WorktreeInfo`**
+
+Add fields:
+
+```rust
+pub is_current: bool,
+pub is_detached: bool,
+```
+
+- [ ] **Step 2: Initialize new fields during porcelain parsing**
+
+When creating each `WorktreeInfo`, initialize:
+
+```rust
+is_current: false,
+is_detached: false,
+```
+
+Handle detached porcelain lines:
+
+```rust
+} else if line == "detached" {
+    if let Some(ref mut wt) = current_worktree {
+        wt.is_detached = true;
+    }
+}
+```
+
+- [ ] **Step 3: Enrich entries after parsing**
+
+After pushing the final worktree, add:
+
+```rust
+let current_root = self
+    .repo_path
+    .canonicalize()
+    .unwrap_or_else(|_| self.repo_path.clone());
+
+for (index, worktree) in worktrees.iter_mut().enumerate() {
+    if index == 0 {
+        worktree.is_primary = true;
+    }
+
+    let worktree_path = worktree
+        .path
+        .canonicalize()
+        .unwrap_or_else(|_| worktree.path.clone());
+    worktree.is_current = worktree_path == current_root;
+
+    if worktree.branch.is_empty() {
+        worktree.is_detached = true;
+    }
+}
+```
+
+- [ ] **Step 4: Run unit tests and confirm GREEN for identity**
+
+Run:
+
+```bash
+cargo test test_list_worktrees -- --nocapture
+```
+
+Expected: all `test_list_worktrees*` tests pass.
+
+### Task 4: Add compact `warp ls` status labels
+
+**Files:**
+- Modify: `src/cli.rs`
+
+- [ ] **Step 1: Import and initialize process manager in `handle_ls`**
+
+Add inside `handle_ls`:
+
+```rust
+use crate::process::ProcessManager;
+```
+
+After loading worktrees:
+
+```rust
+let mut process_manager = ProcessManager::new();
+```
+
+- [ ] **Step 2: Compute labels for each row**
+
+Add private helper methods on `Cli`:
+
+```rust
+fn worktree_status_labels(
+    worktree: &crate::git::WorktreeInfo,
+    is_dirty: bool,
+    is_busy: bool,
+) -> Vec<&'static str> {
+    let mut labels = Vec::new();
+    if worktree.is_primary {
+        labels.push("primary");
+    }
+    if worktree.is_current {
+        labels.push("current");
+    }
+    if is_dirty {
+        labels.push("dirty");
+    }
+    if worktree.is_detached {
+        labels.push("detached");
+    }
+    if is_busy {
+        labels.push("busy");
+    }
+    labels
+}
+
+fn format_status_labels(labels: &[&str]) -> String {
+    if labels.is_empty() {
+        String::new()
+    } else {
+        format!(" [{}]", labels.join(" "))
+    }
+}
+```
+
+- [ ] **Step 3: Update `handle_ls` row output**
+
+Inside the row loop, compute:
+
+```rust
+let is_dirty = git_repo
+    .has_uncommitted_changes(&worktree.path)
+    .unwrap_or(false);
+let is_busy = !worktree.is_current
+    && process_manager
+        .has_processes_in_directory(&worktree.path)
+        .unwrap_or(false);
+let labels = Self::worktree_status_labels(worktree, is_dirty, is_busy);
+let label_display = Self::format_status_labels(&labels);
+```
+
+Then print:
+
+```rust
+println!(
+    "{}  {}{} {}",
+    status_icon,
+    branch_display,
+    label_display,
+    worktree.path.display()
+);
+```
+
+- [ ] **Step 4: Extend debug output**
+
+Add debug lines:
+
+```rust
+println!("     Current: {}", worktree.is_current);
+println!("     Detached: {}", worktree.is_detached);
+println!("     Dirty: {}", is_dirty);
+println!("     Busy: {}", is_busy);
+```
+
+- [ ] **Step 5: Run CLI integration test and confirm GREEN**
+
+Run:
+
+```bash
+cargo test test_ls_shows_primary_current_dirty_and_detached_statuses -- --nocapture
+```
+
+Expected: test passes and stdout contains compact labels.
+
+### Task 5: Verify full focused behavior
+
+**Files:**
+- No code edits unless verification exposes a defect.
+
+- [ ] **Step 1: Format and lint whitespace**
+
+Run:
+
+```bash
+cargo fmt
+git diff --check
+```
+
+Expected: both commands exit successfully.
+
+- [ ] **Step 2: Run focused test suite**
+
+Run:
+
+```bash
+cargo test git_tests -- --nocapture
+cargo test cli_surface_tests -- --nocapture
+```
+
+Expected: all focused tests pass.
+
+- [ ] **Step 3: Smoke test local `warp ls`**
+
+Run:
+
+```bash
+cargo run -- ls
+```
+
+Expected: the main checkout line contains `[primary]`, the issue worktree line contains `[current]`, and the output remains compact.

--- a/docs/superpowers/specs/2026-04-24-primary-worktree-ls-design.md
+++ b/docs/superpowers/specs/2026-04-24-primary-worktree-ls-design.md
@@ -1,0 +1,56 @@
+# Primary Worktree Detection And `warp ls` Status Design
+
+Source of truth: GitHub issue #3, fetched on 2026-04-24 from `denysbutenko/git-warp`.
+
+## Problem
+
+`warp ls` currently trusts the `bare` line from `git worktree list --porcelain` to identify the primary worktree. Normal non-bare repositories do not emit that line, so the main checkout is displayed like a linked worktree. The list also omits important state, which forces users to run follow-up commands before deciding whether to switch, clean up, or avoid a worktree.
+
+## Goals
+
+- Mark the main checkout as primary in a normal non-bare repository.
+- Mark the worktree that contains the current process as current.
+- Show compact `warp ls` labels for high-signal state: primary, current, dirty, detached, and process-occupied.
+- Keep cleanup behavior safer by ensuring primary worktrees are excluded from branch cleanup analysis.
+- Preserve the existing command shape: `warp ls`, `warp list`, and `warp ls --debug`.
+
+## Non-Goals
+
+- Redesign `warp ls` into a table or TUI.
+- Add JSON output.
+- Change cleanup modes or branch deletion policy beyond fixing primary detection input.
+- Add expensive process details to every `ls` line.
+
+## Design
+
+`GitRepository::list_worktrees` remains the source for structural worktree facts. It will parse porcelain output as it does today, then normalize paths and enrich each entry with:
+
+- `is_primary`: true for the first porcelain worktree entry, and also true if Git emits `bare`.
+- `is_current`: true when the worktree path matches the repository root discovered from the current directory.
+- `is_detached`: true when Git emits `detached` or when no branch name is present.
+
+`warp ls` will layer volatile status on top of those facts:
+
+- `dirty`: from `git status --porcelain` for that worktree.
+- `busy`: from `ProcessManager`, but only for non-current worktrees so the shell running `warp ls` does not make the current line noisy.
+
+Output stays line-oriented and compact:
+
+```text
+🏠  main [primary] /repo
+🌿  feature/demo [current dirty] /repo/.worktrees/feature-demo
+🌿  (detached: abc12345) [detached] /repo/.worktrees/detached
+```
+
+`--debug` continues to show HEAD and primary state, and will also show current and detached state for troubleshooting.
+
+## Testing
+
+- Unit coverage in `tests/unit/git_tests.rs` will verify that a normal one-worktree repository marks its main checkout as both primary and current.
+- Unit coverage will verify that when the command is run from a linked worktree, the first/main checkout remains primary while the linked checkout is current.
+- Integration coverage in `tests/integration/cli_surface_tests.rs` will verify that `warp ls` prints compact labels for primary, current, dirty, and detached worktrees.
+
+## Risks
+
+- Process detection can be noisy because the current shell is itself a process in the current worktree. The design avoids this by only showing `busy` for non-current worktrees.
+- `git worktree list --porcelain` ordering is relied on for primary detection. This matches Git's worktree listing behavior and is also backed by preserving the existing `bare` marker handling.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -415,6 +415,7 @@ impl Cli {
 
     fn handle_ls(&self, debug: bool) -> Result<()> {
         use crate::git::GitRepository;
+        use crate::process::ProcessManager;
 
         info!("Listing worktrees");
 
@@ -427,6 +428,7 @@ impl Cli {
         }
 
         let worktrees = git_repo.list_worktrees()?;
+        let mut process_manager = ProcessManager::new();
 
         if worktrees.is_empty() {
             println!("📭 No worktrees found");
@@ -438,22 +440,37 @@ impl Cli {
 
         for (i, worktree) in worktrees.iter().enumerate() {
             let status_icon = if worktree.is_primary { "🏠" } else { "🌿" };
-            let branch_display = if worktree.branch.is_empty() {
-                format!("(detached HEAD: {})", &worktree.head[..8])
+            let branch_display = if worktree.is_detached {
+                let short_head: String = worktree.head.chars().take(8).collect();
+                format!("(detached: {})", short_head)
             } else {
                 worktree.branch.clone()
             };
+            let is_dirty = git_repo
+                .has_uncommitted_changes(&worktree.path)
+                .unwrap_or(false);
+            let is_busy = !worktree.is_current
+                && process_manager
+                    .has_processes_in_directory(&worktree.path)
+                    .unwrap_or(false);
+            let labels = Self::worktree_status_labels(worktree, is_dirty, is_busy);
+            let label_display = Self::format_status_labels(&labels);
 
             println!(
-                "{}  {} {}",
+                "{}  {}{} {}",
                 status_icon,
                 branch_display,
+                label_display,
                 worktree.path.display()
             );
 
             if debug {
                 println!("     HEAD: {}", worktree.head);
                 println!("     Primary: {}", worktree.is_primary);
+                println!("     Current: {}", worktree.is_current);
+                println!("     Detached: {}", worktree.is_detached);
+                println!("     Dirty: {}", is_dirty);
+                println!("     Busy: {}", is_busy);
                 if i < worktrees.len() - 1 {
                     println!();
                 }
@@ -464,6 +481,38 @@ impl Cli {
         println!("📊 Total: {} worktrees", worktrees.len());
 
         Ok(())
+    }
+
+    fn worktree_status_labels(
+        worktree: &crate::git::WorktreeInfo,
+        is_dirty: bool,
+        is_busy: bool,
+    ) -> Vec<&'static str> {
+        let mut labels = Vec::new();
+        if worktree.is_primary {
+            labels.push("primary");
+        }
+        if worktree.is_current {
+            labels.push("current");
+        }
+        if is_dirty {
+            labels.push("dirty");
+        }
+        if worktree.is_detached {
+            labels.push("detached");
+        }
+        if is_busy {
+            labels.push("busy");
+        }
+        labels
+    }
+
+    fn format_status_labels(labels: &[&str]) -> String {
+        if labels.is_empty() {
+            String::new()
+        } else {
+            format!(" [{}]", labels.join(" "))
+        }
     }
 
     fn handle_cleanup(

--- a/src/git.rs
+++ b/src/git.rs
@@ -8,6 +8,8 @@ pub struct WorktreeInfo {
     pub branch: String,
     pub head: String,
     pub is_primary: bool,
+    pub is_current: bool,
+    pub is_detached: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -84,6 +86,8 @@ impl GitRepository {
                     branch: String::new(),
                     head: String::new(),
                     is_primary: false,
+                    is_current: false,
+                    is_detached: false,
                 });
             } else if line.starts_with("HEAD ") {
                 if let Some(ref mut wt) = current_worktree {
@@ -100,12 +104,37 @@ impl GitRepository {
                 if let Some(ref mut wt) = current_worktree {
                     wt.is_primary = true;
                 }
+            } else if line == "detached" {
+                if let Some(ref mut wt) = current_worktree {
+                    wt.is_detached = true;
+                }
             }
         }
 
         // Add the last worktree
         if let Some(wt) = current_worktree {
             worktrees.push(wt);
+        }
+
+        let current_root = self
+            .repo_path
+            .canonicalize()
+            .unwrap_or_else(|_| self.repo_path.clone());
+
+        for (index, worktree) in worktrees.iter_mut().enumerate() {
+            if index == 0 {
+                worktree.is_primary = true;
+            }
+
+            let worktree_path = worktree
+                .path
+                .canonicalize()
+                .unwrap_or_else(|_| worktree.path.clone());
+            worktree.is_current = worktree_path == current_root;
+
+            if worktree.branch.is_empty() {
+                worktree.is_detached = true;
+            }
         }
 
         Ok(worktrees)

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -53,6 +53,27 @@ fn create_worktree(repo_path: &Path, branch: &str) -> PathBuf {
     worktree_path
 }
 
+fn create_detached_worktree(repo_path: &Path, name: &str) -> PathBuf {
+    let worktree_path = repo_path.join(".worktrees").join(name);
+    fs::create_dir_all(worktree_path.parent().unwrap()).unwrap();
+
+    let output = Command::new("git")
+        .args(["worktree", "add", "--detach"])
+        .arg(&worktree_path)
+        .arg("HEAD")
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "git worktree add --detach failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    worktree_path
+}
+
 fn write_codex_session(home: &Path, cwd: &Path, session_id: &str, branch: &str, timestamp: &str) {
     let sessions_dir = home.join(".codex").join("sessions");
     fs::create_dir_all(&sessions_dir).unwrap();
@@ -201,6 +222,32 @@ fn test_switch_waiting_resolves_branch_from_waiting_agent_session() {
 
     assert!(output.status.success(), "{stdout}");
     assert!(stdout.contains("Would switch to branch 'agent-waiting'"));
+}
+
+#[test]
+fn test_ls_shows_primary_current_dirty_and_detached_statuses() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+    let feature_path = create_worktree(repo_path, "feature-status");
+    let detached_path = create_detached_worktree(repo_path, "detached-status");
+
+    fs::write(feature_path.join("dirty.txt"), "changed\n").unwrap();
+
+    let output = warp_command(&feature_path).args(["ls"]).output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{stdout}");
+    assert!(stdout.contains("main [primary"), "{stdout}");
+    assert!(stdout.contains("feature-status [current dirty"), "{stdout}");
+    assert!(stdout.contains("[detached]"), "{stdout}");
+    assert!(
+        stdout.contains(&repo_path.canonicalize().unwrap().display().to_string()),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains(&detached_path.canonicalize().unwrap().display().to_string()),
+        "{stdout}"
+    );
 }
 
 #[test]

--- a/tests/unit/git_tests.rs
+++ b/tests/unit/git_tests.rs
@@ -9,7 +9,7 @@ fn setup_test_repo() -> tempfile::TempDir {
 
     // Initialize git repo
     Command::new("git")
-        .args(&["init"])
+        .args(&["init", "-b", "main"])
         .current_dir(repo_path)
         .output()
         .unwrap();
@@ -83,7 +83,44 @@ fn test_list_worktrees_single() {
 
     assert_eq!(worktrees.len(), 1); // Only main worktree
     assert_eq!(worktrees[0].branch, "main");
-    assert_eq!(worktrees[0].path, repo_path);
+    assert_eq!(
+        worktrees[0].path.canonicalize().unwrap(),
+        repo_path.canonicalize().unwrap()
+    );
+    assert!(worktrees[0].is_primary);
+    assert!(worktrees[0].is_current);
+    assert!(!worktrees[0].is_detached);
+}
+
+#[test]
+fn test_list_worktrees_marks_main_primary_and_linked_current() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path().canonicalize().unwrap();
+    let linked_path = repo_path.join("worktrees").join("feature-current");
+
+    std::env::set_current_dir(&repo_path).unwrap();
+    let main_repo = GitRepository::find().unwrap();
+    main_repo
+        .create_worktree_and_branch("feature-current", &linked_path, None)
+        .unwrap();
+
+    std::env::set_current_dir(&linked_path).unwrap();
+    let linked_repo = GitRepository::find().unwrap();
+    let worktrees = linked_repo.list_worktrees().unwrap();
+
+    let main = worktrees
+        .iter()
+        .find(|w| w.path.canonicalize().unwrap() == repo_path)
+        .unwrap();
+    let linked = worktrees
+        .iter()
+        .find(|w| w.path.canonicalize().unwrap() == linked_path)
+        .unwrap();
+
+    assert!(main.is_primary);
+    assert!(!main.is_current);
+    assert!(!linked.is_primary);
+    assert!(linked.is_current);
 }
 
 #[test]
@@ -108,7 +145,10 @@ fn test_create_worktree_and_branch() {
 
     let feature_worktree = worktrees.iter().find(|w| w.branch == "feature-branch");
     assert!(feature_worktree.is_some());
-    assert_eq!(feature_worktree.unwrap().path, worktree_path);
+    assert_eq!(
+        feature_worktree.unwrap().path.canonicalize().unwrap(),
+        worktree_path.canonicalize().unwrap()
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #3

## Summary
- mark the first porcelain worktree as primary and mark the current worktree by canonical path
- add compact `warp ls` labels for primary, current, dirty, detached, and busy state
- keep `--debug` useful by printing the enriched state fields
- add the issue spec, plan, and regression coverage for identity and list output

## Verification
- `cargo fmt`
- `git diff --check`
- `cargo test test_list_worktrees -- --nocapture --test-threads=1`
- `cargo test test_ls_shows_primary_current_dirty_and_detached_statuses -- --nocapture`
- `cargo test git_tests -- --nocapture --test-threads=1`
- `cargo test cli_surface_tests -- --nocapture`
- `cargo run --quiet -- ls`

## Full suite note
- `cargo test -- --test-threads=1` is not clean in this checkout: 101 passed, 9 failed in existing CoW/process/rewrite tests outside this change surface (`test_cow_filesystem_detection`, `test_process_detection_and_cleanup_workflow`, several `process_tests`, and two `rewrite_tests`).