### PR TITLE
Improve TUI legibility and keyboard ergonomics

### DIFF
--- a/docs/superpowers/plans/2026-04-26-tui-ergonomics.md
+++ b/docs/superpowers/plans/2026-04-26-tui-ergonomics.md
@@ -1,0 +1,103 @@
+# TUI Ergonomics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the agents and cleanup TUIs easier to scan and operate on first use.
+
+**Architecture:** Keep the existing `src/tui.rs` architecture, but move user-visible semantics into small model helpers that can be unit tested without terminal snapshots. Rendering will consume those model fields and keyboard handling will add expected aliases without changing existing commands.
+
+**Tech Stack:** Rust, ratatui, crossterm, existing Cargo unit tests.
+
+---
+
+### Task 1: Agents Dashboard Semantics
+
+**Files:**
+- Modify: `src/tui.rs`
+- Modify: `tests/unit/tui_tests.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add assertions that `build_dashboard_model` exposes `state_label`, that empty-state copy is action-oriented, and that `session_detail_lines` includes a plain `State:` line.
+
+Run: `cargo test --test mod test_build_dashboard_model_empty_state test_session_detail_lines_include_expected_fields -- --nocapture`
+
+Expected: FAIL because `DashboardRow::state_label` and `State:` do not exist yet.
+
+- [ ] **Step 2: Implement the model fields**
+
+Add `state_label` to `DashboardRow`, add `session_state_label`, populate it in `build_dashboard_model`, and include it in `session_detail_lines`.
+
+- [ ] **Step 3: Update dashboard rendering**
+
+Render agents rows as symbol plus plain state, runtime, location, agent, and relative time. Keep selection styling and details panel unchanged except for the new state line.
+
+- [ ] **Step 4: Verify agents tests**
+
+Run: `cargo test --test mod test_build_dashboard_model_empty_state test_session_detail_lines_include_expected_fields -- --nocapture`
+
+Expected: PASS.
+
+### Task 2: Cleanup Row Model and Bulk Selection
+
+**Files:**
+- Modify: `src/tui.rs`
+- Modify: `tests/unit/tui_tests.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add tests for a public `build_cleanup_rows` helper and `next_bulk_selection_state` helper. The row test should cover merged, remote, dirty state and assert display text contains plain words instead of relying on emoji-only meaning.
+
+Run: `cargo test --test mod cleanup -- --nocapture`
+
+Expected: FAIL because the cleanup helpers do not exist.
+
+- [ ] **Step 2: Implement cleanup helpers**
+
+Create `CleanupRow` with `branch`, `path_label`, `reason_label`, `remote_label`, `dirty_label`, and `display_line`. Implement `build_cleanup_rows(statuses, selected)` and `next_bulk_selection_state(selected)` in `src/tui.rs`.
+
+- [ ] **Step 3: Wire cleanup rendering**
+
+Use `build_cleanup_rows` inside `CleanupTui::run`, change the header to `Worktree cleanup`, update the list title to explain the screen, and update the footer to include `a: Toggle all` and `Esc: Cancel`.
+
+- [ ] **Step 4: Add keyboard aliases**
+
+Handle `j` as down, `k` as up, `a` as select/clear all, and `Esc` as cancel in cleanup. Add `j/k` aliases to agents and worktree switcher navigation.
+
+- [ ] **Step 5: Verify cleanup tests**
+
+Run: `cargo test --test mod cleanup -- --nocapture`
+
+Expected: PASS.
+
+### Task 3: Final Verification
+
+**Files:**
+- Modify: `src/tui.rs`
+- Modify: `tests/unit/tui_tests.rs`
+- Create: `docs/superpowers/specs/2026-04-26-tui-ergonomics-design.md`
+- Create: `docs/superpowers/plans/2026-04-26-tui-ergonomics.md`
+
+- [ ] **Step 1: Format**
+
+Run: `cargo fmt --check`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run focused TUI tests**
+
+Run: `cargo test --test mod tui_tests -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run adjacent agents tests**
+
+Run: `cargo test --test mod agents_tests -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 4: Check patch hygiene**
+
+Run: `git diff --check`
+
+Expected: PASS.

