### PR TITLE
Add actionable recovery guidance

### DIFF
--- a/docs/superpowers/plans/2026-04-26-recovery-guidance.md
+++ b/docs/superpowers/plans/2026-04-26-recovery-guidance.md
@@ -1,0 +1,147 @@
+# Recovery Guidance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add concise next-step recovery hints to common Git-Warp failure paths.
+
+**Architecture:** Keep hints in `src/cli.rs` near the existing command flows. Add a small helper for "not in repo" errors, extend switch and cleanup warning text, and reuse `warp doctor` for setup-oriented hooks and CoW guidance.
+
+**Tech Stack:** Rust CLI, `anyhow`, existing integration tests under `tests/integration`.
+
+---
+
+### Task 1: Failing Regression Tests
+
+**Files:**
+- Modify: `tests/integration/cli_surface_tests.rs`
+- Modify: `tests/integration/terminal_switch_tests.rs`
+
+- [ ] **Step 1: Assert repo-bound commands explain where to run**
+
+In `test_switch_rejects_multiple_target_selectors`'s area, add a new test that runs:
+
+```bash
+warp switch feature/demo
+```
+
+from a temp directory that is not a Git repo. Expected stderr contains:
+
+```text
+Not in a Git repository
+Run this command inside a Git repository
+```
+
+- [ ] **Step 2: Assert doctor gives setup recovery commands**
+
+Extend `test_doctor_outside_repo_prints_recovery_guidance` so stdout also contains:
+
+```text
+warp hooks-install --level user --runtime all
+warp switch --no-cow <branch>
+```
+
+- [ ] **Step 3: Assert terminal handoff gives a manual-terminal fallback**
+
+Extend `test_warp_switch_reports_terminal_handoff_failure_as_incomplete` so stdout contains:
+
+```text
+Retry with `--terminal echo`
+```
+
+- [ ] **Step 4: Assert branch/path mismatch gives inspection guidance**
+
+Extend `test_warp_switch_reports_existing_worktree_branch_mismatch_as_incomplete` so stdout contains:
+
+```text
+Use a different --path or run `warp ls`
+```
+
+- [ ] **Step 5: Verify RED**
+
+Run:
+
+```bash
+cargo test --test mod cli_surface_tests::test_switch_outside_repo_prints_recovery_guidance -- --nocapture
+cargo test --test mod cli_surface_tests::test_doctor_outside_repo_prints_recovery_guidance -- --nocapture
+cargo test --test mod terminal_switch_tests::test_warp_switch_reports_terminal_handoff_failure_as_incomplete -- --nocapture
+cargo test --test mod terminal_switch_tests::test_warp_switch_reports_existing_worktree_branch_mismatch_as_incomplete -- --nocapture
+```
+
+Expected: the new assertions fail before implementation.
+
+### Task 2: Recovery Hint Implementation
+
+**Files:**
+- Modify: `src/cli.rs`
+
+- [ ] **Step 1: Add not-in-repo helper**
+
+Add:
+
+```rust
+fn not_in_git_repo_error() -> anyhow::Error {
+    anyhow::anyhow!(
+        "Not in a Git repository. Run this command inside a Git repository, or use `cd <repo>` first."
+    )
+}
+```
+
+Use it where `GitRepository::find().map_err(|_| anyhow::anyhow!("Not in a Git repository"))?` appears.
+
+- [ ] **Step 2: Add switch warning hints**
+
+When branch checkout verification warns because an existing path is on a different branch, append:
+
+```text
+. Use a different --path or run `warp ls` to inspect worktrees.
+```
+
+When terminal handoff fails, append:
+
+```text
+. Retry with `--terminal echo` to print manual commands instead.
+```
+
+- [ ] **Step 3: Add cleanup process hint**
+
+When cleanup finds processes and skips a worktree, print:
+
+```text
+💡 Run `warp cleanup --mode <mode> --kill` to terminate them, use `--force` to ignore them, or stop the process manually.
+```
+
+- [ ] **Step 4: Add doctor CoW fallback hint**
+
+When doctor reports CoW unavailable, add a next step:
+
+```text
+Run `warp switch --no-cow <branch>` to skip CoW checks for a switch.
+```
+
+### Task 3: Verification And Publish
+
+**Files:**
+- Verify changed tests and formatting.
+
+- [ ] **Step 1: Run focused tests**
+
+```bash
+cargo test --test mod cli_surface_tests -- --nocapture
+cargo test --test mod terminal_switch_tests -- --nocapture
+```
+
+- [ ] **Step 2: Run formatting and whitespace checks**
+
+```bash
+cargo fmt --check
+git diff --check
+```
+
+- [ ] **Step 3: Commit and open PR**
+
+```bash
+git add src/cli.rs tests/integration/cli_surface_tests.rs tests/integration/terminal_switch_tests.rs docs/superpowers/specs/2026-04-26-recovery-guidance-design.md docs/superpowers/plans/2026-04-26-recovery-guidance.md
+git commit -m "Add actionable recovery guidance"
+git push -u origin 8-recovery-guidance
+gh pr create --repo denysbutenko/git-warp --base main --head 8-recovery-guidance --title "Add actionable recovery guidance" --body-file /tmp/git-warp-pr-body.md
+```

