### PR TITLE
Wire terminal launch config into switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,8 @@ kill_timeout = 5               # Timeout in seconds
 
 [terminal]
 app = "auto"                   # auto, terminal, iterm2, warp
-auto_activate = true           # Activate new terminal windows
+auto_activate = true           # Activate new macOS terminal tabs/windows
+init_commands = []             # Commands to run after cd into a worktree
 
 [agent]
 enabled = true                 # Enable Claude Code integration
@@ -235,6 +236,9 @@ export GIT_WARP_USE_COW=false
 export GIT_WARP_AUTO_CONFIRM=true
 export GIT_WARP_WORKTREES_PATH=/custom/worktrees
 ```
+
+`terminal.init_commands` are emitted after Git-Warp changes into the worktree for
+terminal modes such as `tab`, `window`, `inplace`, and `echo`.
 
 ## 🎨 Design Philosophy
 

--- a/docs/superpowers/plans/2026-04-26-runtime-config.md
+++ b/docs/superpowers/plans/2026-04-26-runtime-config.md
@@ -1,0 +1,124 @@
+# Runtime Config Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make terminal launch config values produce visible `warp switch` behavior.
+
+**Architecture:** Thread terminal launch options from loaded config through the existing CLI handoff into terminal backends. Keep mode precedence unchanged: CLI `--terminal` chooses the mode, config supplies app, auto-activation, and init commands.
+
+**Tech Stack:** Rust, clap CLI, integration tests under `tests/integration/terminal_switch_tests.rs`.
+
+---
+
+### Task 1: Prove Missing Init Command Behavior
+
+**Files:**
+- Modify: `tests/integration/terminal_switch_tests.rs`
+
+- [x] **Step 1: Add a config helper that can write terminal mode, activation, and init commands**
+
+```rust
+fn write_config_with_terminal_options(
+    home_dir: &Path,
+    app: &str,
+    terminal_mode: &str,
+    auto_activate: bool,
+    init_commands: &[&str],
+)
+```
+
+- [x] **Step 2: Add a failing integration test**
+
+```rust
+#[test]
+fn test_warp_switch_echo_includes_configured_init_commands()
+```
+
+- [x] **Step 3: Run the focused red check**
+
+Run: `cargo test --test mod terminal_switch_tests::test_warp_switch_echo_includes_configured_init_commands -- --nocapture`
+
+Expected before implementation: FAIL because stdout has `cd ...` but not `corepack enable` or `pnpm install`.
+
+### Task 2: Thread Terminal Launch Options
+
+**Files:**
+- Modify: `src/terminal.rs`
+- Modify: `src/cli.rs`
+
+- [x] **Step 1: Add a `TerminalLaunchOptions` type**
+
+```rust
+#[derive(Debug, Clone)]
+pub struct TerminalLaunchOptions {
+    pub auto_activate: bool,
+    pub init_commands: Vec<String>,
+}
+```
+
+- [x] **Step 2: Add command construction helpers**
+
+Generate one shell command per line: `cd '<path>'`, followed by configured init commands.
+
+- [x] **Step 3: Pass options from CLI config into terminal handoff**
+
+`record_terminal_handoff` should pass `config.terminal.auto_activate` and `config.terminal.init_commands.clone()`.
+
+### Task 3: Apply Options in Terminal Backends
+
+**Files:**
+- Modify: `src/terminal.rs`
+
+- [x] **Step 1: Update echo and inplace modes**
+
+Print `cd '<worktree>'` and then each init command.
+
+- [x] **Step 2: Update iTerm2 and Terminal.app AppleScript**
+
+When `auto_activate` is true, include `activate`; then write the `cd` command and each init command.
+
+- [x] **Step 3: Keep current mode shell handoff compatible**
+
+For `current`, start the shell in the worktree as before. If init commands are configured, run them in a shell command before dropping into the interactive shell only when that can be done without breaking existing fake-shell tests.
+
+### Task 4: Align Config Display and Docs
+
+**Files:**
+- Modify: `src/cli.rs`
+- Modify: `README.md`
+- Modify: `docs/user-guide.md`
+
+- [x] **Step 1: Print init commands in `warp config --show`**
+
+Display `Init commands: []` when empty, or the configured list when present.
+
+- [x] **Step 2: Document terminal launch behavior**
+
+README and user guide should state that init commands run after switching into the worktree and `auto_activate` affects macOS terminal activation.
+
+### Task 5: Verify and Publish
+
+**Files:**
+- All changed files
+
+- [x] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+cargo test --test mod terminal_switch_tests -- --nocapture
+cargo test --test mod config_tests -- --nocapture
+```
+
+- [x] **Step 2: Run formatting and whitespace checks**
+
+Run:
+
+```bash
+cargo fmt --check
+git diff --check
+```
+
+- [ ] **Step 3: Commit, push, and open a ready PR**
+
+Use a concise PR body with summary and only the verification commands that actually ran.