--- a/docs/superpowers/specs/2026-04-26-tui-ergonomics-design.md
+++ b/docs/superpowers/specs/2026-04-26-tui-ergonomics-design.md
@@ -1,0 +1,36 @@
+# TUI Ergonomics Design
+
+GitHub issue #9, "[P2] Improve TUI legibility and keyboard ergonomics", asks the cleanup and agents TUIs to become easier to scan and operate on first use. The current screens work, but they lean on compact symbols, footer-only controls, and inline cleanup rendering that is hard to test.
+
+## Approaches Considered
+
+1. Full TUI redesign with new layout primitives.
+   - This could produce a larger visual jump, but it would be high-risk for a small issue and hard to verify without snapshot infrastructure.
+2. Model-first semantic polish.
+   - Add explicit labels, status descriptions, and reusable row text builders, then let existing ratatui screens render those improved model fields.
+   - This is the recommended approach because existing tests already cover TUI models.
+3. Documentation-only guidance.
+   - This would explain controls, but it would not improve first-use operation inside the actual screens.
+
+## Design
+
+Agents dashboard rows will keep their compact status symbol, but every row will also carry a plain-language state label such as `working`, `waiting`, or `recent`. The row text should show runtime, state, location, agent, and relative time so users do not need a legend to decode symbols. Details will also include the plain state. The empty state will explicitly say that there are no sessions to show, mention the 7-day recent-history window, and point to hook installation for live monitoring.
+
+Cleanup TUI row rendering will move from anonymous inline string formatting into a small `CleanupRow` model. Each row will expose a checkbox, branch, reason, remote label, dirty label, and a combined display line. The cleanup screen will use text-backed status words (`merged`, `identical`, `remote`, `no remote`, `dirty`) instead of emoji-only meaning. The title and footer will name the important actions directly: `Space` toggles a row, `a` toggles all rows, `Enter` confirms, and `q/Esc` cancels.
+
+Keyboard behavior will add two low-cost affordances where the current screens are stiff: `j/k` will mirror down/up navigation for agents, switcher, and cleanup; cleanup will support `a` to select or clear all candidates; cleanup will support `Esc` as cancel. These keys supplement the existing controls and do not remove current behavior.
+
+## Boundaries
+
+This change will not introduce terminal screenshot tests, new dependencies, async event handling, or a new TUI architecture. Verification should stay focused on unit tests for model semantics plus the existing TUI-adjacent test suite.
+
+## Testing
+
+Add failing unit tests first for:
+
+- agents dashboard rows exposing text status labels and clearer empty-state copy,
+- session detail lines including plain state,
+- cleanup row display explaining candidate reason, remote status, and dirty state,
+- cleanup selection helper deciding whether `a` selects all or clears all.
+
+Then update the TUI rendering and keyboard handling until those tests pass, followed by `cargo fmt --check`, focused unit tests, and `git diff --check`.

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -4,7 +4,7 @@ use crate::{
         sort_session_summaries,
     },
     error::Result,