--- a/docs/superpowers/specs/2026-04-26-recovery-guidance-design.md
+++ b/docs/superpowers/specs/2026-04-26-recovery-guidance-design.md
@@ -1,0 +1,55 @@
+# Recovery Guidance Design
+
+## Source Of Truth
+
+GitHub issue #8, "[P1] Turn common failures into actionable recovery guidance", asks Git-Warp to explain what users should do next for frequent failures. The requested cases are: not in a Git repository, branch/worktree already in use, terminal automation failure, hooks missing, processes blocking cleanup, and Copy-on-Write unavailable. Normal output should stay concise, while raw internals should remain a debug concern.
+
+## Brainstorming
+
+### Options Considered
+
+1. Add a global rich error formatter.
+   - This would cover hard failures consistently, but it touches the executable boundary and risks changing every command's error shape at once.
+
+2. Add focused hints at the failure sites that already print user-facing output.
+   - This is smaller and testable with the current integration harness.
+   - It keeps command-specific advice near the command that knows the correct fallback.
+
+3. Expand `warp doctor` only.
+   - Helpful for setup, but it would not improve live failures during `switch` and `cleanup`.
+
+Recommended approach: option 2, plus a small shared helper for hard "not in repo" errors. It gives immediate recovery guidance where users see the failure without turning normal output into a troubleshooting manual.
+
+## Design
+
+Add short, command-oriented hints to the existing CLI surfaces:
+
+- Not in a Git repository:
+  - Return `Not in a Git repository. Run this command inside a Git repository, or use \`cd <repo>\` first.`
+  - Apply this to `switch`, `ls`, `cleanup`, `agents`, and related repo-bound commands through a helper.
+- Branch/worktree already in use:
+  - When `warp switch --path <existing-path>` finds a different branch at that path, keep the warning but add `Use a different --path or run \`warp ls\` to inspect worktrees.`
+- Terminal automation failure:
+  - Keep the existing incomplete switch summary and `cd` fallback.
+  - Add `Retry with \`--terminal echo\` to print manual commands instead.`
+- Hooks missing:
+  - `warp doctor` already reports `warp hooks-install --level user --runtime all`; keep that as the setup hint.
+- Processes blocking cleanup:
+  - Keep the skip behavior, but add explicit alternatives: `warp cleanup --kill ...`, `--force`, or stop the process manually.
+- Copy-on-Write unavailable:
+  - `warp doctor` should say Git-Warp will fall back to traditional worktree creation and suggest `warp switch --no-cow <branch>` when users want to skip CoW checks.
+
+## Error Handling
+
+Hints should not change exit codes. Hard errors remain hard errors; recoverable switch/cleanup warnings stay in normal output. The hints must be concise and should not dump raw command output unless existing debug logging is enabled.
+
+## Testing
+
+Use focused integration tests:
+
+- `cli_surface_tests`: repo-bound command outside a Git repo prints the new "cd repo" guidance.
+- `terminal_switch_tests`: existing worktree branch mismatch prints the branch/worktree hint.
+- `terminal_switch_tests`: terminal handoff failure prints the `--terminal echo` hint.
+- `cli_surface_tests`: `warp doctor` outside a repo prints the hooks hint and the `--no-cow` fallback.
+
+Run focused tests, formatting, and diff whitespace checks before committing.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -210,6 +210,26 @@ impl SwitchOutcomeReport {
 }
 
 impl Cli {
+    fn not_in_git_repo_error() -> anyhow::Error {
+        anyhow::anyhow!(
+            "Not in a Git repository. Run this command inside a Git repository, or use `cd <repo>` first."
+        )
+    }
+
+    fn create_worktree_with_recovery(
+        git_repo: &crate::git::GitRepository,
+        branch: &str,
+        worktree_path: &Path,
+    ) -> Result<()> {
+        git_repo
+            .create_worktree_and_branch(branch, worktree_path, None)
+            .map_err(|error| {
+                anyhow::anyhow!(
+                    "{error}. Use a different branch name or run `warp ls` to inspect existing worktrees."
+                )
+            })
+    }
+
     pub fn run(&self) -> Result<()> {
         if self.debug {
             unsafe {
@@ -274,8 +294,7 @@ impl Cli {
 
         info!("Starting default worktree switcher");
 
-        let git_repo =
-            GitRepository::find().map_err(|_| anyhow::anyhow!("Not in a Git repository"))?;
+        let git_repo = GitRepository::find().map_err(|_| Self::not_in_git_repo_error())?;
         let worktrees = git_repo.list_worktrees()?;
         let statuses =
             Self::collect_worktree_runtime_statuses(&git_repo, &worktrees, ProcessManager::new());
@@ -401,8 +420,7 @@ impl Cli {
         use crate::terminal::TerminalMode;
 
         // Find the Git repository
-        let git_repo =
-            GitRepository::find().map_err(|_| anyhow::anyhow!("Not in a Git repository"))?;
+        let git_repo = GitRepository::find().map_err(|_| Self::not_in_git_repo_error())?;
         let branch = self.resolve_switch_branch(&git_repo, branch, latest, waiting)?;
 
         info!("Switching to branch: {}", branch);
@@ -450,7 +468,7 @@ impl Cli {
                 println!("⚡ Using Copy-on-Write for instant creation...");
 
                 // Create worktree using traditional method first
-                git_repo.create_worktree_and_branch(&branch, &worktree_path, None)?;
+                Self::create_worktree_with_recovery(&git_repo, &branch, &worktree_path)?;
 
                 // If we have existing worktrees, try CoW enhancement
                 let worktrees = git_repo.list_worktrees()?;
@@ -464,7 +482,7 @@ impl Cli {
                     if let Err(e) = cow::clone_directory(&main_worktree.path, &worktree_path) {
                         log::warn!("CoW failed, falling back to traditional method: {}", e);
                         // Recreate using traditional method
-                        git_repo.create_worktree_and_branch(&branch, &worktree_path, None)?;
+                        Self::create_worktree_with_recovery(&git_repo, &branch, &worktree_path)?;
                     } else {
                         // Rewrite paths in the CoW copy
                         let rewriter = PathRewriter::new(&main_worktree.path, &worktree_path);
@@ -488,7 +506,7 @@ impl Cli {
                 }
             } else {
                 println!("📦 Using traditional Git worktree creation...");
-                git_repo.create_worktree_and_branch(&branch, &worktree_path, None)?;
+                Self::create_worktree_with_recovery(&git_repo, &branch, &worktree_path)?;
             }
 
             if worktree_path.exists() {
@@ -569,7 +587,9 @@ impl Cli {
                     Some(warning) if !warning.is_empty() => {
                         format!("expected {branch}, found {found}; checkout failed: {warning}")
                     }
-                    _ => format!("expected {branch}, found {found}"),
+                    _ => format!(
+                        "expected {branch}, found {found}. Use a different --path or run `warp ls` to inspect worktrees."
+                    ),
                 };
                 report.warned("Branch checkout", detail);
             }
@@ -634,7 +654,12 @@ impl Cli {
             }
             Err(e) => {
                 log::warn!("Terminal switching failed: {}", e);
-                report.warned("Terminal handoff", format!("failed: {e}"));
+                report.warned(
+                    "Terminal handoff",
+                    format!(
+                        "failed: {e}. Retry with `--terminal echo` to print manual commands instead."
+                    ),
+                );
             }
         }
     }
@@ -730,8 +755,7 @@ impl Cli {
 
         info!("Listing worktrees");
 
-        let git_repo =
-            GitRepository::find().map_err(|_| anyhow::anyhow!("Not in a Git repository"))?;
+        let git_repo = GitRepository::find().map_err(|_| Self::not_in_git_repo_error())?;
 
         if self.dry_run {
             println!("Would list all worktrees");
@@ -840,8 +864,7 @@ impl Cli {
 
         info!("Cleaning up worktrees with mode: {}", mode);
 
-        let git_repo =
-            GitRepository::find().map_err(|_| anyhow::anyhow!("Not in a Git repository"))?;
+        let git_repo = GitRepository::find().map_err(|_| Self::not_in_git_repo_error())?;
         let config_manager = ConfigManager::new()?;
         let protected_branches = config_manager.get().git.protected_branches.clone();
         let mut process_manager = ProcessManager::new();
@@ -989,6 +1012,9 @@ impl Cli {
                         } else {
                             println!(
                                 "❌ Processes found in worktree, use --kill to terminate them or --force to ignore"
+                            );
+                            println!(
+                                "💡 Run `warp cleanup --mode {mode} --kill` to terminate them, use `--force` to ignore them, or stop the process manually."
                             );
                             failed += 1;
                             continue;
@@ -1179,7 +1205,8 @@ impl Cli {
         };
 
         let cow_check_path = Self::nearest_existing_parent(&worktree_base);
-        match cow::is_cow_supported(&cow_check_path) {
+        let cow_supported = cow::is_cow_supported(&cow_check_path);
+        match &cow_supported {
             Ok(true) => Self::doctor_ok(
                 "Copy-on-Write",
                 format!(
@@ -1200,6 +1227,12 @@ impl Cli {
             "Terminal",
             format!("mode {}, app {}", config.terminal_mode, config.terminal.app),
         );
+
+        if repo.is_none() || !matches!(cow_supported, Ok(true)) {
+            next_steps.push(
+                "Run `warp switch --no-cow <branch>` to skip CoW checks for a switch.".to_string(),
+            );
+        }
 
         let hooks_installed = Self::doctor_hooks_installed();
         if hooks_installed {
@@ -1282,8 +1315,7 @@ impl Cli {
             return Ok(());
         }
 
-        let git_repo =
-            GitRepository::find().map_err(|_| anyhow::anyhow!("Not in a Git repository"))?;
+        let git_repo = GitRepository::find().map_err(|_| Self::not_in_git_repo_error())?;
         let dashboard =
             AgentsDashboard::new(AgentDiscovery::new(Self::agent_monitored_paths(&git_repo)?));
         dashboard.run()

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -163,6 +163,8 @@ fn test_doctor_outside_repo_prints_recovery_guidance() {
     assert!(stdout.contains("Config file"));
     assert!(stdout.contains("Git repository"));
     assert!(stdout.contains("Run this command inside a Git repository"));
+    assert!(stdout.contains("warp hooks-install --level user --runtime all"));
+    assert!(stdout.contains("warp switch --no-cow <branch>"));
 }
 
 #[test]
@@ -215,6 +217,24 @@ fn test_switch_rejects_multiple_target_selectors() {
 
     assert!(!output.status.success());
     assert!(stderr.contains("exactly one of [BRANCH], --latest, or --waiting"));
+}
+
+#[test]
+fn test_switch_outside_repo_prints_recovery_guidance() {
+    let temp_dir = tempdir().unwrap();
+
+    let output = warp_command(temp_dir.path())
+        .args(["switch", "feature/demo"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success());
+    assert!(stderr.contains("Not in a Git repository"), "{stderr}");
+    assert!(
+        stderr.contains("Run this command inside a Git repository"),
+        "{stderr}"
+    );
 }
 
 #[test]

--- a/tests/integration/terminal_switch_tests.rs
+++ b/tests/integration/terminal_switch_tests.rs
@@ -236,8 +236,35 @@ fn test_warp_switch_reports_terminal_handoff_failure_as_incomplete() {
         "{stdout}"
     );
     assert!(stdout.contains("⚠️  Terminal handoff: failed"), "{stdout}");
+    assert!(stdout.contains("Retry with `--terminal echo`"), "{stdout}");
     assert!(stdout.contains("⚠️  Switch incomplete"), "{stdout}");
     assert!(stdout.contains("💡 Run: cd '"), "{stdout}");
+}
+
+#[test]
+fn test_warp_switch_branch_already_in_use_prints_recovery_guidance() {
+    let repo_dir = setup_git_repo();
+    let repo_path = repo_dir.path();
+    let home_dir = tempdir().unwrap();
+    let worktree_path = repo_path.join("worktrees").join("main-copy");
+
+    write_config(home_dir.path(), "auto");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_warp"))
+        .args(["switch", "--no-cow", "main", "--path"])
+        .arg(&worktree_path)
+        .current_dir(repo_path)
+        .env("HOME", home_dir.path())
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success(), "{stderr}");
+    assert!(stderr.contains("Failed to create worktree"), "{stderr}");
+    assert!(
+        stderr.contains("Use a different branch name or run `warp ls`"),
+        "{stderr}"
+    );
 }
 
 #[test]
@@ -293,6 +320,10 @@ fn test_warp_switch_reports_existing_worktree_branch_mismatch_as_incomplete() {
     );
     assert!(
         stdout.contains("⚠️  Branch checkout: expected feature/wrong"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("Use a different --path or run `warp ls`"),
         "{stdout}"
     );
     assert!(stdout.contains("⚠️  Switch incomplete"), "{stdout}");


### PR DESCRIPTION
## Summary
- add concise recovery hints for repo-bound commands, branch/worktree conflicts, terminal handoff failures, cleanup process blockers, and CoW fallback
- extend `warp doctor` next steps for hooks and `--no-cow`
- cover the hints with CLI surface and terminal switch integration tests

Closes #8

## Verification
- `cargo test --test mod cli_surface_tests -- --nocapture` - 14 passed
- `cargo test --test mod terminal_switch_tests -- --nocapture` - 9 passed
- `cargo fmt --check`
- `git diff --check`
