### PR TITLE
[codex] Protect cleanup base branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ auto_confirm = false           # Skip confirmation prompts
 
 [git]
 default_branch = "main"        # Default branch for operations
+protected_branches = ["main", "master", "develop"]  # Never removed by cleanup
 auto_fetch = true              # Fetch before branch analysis
 auto_prune = true              # Prune during fetch
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -382,6 +382,9 @@ auto_confirm = false
 # Default main branch name
 default_branch = "main"
 
+# Branches cleanup must never remove
+protected_branches = ["main", "master", "develop"]
+
 # Auto-fetch before operations
 auto_fetch = true
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -474,6 +474,7 @@ impl Cli {
         no_kill: bool,
         interactive: bool,
     ) -> Result<()> {
+        use crate::config::ConfigManager;
         use crate::git::GitRepository;
         use crate::process::ProcessManager;
 
@@ -481,6 +482,8 @@ impl Cli {
 
         let git_repo =
             GitRepository::find().map_err(|_| anyhow::anyhow!("Not in a Git repository"))?;
+        let config_manager = ConfigManager::new()?;
+        let protected_branches = config_manager.get().git.protected_branches.clone();
         let mut process_manager = ProcessManager::new();
 
         if self.dry_run {
@@ -495,7 +498,10 @@ impl Cli {
         }
 
         let worktrees = git_repo.list_worktrees()?;
-        let branch_statuses = git_repo.analyze_branches_for_cleanup(&worktrees)?;
+        let branch_statuses = git_repo.analyze_branches_for_cleanup_with_protected_branches(
+            &worktrees,
+            &protected_branches,
+        )?;
 
         if branch_statuses.is_empty() {
             println!("✨ No worktrees to clean up");
@@ -709,6 +715,7 @@ impl Cli {
 
             println!("🔧 Git Settings:");
             println!("  Default branch: {}", config.git.default_branch);
+            println!("  Protected branches: {:?}", config.git.protected_branches);
             println!("  Auto-fetch: {}", config.git.auto_fetch);
             println!("  Auto-prune: {}", config.git.auto_prune);
             println!();

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,6 +48,10 @@ pub struct GitConfig {
     #[serde(default = "default_main_branch")]
     pub default_branch: String,
 
+    /// Branches that cleanup must never remove
+    #[serde(default = "default_protected_branches")]
+    pub protected_branches: Vec<String>,
+
     /// Whether to auto-fetch before operations
     #[serde(default = "default_true")]
     pub auto_fetch: bool,
@@ -120,6 +124,14 @@ fn default_main_branch() -> String {
     "main".to_string()
 }
 
+fn default_protected_branches() -> Vec<String> {
+    vec![
+        "main".to_string(),
+        "master".to_string(),
+        "develop".to_string(),
+    ]
+}
+
 fn default_kill_timeout() -> u64 {
     5
 }
@@ -156,6 +168,7 @@ impl Default for GitConfig {
     fn default() -> Self {
         Self {
             default_branch: default_main_branch(),
+            protected_branches: default_protected_branches(),
             auto_fetch: true,
             auto_prune: true,
         }
@@ -246,6 +259,9 @@ auto_confirm = {}
 # Default main branch name
 default_branch = "{}"
 
+# Branches cleanup must never remove
+protected_branches = {:?}
+
 # Auto-fetch before operations
 auto_fetch = {}
 
@@ -286,6 +302,7 @@ claude_hooks = {}
             config.use_cow,
             config.auto_confirm,
             config.git.default_branch,
+            config.git.protected_branches,
             config.git.auto_fetch,
             config.git.auto_prune,
             config.process.check_processes,

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,3 +1,4 @@
+use crate::config::GitConfig;
 use crate::error::{GitWarpError, Result};
 use gix::Repository;
 use std::path::{Path, PathBuf};
@@ -23,6 +24,23 @@ pub struct BranchStatus {
 pub struct GitRepository {
     repo: Repository,
     repo_path: PathBuf,
+}
+
+fn paths_match(left: &Path, right: &Path) -> bool {
+    if left == right {
+        return true;
+    }
+
+    match (left.canonicalize(), right.canonicalize()) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
+    }
+}
+
+fn is_protected_branch(branch: &str, protected_branches: &[String]) -> bool {
+    protected_branches
+        .iter()
+        .any(|protected_branch| protected_branch.trim() == branch)
 }
 
 impl GitRepository {
@@ -106,6 +124,16 @@ impl GitRepository {
         // Add the last worktree
         if let Some(wt) = current_worktree {
             worktrees.push(wt);
+        }
+
+        if let Some(first_worktree) = worktrees.first_mut() {
+            first_worktree.is_primary = true;
+        }
+
+        for worktree in &mut worktrees {
+            if paths_match(&worktree.path, &self.repo_path) {
+                worktree.is_primary = true;
+            }
         }
 
         Ok(worktrees)
@@ -235,12 +263,27 @@ impl GitRepository {
         &self,
         worktrees: &[WorktreeInfo],
     ) -> Result<Vec<BranchStatus>> {
+        self.analyze_branches_for_cleanup_with_protected_branches(
+            worktrees,
+            &GitConfig::default().protected_branches,
+        )
+    }
+
+    /// Analyze branches for cleanup using an explicit protected branch list
+    pub fn analyze_branches_for_cleanup_with_protected_branches(
+        &self,
+        worktrees: &[WorktreeInfo],
+        protected_branches: &[String],
+    ) -> Result<Vec<BranchStatus>> {
         use std::process::Command;
 
         let mut branch_statuses = Vec::new();
 
         for worktree in worktrees {
-            if worktree.is_primary || worktree.branch.is_empty() {
+            if worktree.is_primary
+                || worktree.branch.is_empty()
+                || is_protected_branch(&worktree.branch, protected_branches)
+            {
                 continue;
             }
 
@@ -258,12 +301,15 @@ impl GitRepository {
                 output.status.success() && !output.stdout.is_empty()
             };
 
-            // Check if branch is merged to main/master
+            // Check if branch is merged to a protected base branch
             let is_merged = {
-                let main_branches = ["main", "master", "develop"];
                 let mut merged = false;
 
-                for main_branch in &main_branches {
+                for main_branch in protected_branches {
+                    if branch == main_branch {
+                        continue;
+                    }
+
                     let output = Command::new("git")
                         .args(&["merge-base", "--is-ancestor", branch, main_branch])
                         .current_dir(&self.repo_path)

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -517,6 +517,7 @@ impl CleanupTui {
     }
 
     pub fn run(&self) -> Result<Vec<String>> {
+        use crate::config::ConfigManager;
         use crate::git::GitRepository;
         use crossterm::{
             event::{self, Event, KeyCode, KeyEventKind},
@@ -537,8 +538,13 @@ impl CleanupTui {
         // Get the git repository and worktrees
         let git_repo =
             GitRepository::find().map_err(|_| anyhow::anyhow!("Not in a git repository"))?;
+        let config_manager = ConfigManager::new()?;
+        let protected_branches = config_manager.get().git.protected_branches.clone();
         let worktrees = git_repo.list_worktrees()?;
-        let branch_statuses = git_repo.analyze_branches_for_cleanup(&worktrees)?;
+        let branch_statuses = git_repo.analyze_branches_for_cleanup_with_protected_branches(
+            &worktrees,
+            &protected_branches,
+        )?;
 
         if branch_statuses.is_empty() {
             println!("✨ No worktrees found that can be cleaned up!");

--- a/tests/unit/config_tests.rs
+++ b/tests/unit/config_tests.rs
@@ -11,6 +11,10 @@ fn test_config_defaults() {
     assert!(config.use_cow);
     assert!(!config.auto_confirm);
     assert_eq!(config.git.default_branch, "main");
+    assert_eq!(
+        config.git.protected_branches,
+        vec!["main", "master", "develop"]
+    );
     assert!(config.git.auto_fetch);
     assert!(config.git.auto_prune);
     assert!(config.process.check_processes);
@@ -38,6 +42,7 @@ fn test_config_with_custom_values() {
         auto_confirm: true,
         git: GitConfig {
             default_branch: "develop".to_string(),
+            protected_branches: vec!["develop".to_string(), "staging".to_string()],
             auto_fetch: false,
             auto_prune: false,
         },
@@ -65,6 +70,7 @@ fn test_config_with_custom_values() {
     assert_eq!(config.terminal_mode, parsed.terminal_mode);
     assert_eq!(config.use_cow, parsed.use_cow);
     assert_eq!(config.git.default_branch, parsed.git.default_branch);
+    assert_eq!(config.git.protected_branches, parsed.git.protected_branches);
     assert!(!parsed.git.auto_fetch);
     assert!(parsed.process.auto_kill);
 }
@@ -113,6 +119,7 @@ fn test_sample_config_generation() {
 
     assert!(sample.contains("terminal_mode"));
     assert!(sample.contains("[git]"));
+    assert!(sample.contains("protected_branches"));
     assert!(sample.contains("[process]"));
     assert!(sample.contains("[terminal]"));
     assert!(sample.contains("[agent]"));

--- a/tests/unit/git_tests.rs
+++ b/tests/unit/git_tests.rs
@@ -1,4 +1,4 @@
-use git_warp::git::{BranchStatus, GitRepository};
+use git_warp::git::GitRepository;
 use std::fs;
 use std::process::Command;
 use tempfile::tempdir;
@@ -9,7 +9,7 @@ fn setup_test_repo() -> tempfile::TempDir {
 
     // Initialize git repo
     Command::new("git")
-        .args(&["init"])
+        .args(&["init", "--initial-branch", "main"])
         .current_dir(repo_path)
         .output()
         .unwrap();
@@ -83,7 +83,83 @@ fn test_list_worktrees_single() {
 
     assert_eq!(worktrees.len(), 1); // Only main worktree
     assert_eq!(worktrees[0].branch, "main");
-    assert_eq!(worktrees[0].path, repo_path);
+    assert_eq!(
+        worktrees[0].path.canonicalize().unwrap(),
+        repo_path.canonicalize().unwrap()
+    );
+    assert!(worktrees[0].is_primary);
+}
+
+#[test]
+fn test_cleanup_analysis_excludes_protected_branches() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+    std::env::set_current_dir(repo_path).unwrap();
+
+    let git_repo = GitRepository::find().unwrap();
+
+    Command::new("git")
+        .args(&["branch", "develop"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    let develop_path = repo_path.join("worktrees").join("develop");
+    git_repo
+        .create_worktree_and_branch("develop", &develop_path, Some("develop"))
+        .unwrap();
+
+    let worktrees = git_repo.list_worktrees().unwrap();
+    let branch_statuses = git_repo.analyze_branches_for_cleanup(&worktrees).unwrap();
+
+    assert!(branch_statuses.iter().all(|status| status.branch != "main"));
+    assert!(
+        branch_statuses
+            .iter()
+            .all(|status| status.branch != "develop")
+    );
+}
+
+#[test]
+fn test_cleanup_analysis_excludes_custom_protected_branches() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+    std::env::set_current_dir(repo_path).unwrap();
+
+    let git_repo = GitRepository::find().unwrap();
+
+    Command::new("git")
+        .args(&["branch", "staging"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    let staging_path = repo_path.join("worktrees").join("staging");
+    git_repo
+        .create_worktree_and_branch("staging", &staging_path, Some("staging"))
+        .unwrap();
+
+    let feature_path = repo_path.join("worktrees").join("feature");
+    git_repo
+        .create_worktree_and_branch("feature", &feature_path, None)
+        .unwrap();
+
+    let worktrees = git_repo.list_worktrees().unwrap();
+    let protected_branches = vec!["staging".to_string()];
+    let branch_statuses = git_repo
+        .analyze_branches_for_cleanup_with_protected_branches(&worktrees, &protected_branches)
+        .unwrap();
+
+    assert!(
+        branch_statuses
+            .iter()
+            .all(|status| status.branch != "staging")
+    );
+    assert!(
+        branch_statuses
+            .iter()
+            .any(|status| status.branch == "feature")
+    );
 }
 
 #[test]
@@ -108,7 +184,10 @@ fn test_create_worktree_and_branch() {
 
     let feature_worktree = worktrees.iter().find(|w| w.branch == "feature-branch");
     assert!(feature_worktree.is_some());
-    assert_eq!(feature_worktree.unwrap().path, worktree_path);
+    assert_eq!(
+        feature_worktree.unwrap().path.canonicalize().unwrap(),
+        worktree_path.canonicalize().unwrap()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add configurable `git.protected_branches` with `main`, `master`, and `develop` defaults
- mark the root worktree as primary when parsing `git worktree list --porcelain`
- exclude protected branches from cleanup analysis and self-merge checks
- document the new config setting and cover default/custom protections in tests

## Validation
- `git diff --check`
- `cargo fmt --check`
- `cargo test unit::config_tests -- --nocapture`
- `cargo test unit::git_tests -- --test-threads=1`
- `cargo test test_branch_analysis_and_cleanup_workflow -- --test-threads=1`
- `cargo build`
- `warp ls --debug` in `/Users/deryzh/dev/webui-nodeum` shows `develop` as `Primary: true`
- `printf 'n\\n' | warp cleanup` in `/Users/deryzh/dev/webui-nodeum` no longer lists `develop`; it listed only `274-static-config` and cancelled