--- a/docs/superpowers/specs/2026-04-26-runtime-config-design.md
+++ b/docs/superpowers/specs/2026-04-26-runtime-config-design.md
@@ -1,0 +1,27 @@
+# Runtime Config Behavior Design
+
+Issue #7 asks Git-Warp to make documented configuration values affect command behavior, not only serialization and display. The broad config surface already loads and displays many values, and recent work has wired `terminal_mode`, `terminal.app`, and custom worktree paths into `warp switch`. The remaining high-value gap is terminal launch behavior: `terminal.auto_activate` and `terminal.init_commands` exist in config but do not change the generated terminal handoff.
+
+## Approach
+
+Use the existing `warp switch` handoff path as the single integration point. `Cli::record_terminal_handoff` will pass the loaded `TerminalConfig` into `TerminalManager`, and terminal backends will build launch commands from a shared launch-options value. This keeps CLI precedence intact: explicit `--terminal` still chooses the mode, config still supplies the terminal app and launch options, and custom `--path` continues to override configured worktree base paths.
+
+## Runtime Behavior
+
+- `terminal.init_commands` runs after the generated `cd <worktree>` command for shell-printing modes, current mode, and macOS AppleScript tab/window handoff.
+- Echo and inplace modes print shell commands that can be evaluated by shell integrations.
+- iTerm2 and Terminal.app AppleScript writes the `cd` command first, then each configured init command.
+- `terminal.auto_activate = true` adds an AppleScript `activate` command for iTerm2 and Terminal.app. `false` omits it.
+- Warp URI handoff keeps using the URI launch path for tab/window creation; init commands are not appended to the URI because Git-Warp's current Warp URI action only carries a path.
+
+## Config Visibility
+
+`warp config --show` will include `terminal.init_commands`, using `[]` when no commands are configured. README and the user guide will document that init commands run after switching into the worktree and that auto-activation affects macOS AppleScript terminal backends.
+
+## Tests
+
+Integration coverage should prove the actual CLI path:
+
+- `warp switch` with config `terminal_mode = "echo"` prints configured init commands.
+- Terminal.app AppleScript includes `activate` when `auto_activate = true`.
+- Terminal.app AppleScript omits `activate` when `auto_activate = false`.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -402,11 +402,14 @@ auto_kill = false
 kill_timeout = 5
 
 [terminal]
-# Terminal app: auto, iterm2, terminal
+# Terminal app: auto, iterm2, terminal, warp
 app = "auto"
 
-# Auto-activate new tabs/windows
+# Auto-activate new macOS terminal tabs/windows
 auto_activate = true
+
+# Commands to run after Git-Warp changes into the worktree
+init_commands = []
 
 [agent]
 # Enable agent monitoring

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -378,6 +378,7 @@ impl Cli {
             worktree_path,
             terminal_mode,
             config.terminal.app.as_str(),
+            &config.terminal,
         );
         report.finish();
 
@@ -531,6 +532,7 @@ impl Cli {
             &worktree_path,
             terminal_mode,
             config.terminal.app.as_str(),
+            &config.terminal,
         );
         report.finish();
 
