### PR TITLE
[codex] Sort worktree switcher by recency

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,6 +3,7 @@ use clap::{Parser, Subcommand};
 use log::info;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::SystemTime;
 
 #[derive(Parser)]
 #[command(
@@ -248,6 +249,7 @@ impl Cli {
                 is_occupied: process_manager
                     .has_processes_in_directory(&worktree.path)
                     .unwrap_or(false),
+                last_touched: worktree_last_touched(&worktree.path),
             })
             .collect()
     }
@@ -1085,4 +1087,13 @@ impl Cli {
             "No editor configured. Set $VISUAL or $EDITOR to use `warp config --edit`"
         ))
     }
+}
+
+fn worktree_last_touched(path: &Path) -> Option<SystemTime> {
+    let metadata = std::fs::metadata(path).ok()?;
+
+    [metadata.modified().ok(), metadata.created().ok()]
+        .into_iter()
+        .flatten()
+        .max()
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -23,7 +23,7 @@ use ratatui::{
 use std::{
     io,
     path::PathBuf,
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime},
 };
 
 const REFRESH_INTERVAL: Duration = Duration::from_secs(2);
@@ -94,6 +94,7 @@ pub struct WorktreeRuntimeStatus {
     pub is_current: bool,
     pub is_dirty: bool,
     pub is_occupied: bool,
+    pub last_touched: Option<SystemTime>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -324,9 +325,10 @@ pub fn build_worktree_switch_model(
     worktrees: &[WorktreeInfo],
     statuses: &[WorktreeRuntimeStatus],
 ) -> WorktreeSwitchModel {
-    let rows = worktrees
+    let mut rows = worktrees
         .iter()
-        .map(|worktree| {
+        .enumerate()
+        .map(|(index, worktree)| {
             let status = statuses.iter().find(|status| status.path == worktree.path);
             let is_detached = worktree.branch.trim().is_empty();
             let mut badges = Vec::new();
@@ -347,17 +349,28 @@ pub fn build_worktree_switch_model(
                 badges.push("occupied".to_string());
             }
 
-            WorktreeSwitchRow {
-                branch_label: worktree_branch_label(worktree),
-                path_label: worktree.path.display().to_string(),
-                badges,
-                target: WorktreeSwitchTarget {
-                    branch: (!is_detached).then(|| worktree.branch.clone()),
-                    path: worktree.path.clone(),
+            (
+                index,
+                status.and_then(|status| status.last_touched),
+                WorktreeSwitchRow {
+                    branch_label: worktree_branch_label(worktree),
+                    path_label: worktree.path.display().to_string(),
+                    badges,
+                    target: WorktreeSwitchTarget {
+                        branch: (!is_detached).then(|| worktree.branch.clone()),
+                        path: worktree.path.clone(),
+                    },
                 },
-            }
+            )
         })
         .collect::<Vec<_>>();
+
+    rows.sort_by(|(left_index, left_time, _), (right_index, right_time, _)| {
+        right_time
+            .cmp(left_time)
+            .then_with(|| left_index.cmp(right_index))
+    });
+    let rows = rows.into_iter().map(|(_, _, row)| row).collect::<Vec<_>>();
 
     let empty_state_lines = if rows.is_empty() {
         vec![

--- a/tests/unit/tui_tests.rs
+++ b/tests/unit/tui_tests.rs
@@ -7,7 +7,10 @@ use git_warp::tui::{
     AgentsDashboard, WorktreeRuntimeStatus, build_dashboard_model, build_worktree_switch_model,
     session_detail_lines,
 };
-use std::path::PathBuf;
+use std::{
+    path::PathBuf,
+    time::{Duration, SystemTime},
+};
 
 fn sample_summary(
     runtime: AgentRuntime,
@@ -197,12 +200,14 @@ fn test_build_worktree_switch_model_marks_state_and_detached_rows() {
             is_current: true,
             is_dirty: true,
             is_occupied: false,
+            last_touched: None,
         },
         WorktreeRuntimeStatus {
             path: PathBuf::from("/repo/.worktrees/detached"),
             is_current: false,
             is_dirty: false,
             is_occupied: true,
+            last_touched: None,
         },
     ];
 
@@ -213,6 +218,71 @@ fn test_build_worktree_switch_model_marks_state_and_detached_rows() {
     assert_eq!(model.rows[0].badges, vec!["primary", "current", "dirty"]);
     assert_eq!(model.rows[1].branch_label, "(detached HEAD: abcdef01)");
     assert_eq!(model.rows[1].badges, vec!["detached", "occupied"]);
+}
+
+#[test]
+fn test_build_worktree_switch_model_orders_recently_touched_worktrees_first() {
+    let older_path = PathBuf::from("/repo/.worktrees/older");
+    let newer_path = PathBuf::from("/repo/.worktrees/newer");
+    let middle_path = PathBuf::from("/repo/.worktrees/middle");
+    let worktrees = vec![
+        WorktreeInfo {
+            path: older_path.clone(),
+            branch: "older".to_string(),
+            head: "0123456789abcdef".to_string(),
+            is_primary: false,
+            is_current: false,
+            is_detached: false,
+        },
+        WorktreeInfo {
+            path: newer_path.clone(),
+            branch: "newer".to_string(),
+            head: "abcdef0123456789".to_string(),
+            is_primary: false,
+            is_current: false,
+            is_detached: false,
+        },
+        WorktreeInfo {
+            path: middle_path.clone(),
+            branch: "middle".to_string(),
+            head: "fedcba9876543210".to_string(),
+            is_primary: false,
+            is_current: false,
+            is_detached: false,
+        },
+    ];
+    let statuses = vec![
+        WorktreeRuntimeStatus {
+            path: older_path,
+            is_current: false,
+            is_dirty: false,
+            is_occupied: false,
+            last_touched: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(10)),
+        },
+        WorktreeRuntimeStatus {
+            path: newer_path,
+            is_current: false,
+            is_dirty: false,
+            is_occupied: false,
+            last_touched: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(30)),
+        },
+        WorktreeRuntimeStatus {
+            path: middle_path,
+            is_current: false,
+            is_dirty: false,
+            is_occupied: false,
+            last_touched: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(20)),
+        },
+    ];
+
+    let model = build_worktree_switch_model(&worktrees, &statuses);
+    let branch_labels: Vec<_> = model
+        .rows
+        .iter()
+        .map(|row| row.branch_label.as_str())
+        .collect();
+
+    assert_eq!(branch_labels, vec!["newer", "middle", "older"]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Sort the bare `warp` worktree picker by last filesystem touch time so recently modified or created worktrees appear first.
- Add `last_touched` to picker runtime status using the max of directory modified and created timestamps.
- Cover the recency ordering with a focused TUI model unit test.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test unit::tui_tests -- --nocapture`
- `cargo test tui::tests:: -- --nocapture`
- `cargo run -- --dry-run`