-    git::WorktreeInfo,
+    git::{BranchStatus, WorktreeInfo},
 };
 use chrono::{DateTime, Duration as ChronoDuration, Local};
 use crossterm::{
@@ -76,6 +76,7 @@ impl Drop for TuiTerminalGuard {
 pub struct DashboardRow {
     pub session: AgentSessionSummary,
     pub state_symbol: &'static str,
+    pub state_label: &'static str,
     pub runtime_label: &'static str,
     pub location_label: String,
     pub agent_label: String,
@@ -115,6 +116,16 @@ pub struct WorktreeSwitchRow {
 pub struct WorktreeSwitchModel {
     pub rows: Vec<WorktreeSwitchRow>,
     pub empty_state_lines: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct CleanupRow {
+    pub branch: String,
+    pub path_label: String,
+    pub reason_label: &'static str,
+    pub remote_label: &'static str,
+    pub dirty_label: &'static str,
+    pub display_line: String,
 }
 
 impl WorktreeSwitchModel {
@@ -199,12 +210,12 @@ impl TuiApp {
                         KeyCode::Esc => {
                             self.should_quit = true;
                         }
-                        KeyCode::Up => {
+                        KeyCode::Up | KeyCode::Char('k') => {
                             if self.selected_index > 0 {
                                 self.selected_index -= 1;
                             }
                         }
-                        KeyCode::Down => {
+                        KeyCode::Down | KeyCode::Char('j') => {
                             if self.selected_index < self.sessions.len().saturating_sub(1) {
                                 self.selected_index += 1;
                             }
@@ -277,11 +288,12 @@ impl TuiApp {
                 .iter()
                 .map(|row| {
                     let text = format!(
-                        "{} {:<6} {:<18} {:<20} {}",
+                        "{} {:<6} {:<10} {:<18} {:<18} {}",
                         row.state_symbol,
                         row.runtime_label,
+                        truncate_label(row.state_label, 10),
                         truncate_label(&row.location_label, 18),
-                        truncate_label(&row.agent_label, 20),
+                        truncate_label(&row.agent_label, 18),
                         row.relative_time
                     );
                     let style = Style::default().fg(session_state_color(row.session.state));
@@ -312,7 +324,7 @@ impl TuiApp {
         }
 
         // Help
-        let help_text = "↑↓: Navigate | r: Refresh | q/Esc: Quit";
+        let help_text = "↑↓/jk: Navigate | r: Refresh | q/Esc: Quit";
         let help = Paragraph::new(help_text)
             .style(Style::default().fg(Color::Gray))
             .alignment(Alignment::Center)
@@ -412,6 +424,7 @@ pub fn build_dashboard_model(
         .into_iter()
         .map(|session| DashboardRow {
             state_symbol: session_state_symbol(session.state),
+            state_label: session_state_label(session.state),
             runtime_label: runtime_label(session.runtime),
             location_label: session_location_label(&session),
             agent_label: session.agent_label.clone(),
@@ -422,8 +435,8 @@ pub fn build_dashboard_model(
 
     let empty_state_lines = if rows.is_empty() {
         vec![
-            "No live or recent Claude/Codex sessions found for this repo in the last 7 days."
-                .to_string(),
+            "No agent sessions to show for this repository.".to_string(),
+            "Recent Claude/Codex sessions appear here for 7 days.".to_string(),
             "Hint: run `warp hooks-install --runtime all --level user` to enable live monitoring."
                 .to_string(),
         ]
@@ -447,6 +460,7 @@ pub fn session_detail_lines(session: &AgentSessionSummary) -> Vec<String> {
         ),
         format!("Runtime: {}", runtime_label(session.runtime)),
         format!("Branch: {}", session.branch.as_deref().unwrap_or("-")),
+        format!("State: {}", session_state_label(session.state)),
         format!(
             "Presence: {}",
             if session.is_live { "live" } else { "recent" }
@@ -460,10 +474,21 @@ fn session_state_symbol(state: AgentSessionState) -> &'static str {
     match state {
         AgentSessionState::Working => "●",
         AgentSessionState::Processing => "◔",
-        AgentSessionState::Waiting => "⏳",
+        AgentSessionState::Waiting => "!",
         AgentSessionState::Completed => "✓",
         AgentSessionState::Recent => "○",
         AgentSessionState::Unknown => "?",
+    }
+}
+
+fn session_state_label(state: AgentSessionState) -> &'static str {
+    match state {
+        AgentSessionState::Working => "working",
+        AgentSessionState::Processing => "processing",
+        AgentSessionState::Waiting => "waiting",
+        AgentSessionState::Completed => "complete",
+        AgentSessionState::Recent => "recent",
+        AgentSessionState::Unknown => "unknown",
     }
 }
 
@@ -691,10 +716,10 @@ impl WorktreeSwitchTui {
 
                 match key.code {
                     KeyCode::Char('q') | KeyCode::Esc => return Ok(None),
-                    KeyCode::Up => {
+                    KeyCode::Up | KeyCode::Char('k') => {
                         selected_index = selected_index.saturating_sub(1);
                     }
-                    KeyCode::Down => {
+                    KeyCode::Down | KeyCode::Char('j') => {
                         selected_index =
                             (selected_index + 1).min(self.model.rows.len().saturating_sub(1));
                     }
@@ -776,11 +801,68 @@ fn draw_worktree_switcher(f: &mut Frame, model: &WorktreeSwitchModel, selected_i
         f.render_widget(details, chunks[2]);
     }
 
-    let help = Paragraph::new("↑↓: Navigate | Enter: Switch | q/Esc: Quit")
+    let help = Paragraph::new("↑↓/jk: Navigate | Enter: Switch | q/Esc: Quit")
         .style(Style::default().fg(Color::Gray))
         .alignment(Alignment::Center)
         .block(Block::default().borders(Borders::ALL).title("Help"));
     f.render_widget(help, chunks[3]);
+}
+
+pub fn build_cleanup_rows(statuses: &[BranchStatus], selected: &[bool]) -> Vec<CleanupRow> {
+    statuses
+        .iter()
+        .enumerate()
+        .map(|(index, status)| {
+            let checked = if selected.get(index).copied().unwrap_or(false) {
+                "[x]"
+            } else {
+                "[ ]"
+            };
+            let reason_label = cleanup_reason_label(status);
+            let remote_label = if status.has_remote {
+                "remote"
+            } else {
+                "no remote"
+            };
+            let dirty_label = if status.has_uncommitted_changes {
+                "dirty"
+            } else {
+                "clean"
+            };
+            let path_label = status.path.display().to_string();
+            let display_line = format!(
+                "{checked} {:<28} {:<9} {:<9} {:<5} {}",
+                truncate_label(&status.branch, 28),
+                reason_label,
+                remote_label,
+                dirty_label,
+                path_label
+            );
+
+            CleanupRow {
+                branch: status.branch.clone(),
+                path_label,
+                reason_label,
+                remote_label,
+                dirty_label,
+                display_line,
+            }
+        })
+        .collect()
+}
+
+pub fn next_bulk_selection_state(selected: &[bool]) -> bool {
+    !selected.is_empty() && !selected.iter().all(|is_selected| *is_selected)
+}
+
+fn cleanup_reason_label(status: &BranchStatus) -> &'static str {
+    if status.is_merged {
+        "merged"
+    } else if status.is_identical {
+        "identical"
+    } else {
+        "candidate"
+    }
 }
 
 pub struct CleanupTui;
@@ -850,60 +932,42 @@ impl CleanupTui {
                     .split(f.size());
 
                 // Header
-                let header = Paragraph::new("🧹 Interactive Worktree Cleanup")
+                let header = Paragraph::new(format!(
+                    "Worktree cleanup ({} candidates)",
+                    branch_statuses.len()
+                ))
                     .style(Style::default().fg(Color::Yellow))
                     .alignment(Alignment::Center)
                     .block(Block::default().borders(Borders::ALL));
                 f.render_widget(header, chunks[0]);
 
                 // Branch list
-                let items: Vec<ListItem> = branch_statuses
+                let rows = build_cleanup_rows(&branch_statuses, &selected_branches);
+                let items: Vec<ListItem> = rows
                     .iter()
                     .enumerate()
-                    .map(|(i, status)| {
-                        let checkbox = if selected_branches[i] {
-                            "☑️"
-                        } else {
-                            "☐"
-                        };
-                        let merged_indicator = if status.is_merged { "✅" } else { "🔄" };
+                    .map(|(i, row)| {
                         let style = if i == selected_index {
                             Style::default().bg(Color::Blue).fg(Color::White)
                         } else {
                             Style::default()
                         };
 
-                        ListItem::new(format!(
-                            "{} {} {} - {}{}",
-                            checkbox,
-                            merged_indicator,
-                            status.branch,
-                            if status.has_remote {
-                                "with remote"
-                            } else {
-                                "no remote"
-                            },
-                            if status.has_uncommitted_changes {
-                                " (uncommitted)"
-                            } else {
-                                ""
-                            }
-                        ))
-                        .style(style)
+                        ListItem::new(row.display_line.clone()).style(style)
                     })
                     .collect();
 
                 let list = List::new(items).block(
                     Block::default()
                         .borders(Borders::ALL)
-                        .title("Select branches to clean up (Space to select, Enter to confirm)"),
+                        .title("Space toggles a branch; Enter removes selected branches"),
                 );
                 f.render_widget(list, chunks[1]);
 
                 // Footer with controls
                 let selected_count = selected_branches.iter().filter(|&&x| x).count();
                 let footer_text = format!(
-                    "↑↓: Navigate | Space: Select | Enter: Confirm ({} selected) | q: Quit",
+                    "↑↓/jk: Navigate | Space: Toggle | a: Toggle all | Enter: Confirm ({} selected) | q/Esc: Cancel",
                     selected_count
                 );
                 let footer = Paragraph::new(footer_text)
@@ -917,22 +981,26 @@ impl CleanupTui {
             if let Event::Key(key) = event::read()? {
                 if key.kind == KeyEventKind::Press {
                     match key.code {
-                        KeyCode::Char('q') => {
+                        KeyCode::Char('q') | KeyCode::Esc => {
                             should_quit = true;
                             break;
                         }
-                        KeyCode::Up => {
+                        KeyCode::Up | KeyCode::Char('k') => {
                             if selected_index > 0 {
                                 selected_index -= 1;
                             }
                         }
-                        KeyCode::Down => {
+                        KeyCode::Down | KeyCode::Char('j') => {
                             if selected_index < branch_statuses.len() - 1 {
                                 selected_index += 1;
                             }
                         }
                         KeyCode::Char(' ') => {
                             selected_branches[selected_index] = !selected_branches[selected_index];
+                        }
+                        KeyCode::Char('a') => {
+                            let select_all = next_bulk_selection_state(&selected_branches);
+                            selected_branches.fill(select_all);
                         }
                         KeyCode::Enter => {
                             confirmed = true;
@@ -1010,7 +1078,7 @@ mod tests {
             build_dashboard_model(&[], Local.with_ymd_and_hms(2026, 4, 23, 12, 0, 0).unwrap());
 
         assert!(model.rows.is_empty());
-        assert_eq!(model.empty_state_lines.len(), 2);
+        assert_eq!(model.empty_state_lines.len(), 3);
     }
 
     #[test]

--- a/tests/unit/tui_tests.rs
+++ b/tests/unit/tui_tests.rs
@@ -2,10 +2,10 @@ use chrono::{Local, TimeZone};
 use git_warp::agents::{
     AgentDiscovery, AgentRuntime, AgentSessionSource, AgentSessionState, AgentSessionSummary,
 };
-use git_warp::git::WorktreeInfo;
+use git_warp::git::{BranchStatus, WorktreeInfo};
 use git_warp::tui::{
-    AgentsDashboard, WorktreeRuntimeStatus, build_dashboard_model, build_worktree_switch_model,
-    session_detail_lines,
+    AgentsDashboard, WorktreeRuntimeStatus, build_cleanup_rows, build_dashboard_model,
+    build_worktree_switch_model, next_bulk_selection_state, session_detail_lines,
 };
 use std::{
     path::PathBuf,
@@ -46,8 +46,8 @@ fn test_build_dashboard_model_empty_state() {
     assert_eq!(
         model.empty_state_lines,
         vec![
-            "No live or recent Claude/Codex sessions found for this repo in the last 7 days."
-                .to_string(),
+            "No agent sessions to show for this repository.".to_string(),
+            "Recent Claude/Codex sessions appear here for 7 days.".to_string(),
             "Hint: run `warp hooks-install --runtime all --level user` to enable live monitoring."
                 .to_string(),
         ]
@@ -140,6 +140,7 @@ fn test_session_detail_lines_include_expected_fields() {
     assert!(lines.iter().any(|line| line == "Session ID: session-123"));
     assert!(lines.iter().any(|line| line == "Runtime: Codex"));
     assert!(lines.iter().any(|line| line == "Branch: feat/agents"));
+    assert!(lines.iter().any(|line| line == "State: working"));
     assert!(lines.iter().any(|line| line == "Presence: live"));
     assert!(
         lines
@@ -166,6 +167,26 @@ fn test_build_dashboard_model_renders_future_timestamps_explicitly() {
 
     assert_eq!(model.rows.len(), 1);
     assert_eq!(model.rows[0].relative_time, "in 5m");
+}
+
+#[test]
+fn test_build_dashboard_model_exposes_plain_state_labels() {
+    let now = Local.with_ymd_and_hms(2026, 4, 23, 12, 0, 0).unwrap();
+    let sessions = vec![sample_summary(
+        AgentRuntime::Codex,
+        "waiting-session",
+        "/repo/.worktrees/waiting",
+        AgentSessionState::Waiting,
+        11,
+        true,
+        AgentSessionSource::LiveStatus,
+    )];
+
+    let model = build_dashboard_model(&sessions, now);
+
+    assert_eq!(model.rows.len(), 1);
+    assert_eq!(model.rows[0].state_symbol, "!");
+    assert_eq!(model.rows[0].state_label, "waiting");
 }
 
 #[test]
@@ -304,4 +325,42 @@ fn test_worktree_switch_model_returns_selected_target() {
     assert_eq!(target.branch.as_deref(), Some("feature/default-picker"));
     assert_eq!(target.path, PathBuf::from("/repo/.worktrees/feature"));
     assert!(model.target_at(1).is_none());
+}
+
+#[test]
+fn test_build_cleanup_rows_explains_candidate_status_with_text() {
+    let rows = build_cleanup_rows(
+        &[BranchStatus {
+            branch: "feature/old".to_string(),
+            path: PathBuf::from("/repo/.worktrees/feature-old"),
+            has_remote: true,
+            is_merged: true,
+            is_identical: false,
+            has_uncommitted_changes: true,
+        }],
+        &[true],
+    );
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].branch, "feature/old");
+    assert_eq!(rows[0].reason_label, "merged");
+    assert_eq!(rows[0].remote_label, "remote");
+    assert_eq!(rows[0].dirty_label, "dirty");
+    assert!(rows[0].display_line.contains("[x]"));
+    assert!(rows[0].display_line.contains("merged"));
+    assert!(rows[0].display_line.contains("remote"));
+    assert!(rows[0].display_line.contains("dirty"));
+    assert!(
+        rows[0]
+            .display_line
+            .contains("/repo/.worktrees/feature-old")
+    );
+}
+
+#[test]
+fn test_next_bulk_selection_state_selects_all_unless_all_are_selected() {
+    assert!(next_bulk_selection_state(&[false, false]));
+    assert!(next_bulk_selection_state(&[true, false]));
+    assert!(!next_bulk_selection_state(&[true, true]));
+    assert!(!next_bulk_selection_state(&[]));
 }


### PR DESCRIPTION
## Summary
- add plain-language state labels and clearer empty state copy to the agents dashboard
- make cleanup rows text-backed with reason, remote, dirty, and path labels
- add jk navigation aliases plus cleanup Esc cancel and a toggle-all controls

Closes #9

## Verification
- cargo test --test mod tui_tests -- --nocapture - 11 passed
- cargo test --test mod agents_tests -- --nocapture - 13 passed
- cargo fmt --check
- git diff --check