@@ -607,15 +609,22 @@ impl Cli {
         worktree_path: &Path,
         terminal_mode: crate::terminal::TerminalMode,
         terminal_app: &str,
+        terminal_config: &crate::config::TerminalConfig,
     ) {
-        use crate::terminal::TerminalManager;
+        use crate::terminal::{TerminalLaunchOptions, TerminalManager};
 
         let terminal_manager = TerminalManager;
-        match terminal_manager.switch_to_worktree_with_app(
+        let launch_options = TerminalLaunchOptions {
+            auto_activate: terminal_config.auto_activate,
+            init_commands: terminal_config.init_commands.clone(),
+        };
+
+        match terminal_manager.switch_to_worktree_with_options(
             &worktree_path,
             terminal_mode,
             None,
             Some(terminal_app),
+            &launch_options,
         ) {
             Ok(()) => {
                 report.done(
@@ -1080,6 +1089,7 @@ impl Cli {
             println!("🖥️  Terminal Integration:");
             println!("  App: {}", config.terminal.app);
             println!("  Auto-activate: {}", config.terminal.auto_activate);
+            println!("  Init commands: {:?}", config.terminal.init_commands);
             println!();
 
             println!("🤖 Agent Settings:");

--- a/src/config.rs
+++ b/src/config.rs
@@ -285,6 +285,9 @@ app = "{}"
 # Auto-activate new tabs/windows
 auto_activate = {}
 
+# Commands to run after changing into a worktree
+init_commands = []
+
 [agent]
 # Enable agent monitoring
 enabled = {}

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -24,11 +24,36 @@ impl TerminalMode {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct TerminalLaunchOptions {
+    pub auto_activate: bool,
+    pub init_commands: Vec<String>,
+}
+
+impl Default for TerminalLaunchOptions {
+    fn default() -> Self {
+        Self {
+            auto_activate: true,
+            init_commands: Vec::new(),
+        }
+    }
+}
+
 pub trait Terminal {
-    fn open_tab(&self, path: &Path, session_id: Option<&str>) -> Result<()>;
-    fn open_window(&self, path: &Path, session_id: Option<&str>) -> Result<()>;
-    fn switch_to_directory(&self, path: &Path) -> Result<()>;
-    fn echo_commands(&self, path: &Path) -> Result<()>;
+    fn open_tab(
+        &self,
+        path: &Path,
+        session_id: Option<&str>,
+        options: &TerminalLaunchOptions,
+    ) -> Result<()>;
+    fn open_window(
+        &self,
+        path: &Path,
+        session_id: Option<&str>,
+        options: &TerminalLaunchOptions,
+    ) -> Result<()>;
+    fn switch_to_directory(&self, path: &Path, options: &TerminalLaunchOptions) -> Result<()>;
+    fn echo_commands(&self, path: &Path, options: &TerminalLaunchOptions) -> Result<()>;
     fn is_supported(&self) -> bool;
 }
 
@@ -73,54 +98,68 @@ pub struct ITerm2;
 
 #[cfg(target_os = "macos")]
 impl Terminal for ITerm2 {
-    fn open_tab(&self, path: &Path, _session_id: Option<&str>) -> Result<()> {
+    fn open_tab(
+        &self,
+        path: &Path,
+        _session_id: Option<&str>,
+        options: &TerminalLaunchOptions,
+    ) -> Result<()> {
+        let activate = applescript_activate(options);
+        let commands = iterm_write_commands(path, options, "                ");
         let script = format!(
             r#"
 tell application "iTerm"
+{activate}
     tell current window
         create tab with default profile
         tell current tab
             tell current session
-                write text "cd '{}'"
+{commands}
             end tell
         end tell
     end tell
 end tell
 "#,
-            path.display()
         );
 
         self.run_applescript(&script)
     }
 
-    fn open_window(&self, path: &Path, _session_id: Option<&str>) -> Result<()> {
+    fn open_window(
+        &self,
+        path: &Path,
+        _session_id: Option<&str>,
+        options: &TerminalLaunchOptions,
+    ) -> Result<()> {
+        let activate = applescript_activate(options);
+        let commands = iterm_write_commands(path, options, "                ");
         let script = format!(
             r#"
 tell application "iTerm"
+{activate}
     create window with default profile
     tell current window
         tell current tab
             tell current session
-                write text "cd '{}'"
+{commands}
             end tell
         end tell
     end tell
 end tell
 "#,
-            path.display()
         );
 
         self.run_applescript(&script)
     }
 
-    fn switch_to_directory(&self, path: &Path) -> Result<()> {
-        println!("cd '{}'", path.display());
+    fn switch_to_directory(&self, path: &Path, options: &TerminalLaunchOptions) -> Result<()> {
+        print_shell_commands(path, options);
         Ok(())
     }
 
-    fn echo_commands(&self, path: &Path) -> Result<()> {
+    fn echo_commands(&self, path: &Path, options: &TerminalLaunchOptions) -> Result<()> {
         println!("# Navigate to worktree:");
-        println!("cd '{}'", path.display());
+        print_shell_commands(path, options);
         Ok(())
     }
 
@@ -156,42 +195,56 @@ pub struct AppleTerminal;
 
 #[cfg(target_os = "macos")]
 impl Terminal for AppleTerminal {
-    fn open_tab(&self, path: &Path, _session_id: Option<&str>) -> Result<()> {
+    fn open_tab(
+        &self,
+        path: &Path,
+        _session_id: Option<&str>,
+        options: &TerminalLaunchOptions,
+    ) -> Result<()> {
+        let activate = applescript_activate(options);
+        let commands = terminal_tab_commands(path, options, "        ");
         let script = format!(
             r#"
 tell application "Terminal"
+{activate}
     tell window 1
-        do script "cd '{}'" in (make new tab)
+{commands}
     end tell
 end tell
 "#,
-            path.display()
         );
 
         self.run_applescript(&script)
     }
 
-    fn open_window(&self, path: &Path, _session_id: Option<&str>) -> Result<()> {
+    fn open_window(
+        &self,
+        path: &Path,
+        _session_id: Option<&str>,
+        options: &TerminalLaunchOptions,
+    ) -> Result<()> {
+        let activate = applescript_activate(options);
+        let commands = terminal_window_commands(path, options, "    ");
         let script = format!(
             r#"
 tell application "Terminal"
-    do script "cd '{}'"
+{activate}
+{commands}
 end tell
 "#,
-            path.display()
         );
 
         self.run_applescript(&script)
     }
 
-    fn switch_to_directory(&self, path: &Path) -> Result<()> {
-        println!("cd '{}'", path.display());
+    fn switch_to_directory(&self, path: &Path, options: &TerminalLaunchOptions) -> Result<()> {
+        print_shell_commands(path, options);
         Ok(())
     }
 
-    fn echo_commands(&self, path: &Path) -> Result<()> {
+    fn echo_commands(&self, path: &Path, options: &TerminalLaunchOptions) -> Result<()> {
         println!("# Navigate to worktree:");
-        println!("cd '{}'", path.display());
+        print_shell_commands(path, options);
         Ok(())
     }
 
@@ -222,22 +275,32 @@ pub struct WarpTerminal;
 
 #[cfg(target_os = "macos")]
 impl Terminal for WarpTerminal {
-    fn open_tab(&self, path: &Path, _session_id: Option<&str>) -> Result<()> {
+    fn open_tab(
+        &self,
+        path: &Path,
+        _session_id: Option<&str>,
+        _options: &TerminalLaunchOptions,
+    ) -> Result<()> {
         self.open_uri("new_tab", path)
     }
 
-    fn open_window(&self, path: &Path, _session_id: Option<&str>) -> Result<()> {
+    fn open_window(
+        &self,
+        path: &Path,
+        _session_id: Option<&str>,
+        _options: &TerminalLaunchOptions,
+    ) -> Result<()> {
         self.open_uri("new_window", path)
     }
 
-    fn switch_to_directory(&self, path: &Path) -> Result<()> {
-        println!("cd '{}'", path.display());
+    fn switch_to_directory(&self, path: &Path, options: &TerminalLaunchOptions) -> Result<()> {
+        print_shell_commands(path, options);
         Ok(())
     }
 
-    fn echo_commands(&self, path: &Path) -> Result<()> {
+    fn echo_commands(&self, path: &Path, options: &TerminalLaunchOptions) -> Result<()> {
         println!("# Navigate to worktree:");
-        println!("cd '{}'", path.display());
+        print_shell_commands(path, options);
         Ok(())
     }
 
@@ -285,7 +348,97 @@ fn percent_encode(input: &str) -> String {
     encoded
 }
 
-fn enter_current_shell(path: &Path) -> Result<()> {
+fn shell_quote(input: &str) -> String {
+    format!("'{}'", input.replace('\'', "'\\''"))
+}
+
+fn shell_command_sequence(path: &Path, options: &TerminalLaunchOptions) -> Vec<String> {
+    let mut commands = vec![format!("cd {}", shell_quote(&path.to_string_lossy()))];
+    commands.extend(
+        options
+            .init_commands
+            .iter()
+            .map(|command| command.trim())
+            .filter(|command| !command.is_empty())
+            .map(ToString::to_string),
+    );
+    commands
+}
+
+fn print_shell_commands(path: &Path, options: &TerminalLaunchOptions) {
+    for command in shell_command_sequence(path, options) {
+        println!("{command}");
+    }
+}
+
+fn escape_applescript_string(input: &str) -> String {
+    input.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+#[cfg(target_os = "macos")]
+fn applescript_activate(options: &TerminalLaunchOptions) -> &'static str {
+    if options.auto_activate {
+        "    activate"
+    } else {
+        ""
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn iterm_write_commands(path: &Path, options: &TerminalLaunchOptions, indent: &str) -> String {
+    shell_command_sequence(path, options)
+        .into_iter()
+        .map(|command| {
+            format!(
+                "{indent}write text \"{}\"",
+                escape_applescript_string(&command)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(target_os = "macos")]
+fn terminal_tab_commands(path: &Path, options: &TerminalLaunchOptions, indent: &str) -> String {
+    let commands = shell_command_sequence(path, options);
+    let Some((first, rest)) = commands.split_first() else {
+        return String::new();
+    };
+
+    let mut lines = vec![format!(
+        "{indent}do script \"{}\" in (make new tab)",
+        escape_applescript_string(first)
+    )];
+    lines.extend(rest.iter().map(|command| {
+        format!(
+            "{indent}do script \"{}\" in selected tab",
+            escape_applescript_string(command)
+        )
+    }));
+    lines.join("\n")
+}
+
+#[cfg(target_os = "macos")]
+fn terminal_window_commands(path: &Path, options: &TerminalLaunchOptions, indent: &str) -> String {
+    let commands = shell_command_sequence(path, options);
+    let Some((first, rest)) = commands.split_first() else {
+        return String::new();
+    };
+
+    let mut lines = vec![format!(
+        "{indent}do script \"{}\"",
+        escape_applescript_string(first)
+    )];
+    lines.extend(rest.iter().map(|command| {
+        format!(
+            "{indent}do script \"{}\" in selected tab of front window",
+            escape_applescript_string(command)
+        )
+    }));
+    lines.join("\n")
+}
+
+fn enter_current_shell(path: &Path, options: &TerminalLaunchOptions) -> Result<()> {
     let shell = std::env::var("SHELL")
         .ok()
         .filter(|value| !value.trim().is_empty())
@@ -296,8 +449,16 @@ fn enter_current_shell(path: &Path) -> Result<()> {
         path.display()
     );
 
-    let status = Command::new(&shell)
-        .current_dir(path)
+    let mut command = Command::new(&shell);
+    command.current_dir(path);
+
+    if !options.init_commands.is_empty() {
+        let mut init_script = options.init_commands.join("\n");
+        init_script.push_str(&format!("\nexec {}", shell_quote(&shell)));
+        command.args(["-lc", &init_script]);
+    }
+
+    let status = command
         .status()
         .map_err(|e| anyhow::anyhow!("Failed to start current terminal shell: {}", e))?;
 
@@ -377,19 +538,36 @@ impl TerminalManager {
         session_id: Option<&str>,
         preferred_app: Option<&str>,
     ) -> Result<()> {
+        self.switch_to_worktree_with_options(
+            path,
+            mode,
+            session_id,
+            preferred_app,
+            &TerminalLaunchOptions::default(),
+        )
+    }
+
+    pub fn switch_to_worktree_with_options<P: AsRef<Path>>(
+        &self,
+        path: P,
+        mode: TerminalMode,
+        session_id: Option<&str>,
+        preferred_app: Option<&str>,
+        options: &TerminalLaunchOptions,
+    ) -> Result<()> {
         let path = path.as_ref();
 
         if matches!(mode, TerminalMode::Current) {
-            return enter_current_shell(path);
+            return enter_current_shell(path, options);
         }
 
         let terminal = Self::get_terminal(preferred_app)?;
 
         match mode {
-            TerminalMode::Tab => terminal.open_tab(path, session_id),
-            TerminalMode::Window => terminal.open_window(path, session_id),
-            TerminalMode::InPlace => terminal.switch_to_directory(path),
-            TerminalMode::Echo => terminal.echo_commands(path),
+            TerminalMode::Tab => terminal.open_tab(path, session_id, options),
+            TerminalMode::Window => terminal.open_window(path, session_id, options),
+            TerminalMode::InPlace => terminal.switch_to_directory(path, options),
+            TerminalMode::Echo => terminal.echo_commands(path, options),
             TerminalMode::Current => unreachable!("current mode is handled before terminal lookup"),
         }
     }

--- a/tests/integration/terminal_switch_tests.rs
+++ b/tests/integration/terminal_switch_tests.rs
@@ -109,22 +109,37 @@ fn create_fake_shell(bin_dir: &Path, log_path: &Path) -> PathBuf {
 }
 
 fn write_config(home_dir: &Path, app: &str) {
+    write_config_with_terminal_options(home_dir, app, "tab", true, &[]);
+}
+
+fn write_config_with_terminal_options(
+    home_dir: &Path,
+    app: &str,
+    terminal_mode: &str,
+    auto_activate: bool,
+    init_commands: &[&str],
+) {
     let config_dir = home_dir
         .join("Library")
         .join("Application Support")
         .join("git-warp");
     fs::create_dir_all(&config_dir).unwrap();
+    let init_commands = init_commands
+        .iter()
+        .map(|command| format!("\"{command}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
     fs::write(
         config_dir.join("config.toml"),
         format!(
             r#"
-terminal_mode = "tab"
+terminal_mode = "{terminal_mode}"
 use_cow = false
 
 [terminal]
 app = "{app}"
-auto_activate = true
-init_commands = []
+auto_activate = {auto_activate}
+init_commands = [{init_commands}]
 "#
         ),
     )
@@ -360,5 +375,102 @@ fn test_warp_switch_auto_prefers_current_warp_terminal() {
         "expected Warp URI open call, got open={}, osascript={}",
         open_contents,
         osascript_contents
+    );
+}
+
+#[test]
+fn test_warp_switch_echo_includes_configured_init_commands() {
+    let repo_dir = setup_git_repo();
+    let repo_path = repo_dir.path();
+    let home_dir = tempdir().unwrap();
+
+    write_config_with_terminal_options(
+        home_dir.path(),
+        "auto",
+        "echo",
+        true,
+        &["corepack enable", "pnpm install"],
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_warp"))
+        .args(["switch", "--no-cow", "feature/init-commands"])
+        .current_dir(repo_path)
+        .env("HOME", home_dir.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{stdout}");
+    assert!(stdout.contains("# Navigate to worktree:"), "{stdout}");
+    assert!(stdout.contains("cd '"), "{stdout}");
+    assert!(stdout.contains("corepack enable"), "{stdout}");
+    assert!(stdout.contains("pnpm install"), "{stdout}");
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn test_warp_switch_applescript_activates_when_configured() {
+    let repo_dir = setup_git_repo();
+    let repo_path = repo_dir.path();
+    let home_dir = tempdir().unwrap();
+    let bin_dir = tempdir().unwrap();
+    let osascript_log_dir = tempdir().unwrap();
+    let osascript_log = osascript_log_dir.path().join("osascript.log");
+
+    write_config_with_terminal_options(home_dir.path(), "terminal", "tab", true, &[]);
+    create_fake_osascript(bin_dir.path(), &osascript_log);
+
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    let path_env = format!("{}:{}", bin_dir.path().display(), original_path);
+
+    let output = run_warp_switch(
+        repo_path,
+        "feature/activate-terminal",
+        home_dir.path(),
+        &path_env,
+        "Apple_Terminal",
+    );
+
+    assert!(output.status.success());
+
+    let osascript_contents = fs::read_to_string(&osascript_log).unwrap_or_default();
+    assert!(
+        osascript_contents.contains("\n    activate\n")
+            || osascript_contents.contains("\nactivate\n"),
+        "expected activate command in AppleScript, got {osascript_contents}"
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn test_warp_switch_applescript_skips_activation_when_disabled() {
+    let repo_dir = setup_git_repo();
+    let repo_path = repo_dir.path();
+    let home_dir = tempdir().unwrap();
+    let bin_dir = tempdir().unwrap();
+    let osascript_log_dir = tempdir().unwrap();
+    let osascript_log = osascript_log_dir.path().join("osascript.log");
+
+    write_config_with_terminal_options(home_dir.path(), "terminal", "tab", false, &[]);
+    create_fake_osascript(bin_dir.path(), &osascript_log);
+
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    let path_env = format!("{}:{}", bin_dir.path().display(), original_path);
+
+    let output = run_warp_switch(
+        repo_path,
+        "feature/no-activate-terminal",
+        home_dir.path(),
+        &path_env,
+        "Apple_Terminal",
+    );
+
+    assert!(output.status.success());
+
+    let osascript_contents = fs::read_to_string(&osascript_log).unwrap_or_default();
+    assert!(
+        !osascript_contents.contains("\n    activate\n")
+            && !osascript_contents.contains("\nactivate\n"),
+        "did not expect activate command in AppleScript, got {osascript_contents}"
     );
 }


### PR DESCRIPTION
## Summary
- Thread terminal launch options from config into `warp switch` handoff
- Run configured init commands for shell-printing/current modes and macOS AppleScript terminal handoff
- Make Terminal.app/iTerm activation follow `terminal.auto_activate`
- Show and document `terminal.init_commands`

Closes #7

## Verification
- `cargo test --test mod terminal_switch_tests -- --nocapture` - 8 passed
- `cargo test --test mod config_tests -- --nocapture` - 9 passed
- `cargo fmt --check`
- `git diff --check`