### PR TITLE
Report switch/create outcomes

### DIFF
--- a/docs/superpowers/plans/2026-04-24-switch-outcomes.md
+++ b/docs/superpowers/plans/2026-04-24-switch-outcomes.md
@@ -1,0 +1,128 @@
+# Switch Outcome Reporting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `warp switch` report creation, checkout, terminal handoff, and manual fallback as verified outcomes.
+
+**Architecture:** Keep the change in the switch command path. Add small local outcome structs/helpers in `src/cli.rs`, have `handle_switch` collect step states, and print a compact success or incomplete summary after terminal handoff.
+
+**Tech Stack:** Rust CLI, existing `std::process::Command` Git calls, current integration-test harness with fake executables and temp Git repositories.
+
+---
+
+### Task 1: Regression Tests
+
+**Files:**
+- Modify: `tests/integration/terminal_switch_tests.rs`
+
+- [ ] **Step 1: Add fake failing terminal support**
+
+Add a helper that creates an `open` command exiting non-zero so `--terminal tab` plus `terminal.app = "warp"` exercises terminal handoff failure without depending on the local desktop.
+
+- [ ] **Step 2: Add terminal failure regression test**
+
+Create a temp repo and config, run `warp switch --no-cow feature/handoff-fails`, and assert stdout contains:
+
+```text
+✅ Worktree creation: created
+✅ Branch checkout: feature/handoff-fails
+⚠️  Terminal handoff: failed
+⚠️  Switch incomplete
+💡 Run: cd '
+```
+
+- [ ] **Step 3: Add existing worktree branch mismatch regression test**
+
+Create an existing worktree for `feature/existing`, then run `warp --terminal echo switch --no-cow feature/wrong --path <existing-path>`. Assert stdout contains:
+
+```text
+↪️  Worktree creation: already existed
+⚠️  Branch checkout: expected feature/wrong
+⚠️  Switch incomplete
+💡 Run: cd '
+```
+
+- [ ] **Step 4: Verify tests fail**
+
+Run:
+
+```bash
+cargo test --test mod terminal_switch_tests -- --nocapture
+```
+
+Expected: the new assertions fail because current output does not include the verified step summary.
+
+### Task 2: Outcome Reporter
+
+**Files:**
+- Modify: `src/cli.rs`
+
+- [ ] **Step 1: Add outcome types**
+
+Add local `SwitchStepStatus`, `SwitchStep`, and `SwitchOutcomeReport` structs near the switch helpers. They need methods for `done`, `skipped`, `warned`, `has_warnings`, and `print`.
+
+- [ ] **Step 2: Track creation and checkout**
+
+In `handle_switch`, replace the early success print with outcome recording. Verify the worktree path exists after creation. For existing paths, verify the branch with:
+
+```bash
+git -C <worktree> branch --show-current
+```
+
+Traditional creation records checkout as done after `create_worktree_and_branch` succeeds. CoW checkout records warning on non-zero exit.
+
+- [ ] **Step 3: Track terminal handoff and fallback**
+
+Change `switch_to_worktree_path` to return a terminal handoff outcome instead of printing final success/fallback directly. On error, include the terminal error as warning detail.
+
+- [ ] **Step 4: Print final summary**
+
+After terminal handoff, append the handoff step to the report and print:
+
+```text
+✅ Switch complete: <path>
+```
+
+only when all outcomes are successful or skipped. Otherwise print each step plus:
+
+```text
+⚠️  Switch incomplete: <path>
+💡 Run: cd '<path>'
+```
+
+### Task 3: Verification And Publish
+
+**Files:**
+- Modify: `src/cli.rs`
+- Modify: `tests/integration/terminal_switch_tests.rs`
+- Add: `docs/superpowers/specs/2026-04-24-switch-outcomes-design.md`
+- Add: `docs/superpowers/plans/2026-04-24-switch-outcomes.md`
+
+- [ ] **Step 1: Format**
+
+Run:
+
+```bash
+cargo fmt
+```
+
+- [ ] **Step 2: Check whitespace**
+
+Run:
+
+```bash
+git diff --check
+```
+
+- [ ] **Step 3: Run focused tests**
+
+Run:
+
+```bash
+cargo test --test mod terminal_switch_tests -- --nocapture
+cargo test --test mod switch_post_create_tests -- --nocapture
+```
+
+- [ ] **Step 4: Commit, push, and open PR**
+
+Inspect `git status -sb`, stage only this issue's files, commit with a terse message, push `5-p1-report-switch-create`, and open a non-draft PR against `main`.

