### PR TITLE
feat: add branch autocomplete

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -131,6 +131,15 @@ pub enum Commands {
         /// Shell type: bash, zsh, fish
         shell: Option<String>,
     },
+
+    /// Internal shell completion helper
+    #[command(name = "__complete", hide = true)]
+    Complete {
+        /// Completion target
+        target: String,
+        /// Current token prefix
+        prefix: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -284,6 +293,9 @@ impl Cli {
             }
             Commands::HooksStatus { runtime } => self.handle_hooks_status(runtime),
             Commands::ShellConfig { shell } => self.handle_shell_config(shell.as_deref()),
+            Commands::Complete { target, prefix } => {
+                self.handle_complete(target, prefix.as_deref())
+            }
         }
     }
 
@@ -1386,6 +1398,24 @@ impl Cli {
                     "{}",
                     r#"warp_cd() { eval "$(warp --terminal echo "$@")"; }"#
                 );
+                println!(
+                    "{}",
+                    r#"_warp_completion() {
+    local cur prev commands branches
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    commands="switch ls list cleanup config agents doctor hooks-install hooks-remove hooks-status shell-config"
+
+    if [[ "$prev" == "switch" ]]; then
+        branches="$(warp __complete branches "$cur" 2>/dev/null)"
+        COMPREPLY=($(compgen -W "$branches" -- "$cur"))
+    elif [[ $COMP_CWORD -eq 1 ]]; then
+        branches="$(warp __complete branches "$cur" 2>/dev/null)"
+        COMPREPLY=($(compgen -W "$commands $branches" -- "$cur"))
+    fi
+}
+complete -F _warp_completion warp"#
+                );
             }
             "zsh" => {
                 println!("# Add to ~/.zshrc");
@@ -1393,12 +1423,39 @@ impl Cli {
                     "{}",
                     r#"warp_cd() { eval "$(warp --terminal echo "$@")"; }"#
                 );
+                println!(
+                    "{}",
+                    r#"_warp_branch_completions() {
+    local -a branches
+    branches=("${(@f)$(warp __complete branches "$PREFIX" 2>/dev/null)}")
+    compadd -- "${branches[@]}"
+}
+
+_warp_completion() {
+    local -a commands
+    commands=(switch ls list cleanup config agents doctor hooks-install hooks-remove hooks-status shell-config)
+
+    if (( CURRENT == 2 )); then
+        compadd -- "${commands[@]}"
+        _warp_branch_completions
+    elif [[ ${words[2]} == switch && CURRENT == 3 ]]; then
+        _warp_branch_completions
+    fi
+}
+compdef _warp_completion warp"#
+                );
             }
             "fish" => {
                 println!("# Add to ~/.config/fish/config.fish");
                 println!("function warp_cd");
                 println!("    eval (warp --terminal echo $argv)");
                 println!("end");
+                println!(
+                    "{}",
+                    r#"complete -c warp -n '__fish_use_subcommand' -a 'switch ls list cleanup config agents doctor hooks-install hooks-remove hooks-status shell-config'
+complete -c warp -n '__fish_use_subcommand' -f -a '(warp __complete branches (commandline -ct) 2>/dev/null)'
+complete -c warp -n '__fish_seen_subcommand_from switch' -f -a '(warp __complete branches (commandline -ct) 2>/dev/null)'"#
+                );
             }
             other => {
                 return Err(anyhow::anyhow!(
@@ -1407,6 +1464,22 @@ impl Cli {
             }
         }
         Ok(())
+    }
+
+    fn handle_complete(&self, target: &str, prefix: Option<&str>) -> Result<()> {
+        match target {
+            "branches" => {
+                let git_repo =
+                    crate::git::GitRepository::find().map_err(|_| Self::not_in_git_repo_error())?;
+                for branch in git_repo.list_local_branches_matching_prefix(prefix.unwrap_or(""))? {
+                    println!("{branch}");
+                }
+                Ok(())
+            }
+            other => Err(anyhow::anyhow!(
+                "Unsupported completion target '{other}'. Supported targets: branches"
+            )),
+        }
     }
 
     fn open_in_editor(path: &Path) -> Result<()> {

--- a/src/git.rs
+++ b/src/git.rs
@@ -403,6 +403,32 @@ impl GitRepository {
         Ok(output.status.success())
     }
 
+    /// List local branches matching a prefix for shell completion
+    pub fn list_local_branches_matching_prefix(&self, prefix: &str) -> Result<Vec<String>> {
+        use std::process::Command;
+
+        let output = Command::new("git")
+            .args(["for-each-ref", "--format=%(refname:short)", "refs/heads"])
+            .current_dir(&self.repo_path)
+            .output()
+            .map_err(|e| anyhow::anyhow!("Failed to list local branches: {}", e))?;
+
+        if !output.status.success() {
+            let error = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow::anyhow!("Failed to list local branches: {}", error).into());
+        }
+
+        let mut branches: Vec<String> = String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .filter(|branch| branch.starts_with(prefix))
+            .map(str::to_string)
+            .collect();
+        branches.sort();
+        branches.dedup();
+
+        Ok(branches)
+    }
+
     /// Get the current HEAD commit
     pub fn get_head_commit(&self) -> Result<String> {
         use std::process::Command;

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -411,4 +411,59 @@ fn test_shell_config_bash_outputs_reusable_function() {
     assert!(output.status.success());
     assert!(stdout.contains("warp_cd()"));
     assert!(stdout.contains("warp --terminal echo"));
+    assert!(stdout.contains("complete -F _warp_completion warp"));
+    assert!(stdout.contains("warp __complete branches \"$cur\""));
+}
+
+#[test]
+fn test_complete_branches_outputs_local_branches_matching_prefix() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+
+    run_git(repo_path, &["branch", "261-autocomplete"]);
+    run_git(repo_path, &["branch", "261-other"]);
+    run_git(repo_path, &["branch", "feature/261-nested"]);
+
+    let output = warp_command(repo_path)
+        .args(["__complete", "branches", "261"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{stdout}");
+    assert!(stdout.contains("261-autocomplete"));
+    assert!(stdout.contains("261-other"));
+    assert!(!stdout.contains("feature/261-nested"));
+    assert!(!stdout.contains("main"));
+}
+
+#[test]
+fn test_shell_config_zsh_outputs_branch_completion_for_root_and_switch() {
+    let output = Command::new(env!("CARGO_BIN_EXE_warp"))
+        .args(["shell-config", "zsh"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success());
+    assert!(stdout.contains("warp_cd()"));
+    assert!(stdout.contains("compdef _warp_completion warp"));
+    assert!(stdout.contains("warp __complete branches \"$PREFIX\""));
+    assert!(stdout.contains("CURRENT == 2"));
+    assert!(stdout.contains("${words[2]} == switch && CURRENT == 3"));
+}
+
+#[test]
+fn test_shell_config_fish_outputs_branch_completion_for_root_and_switch() {
+    let output = Command::new(env!("CARGO_BIN_EXE_warp"))
+        .args(["shell-config", "fish"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success());
+    assert!(stdout.contains("function warp_cd"));
+    assert!(stdout.contains("__fish_use_subcommand"));
+    assert!(stdout.contains("__fish_seen_subcommand_from switch"));
+    assert!(stdout.contains("warp __complete branches (commandline -ct)"));
 }


### PR DESCRIPTION
## Summary
- add a hidden branch completion helper for local branch prefix matching
- wire bash, zsh, and fish shell-config output to complete branches at `warp <branch>` and `warp switch <branch>`
- cover the completion helper and generated shell snippets in CLI surface tests

## Testing
- `cargo test --test mod cli_surface_tests -- --nocapture`
- `cargo fmt --check`
- `git diff --check`