--- a/docs/superpowers/specs/2026-04-24-switch-outcomes-design.md
+++ b/docs/superpowers/specs/2026-04-24-switch-outcomes-design.md
@@ -1,0 +1,57 @@
+# Switch Outcome Reporting Design
+
+## Source Of Truth
+
+GitHub issue #5, "[P1] Report switch/create outcomes as verified steps", requires `warp switch` to report the worktree creation, branch checkout, terminal handoff, and manual fallback as explicit outcomes. The final message must be downgraded when part of the flow only partially succeeds, and failure states must point users to the next command.
+
+## Brainstorming
+
+### Options Considered
+
+1. Keep the existing inline `println!` calls and add a few more messages.
+   - Fastest, but it keeps success and warning logic spread through `handle_switch`.
+   - Harder to test because the final state is implicit in message ordering.
+
+2. Add a small switch outcome reporter in `src/cli.rs`.
+   - Tracks each step as `done`, `skipped`, or `warning`.
+   - Keeps the happy path short while making partial failures explicit.
+   - Fits the current CLI structure without broader architecture churn.
+
+3. Push outcome state into `TerminalManager` and `GitRepository`.
+   - Gives stronger typed boundaries, but issue #5 is about the user-facing switch flow.
+   - Higher risk and touches stable shared APIs without enough payoff.
+
+Recommended approach: option 2. It gives verified, testable output while staying scoped to the switch command.
+
+## Design
+
+`handle_switch` will build an outcome report while it performs the existing steps:
+
+- Worktree creation:
+  - Existing worktree: report that creation was skipped because the path already exists.
+  - New worktree: report creation as completed only after the worktree path exists.
+- Branch checkout:
+  - Traditional worktree creation: report checkout as completed because `git worktree add` completed successfully.
+  - CoW enhancement: after cloning and path rewriting, run `git checkout <branch>`. A checkout failure must be captured as a warning outcome, not only a log entry.
+  - Existing worktree: verify the branch by running `git -C <worktree> branch --show-current`; report a warning if it does not match the requested branch.
+- Terminal handoff:
+  - Successful terminal switch: report handoff as completed.
+  - Terminal failure: report handoff as warning and include the error text.
+- Manual fallback:
+  - Hidden on the fully successful path.
+  - Printed when any warning outcome exists, with `cd '<worktree>'` as the next command.
+
+The output should stay compact on the happy path. Partial failures should show an "Incomplete switch" summary with explicit step lines and the fallback command.
+
+## Error Handling
+
+Hard failures that prevent worktree creation still return an error as they do today. Recoverable post-create setup warnings and terminal handoff failures do not fail the command; they degrade the final summary and give the manual recovery command.
+
+## Testing
+
+Add integration coverage around `warp switch` using the existing fake command strategy:
+
+- Existing worktree with mismatched requested branch reports skipped creation, checkout warning, terminal handoff, fallback command, and incomplete summary.
+- Terminal handoff failure reports creation and checkout as completed, handoff warning, fallback command, and incomplete summary.
+
+Run focused integration tests, formatting, and diff whitespace checks before publishing.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -130,6 +130,82 @@ pub enum Commands {
     },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SwitchStepStatus {
+    Done,
+    Skipped,
+    Warning,
+}
+
+struct SwitchStep {
+    label: &'static str,
+    status: SwitchStepStatus,
+    detail: String,
+}
+
+impl SwitchStep {
+    fn print(&self) {
+        let icon = match self.status {
+            SwitchStepStatus::Done => "✅",
+            SwitchStepStatus::Skipped => "↪️ ",
+            SwitchStepStatus::Warning => "⚠️ ",
+        };
+
+        println!("{} {}: {}", icon, self.label, self.detail);
+    }
+}
+
+struct SwitchOutcomeReport {
+    worktree_path: PathBuf,
+    steps: Vec<SwitchStep>,
+}
+
+impl SwitchOutcomeReport {
+    fn new(worktree_path: PathBuf) -> Self {
+        Self {
+            worktree_path,
+            steps: Vec::new(),
+        }
+    }
+
+    fn done(&mut self, label: &'static str, detail: impl Into<String>) {
+        self.push(label, SwitchStepStatus::Done, detail);
+    }
+
+    fn skipped(&mut self, label: &'static str, detail: impl Into<String>) {
+        self.push(label, SwitchStepStatus::Skipped, detail);
+    }
+
+    fn warned(&mut self, label: &'static str, detail: impl Into<String>) {
+        self.push(label, SwitchStepStatus::Warning, detail);
+    }
+
+    fn push(&mut self, label: &'static str, status: SwitchStepStatus, detail: impl Into<String>) {
+        let step = SwitchStep {
+            label,
+            status,
+            detail: detail.into(),
+        };
+        step.print();
+        self.steps.push(step);
+    }
+
+    fn has_warnings(&self) -> bool {
+        self.steps
+            .iter()
+            .any(|step| step.status == SwitchStepStatus::Warning)
+    }
+
+    fn finish(&self) {
+        if self.has_warnings() {
+            println!("⚠️  Switch incomplete: {}", self.worktree_path.display());
+            println!("💡 Run: cd '{}'", self.worktree_path.display());
+        } else {
+            println!("✅ Switch complete: {}", self.worktree_path.display());
+        }
+    }
+}
+
 impl Cli {
     pub fn run(&self) -> Result<()> {
         if self.debug {
@@ -291,7 +367,17 @@ impl Cli {
             TerminalMode::from_str(&config.terminal_mode).unwrap_or(TerminalMode::Tab)
         };
 
-        self.switch_to_worktree_path(worktree_path, terminal_mode, config.terminal.app.as_str())
+        let mut report = SwitchOutcomeReport::new(worktree_path.to_path_buf());
+        report.skipped("Worktree creation", "already existed");
+        self.record_terminal_handoff(
+            &mut report,
+            worktree_path,
+            terminal_mode,
+            config.terminal.app.as_str(),
+        );
+        report.finish();
+
+        Ok(())
     }
 
     fn handle_switch(
@@ -340,11 +426,14 @@ impl Cli {
             return Ok(());
         }
 
+        let mut report = SwitchOutcomeReport::new(worktree_path.clone());
         let mut worktree_created = false;
+        let mut checkout_warning = None;
 
         // Check if worktree already exists
         if worktree_path.exists() {
             println!("📁 Worktree already exists at: {}", worktree_path.display());
+            report.skipped("Worktree creation", "already existed");
         } else {
             println!("🚀 Creating worktree for branch '{}'", branch);
 
@@ -386,7 +475,9 @@ impl Cli {
 
                         if !output.status.success() {
                             let error = String::from_utf8_lossy(&output.stderr);
+                            let error = error.trim().to_string();
                             log::warn!("Failed to checkout branch in CoW worktree: {}", error);
+                            checkout_warning = Some(error);
                         }
                     }
                 }
@@ -395,9 +486,21 @@ impl Cli {
                 git_repo.create_worktree_and_branch(&branch, &worktree_path, None)?;
             }
 
-            println!("✅ Worktree created successfully!");
+            if worktree_path.exists() {
+                report.done("Worktree creation", "created");
+            } else {
+                report.warned(
+                    "Worktree creation",
+                    format!(
+                        "path was not found after creation: {}",
+                        worktree_path.display()
+                    ),
+                );
+            }
             worktree_created = true;
         }
+
+        Self::record_branch_checkout(&mut report, &worktree_path, &branch, checkout_warning);
 
         match run_post_create_setup(&worktree_path, worktree_created) {
             PostCreateSetupStatus::Installed => {
@@ -419,22 +522,89 @@ impl Cli {
             TerminalMode::from_str(&config.terminal_mode).unwrap_or(TerminalMode::Tab)
         };
 
-        self.switch_to_worktree_path(&worktree_path, terminal_mode, config.terminal.app.as_str())
+        self.record_terminal_handoff(
+            &mut report,
+            &worktree_path,
+            terminal_mode,
+            config.terminal.app.as_str(),
+        );
+        report.finish();
+
+        Ok(())
     }
 
-    fn switch_to_worktree_path(
+    fn record_branch_checkout(
+        report: &mut SwitchOutcomeReport,
+        worktree_path: &Path,
+        branch: &str,
+        checkout_warning: Option<String>,
+    ) {
+        match Self::current_branch_at_path(worktree_path) {
+            Ok(current_branch) if current_branch == branch && checkout_warning.is_none() => {
+                report.done("Branch checkout", branch);
+            }
+            Ok(current_branch) if current_branch == branch => {
+                report.warned(
+                    "Branch checkout",
+                    format!(
+                        "checkout reported warning for {}: {}",
+                        branch,
+                        checkout_warning.unwrap_or_default()
+                    ),
+                );
+            }
+            Ok(current_branch) => {
+                let found = if current_branch.is_empty() {
+                    "detached HEAD".to_string()
+                } else {
+                    current_branch
+                };
+                let detail = match checkout_warning {
+                    Some(warning) if !warning.is_empty() => {
+                        format!("expected {branch}, found {found}; checkout failed: {warning}")
+                    }
+                    _ => format!("expected {branch}, found {found}"),
+                };
+                report.warned("Branch checkout", detail);
+            }
+            Err(error) => {
+                let detail = match checkout_warning {
+                    Some(warning) if !warning.is_empty() => {
+                        format!("could not verify {branch}: {error}; checkout failed: {warning}")
+                    }
+                    _ => format!("could not verify {branch}: {error}"),
+                };
+                report.warned("Branch checkout", detail);
+            }
+        }
+    }
+
+    fn current_branch_at_path(worktree_path: &Path) -> Result<String> {
+        let output = Command::new("git")
+            .args(["branch", "--show-current"])
+            .current_dir(worktree_path)
+            .output()
+            .map_err(|e| anyhow::anyhow!("Failed to verify worktree branch: {}", e))?;
+
+        if !output.status.success() {
+            let error = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow::anyhow!(
+                "Failed to verify worktree branch: {}",
+                error.trim()
+            ));
+        }
+
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+
+    fn record_terminal_handoff(
         &self,
+        report: &mut SwitchOutcomeReport,
         worktree_path: &Path,
         terminal_mode: crate::terminal::TerminalMode,
         terminal_app: &str,
-    ) -> Result<()> {
-        use crate::terminal::{TerminalManager, TerminalMode};
-
-        let is_current_mode = matches!(terminal_mode, TerminalMode::Current);
-
-        if is_current_mode {
-            println!("🔄 Switched to worktree: {}", worktree_path.display());
-        }
+    ) {
+        use crate::terminal::TerminalManager;
 
         let terminal_manager = TerminalManager;
         match terminal_manager.switch_to_worktree_with_app(
@@ -444,18 +614,30 @@ impl Cli {
             Some(terminal_app),
         ) {
             Ok(()) => {
-                if !is_current_mode {
-                    println!("🔄 Switched to worktree: {}", worktree_path.display());
-                }
+                report.done(
+                    "Terminal handoff",
+                    Self::terminal_handoff_success_detail(terminal_mode),
+                );
             }
             Err(e) => {
                 log::warn!("Terminal switching failed: {}", e);
-                println!("📍 Worktree created at: {}", worktree_path.display());
-                println!("💡 Run: cd '{}'", worktree_path.display());
+                report.warned("Terminal handoff", format!("failed: {e}"));
             }
         }
+    }
 
-        Ok(())
+    fn terminal_handoff_success_detail(
+        terminal_mode: crate::terminal::TerminalMode,
+    ) -> &'static str {
+        use crate::terminal::TerminalMode;
+
+        match terminal_mode {
+            TerminalMode::Tab => "opened tab",
+            TerminalMode::Window => "opened window",
+            TerminalMode::InPlace => "printed cd command",
+            TerminalMode::Echo => "printed manual commands",
+            TerminalMode::Current => "started current-terminal shell",
+        }
     }
 
     fn resolve_switch_branch(

--- a/tests/integration/switch_post_create_tests.rs
+++ b/tests/integration/switch_post_create_tests.rs
@@ -125,5 +125,5 @@ fn test_warp_switch_warns_when_pnpm_install_fails_but_still_succeeds() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Detected pnpm repo but `pnpm install` failed: install failed"));
-    assert!(stdout.contains("Worktree created successfully"));
+    assert!(stdout.contains("Worktree creation: created"));
 }

--- a/tests/integration/terminal_switch_tests.rs
+++ b/tests/integration/terminal_switch_tests.rs
@@ -81,6 +81,18 @@ fn create_fake_open(bin_dir: &Path, log_path: &Path) -> PathBuf {
     script_path
 }
 
+fn create_failing_open(bin_dir: &Path) -> PathBuf {
+    let script_path = bin_dir.join("open");
+    fs::write(
+        &script_path,
+        "#!/bin/sh\necho \"open failed\" >&2\nexit 1\n",
+    )
+    .unwrap();
+    #[cfg(unix)]
+    make_executable(&script_path);
+    script_path
+}
+
 fn create_fake_shell(bin_dir: &Path, log_path: &Path) -> PathBuf {
     let script_path = bin_dir.join("fake-shell");
     fs::write(
@@ -172,6 +184,104 @@ fn test_warp_switch_honors_explicit_warp_terminal_app() {
         open_contents,
         osascript_contents
     );
+}
+
+#[test]
+fn test_warp_switch_reports_terminal_handoff_failure_as_incomplete() {
+    let repo_dir = setup_git_repo();
+    let repo_path = repo_dir.path();
+    let home_dir = tempdir().unwrap();
+    let bin_dir = tempdir().unwrap();
+    let osascript_log_dir = tempdir().unwrap();
+    let osascript_log = osascript_log_dir.path().join("osascript.log");
+
+    write_config(home_dir.path(), "warp");
+    create_fake_osascript(bin_dir.path(), &osascript_log);
+    create_failing_open(bin_dir.path());
+
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    let path_env = format!("{}:{}", bin_dir.path().display(), original_path);
+    let worktree_path = repo_path.join("worktrees").join("handoff-fails");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_warp"))
+        .args(["switch", "--no-cow", "feature/handoff-fails", "--path"])
+        .arg(&worktree_path)
+        .current_dir(repo_path)
+        .env("HOME", home_dir.path())
+        .env("PATH", path_env)
+        .env("TERM_PROGRAM", "WarpTerminal")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{stdout}");
+    assert!(stdout.contains("✅ Worktree creation: created"), "{stdout}");
+    assert!(
+        stdout.contains("✅ Branch checkout: feature/handoff-fails"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("⚠️  Terminal handoff: failed"), "{stdout}");
+    assert!(stdout.contains("⚠️  Switch incomplete"), "{stdout}");
+    assert!(stdout.contains("💡 Run: cd '"), "{stdout}");
+}
+
+#[test]
+fn test_warp_switch_reports_existing_worktree_branch_mismatch_as_incomplete() {
+    let repo_dir = setup_git_repo();
+    let repo_path = repo_dir.path();
+    let home_dir = tempdir().unwrap();
+    let bin_dir = tempdir().unwrap();
+    let osascript_log_dir = tempdir().unwrap();
+    let osascript_log = osascript_log_dir.path().join("osascript.log");
+    let worktree_path = repo_path.join("worktrees").join("feature-existing");
+
+    write_config(home_dir.path(), "warp");
+    create_fake_osascript(bin_dir.path(), &osascript_log);
+
+    let create_output = Command::new("git")
+        .args(["worktree", "add", "-b", "feature/existing"])
+        .arg(&worktree_path)
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    assert!(
+        create_output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&create_output.stderr)
+    );
+
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    let path_env = format!("{}:{}", bin_dir.path().display(), original_path);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_warp"))
+        .args([
+            "--terminal",
+            "echo",
+            "switch",
+            "--no-cow",
+            "feature/wrong",
+            "--path",
+        ])
+        .arg(&worktree_path)
+        .current_dir(repo_path)
+        .env("HOME", home_dir.path())
+        .env("PATH", path_env)
+        .env("TERM_PROGRAM", "WarpTerminal")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{stdout}");
+    assert!(
+        stdout.contains("↪️  Worktree creation: already existed"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("⚠️  Branch checkout: expected feature/wrong"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("⚠️  Switch incomplete"), "{stdout}");
+    assert!(stdout.contains("💡 Run: cd '"), "{stdout}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add explicit `warp switch` outcomes for worktree creation, branch checkout verification, and terminal handoff.
- Downgrade the final message to `Switch incomplete` when checkout verification or terminal handoff has a warning, with a `cd` fallback command.
- Add regression coverage for terminal handoff failure and existing-path branch mismatch, and update the post-create output assertion.
- Add the issue spec and implementation plan.

Closes #5

## Verification
- `cargo fmt`
- `git diff --check`
- `cargo test --test mod terminal_switch_tests -- --nocapture` - 5 passed
- `cargo test --test mod switch_post_create_tests -- --nocapture` - 2 passed
- `cargo test` - broad suite still fails in unrelated baseline COW/process/rewrite tests after issue-specific tests pass
- `cargo test -- --test-threads=1` - same unrelated broad-suite failures remain