### PR TITLE
Align docs with shipped CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,235 +1,159 @@
-# Git-Warp v0.3.0
+# Git-Warp
 
-**High-performance, UX-focused Git worktree manager with Claude Code integration**
+Fast, safety-focused Git worktree management with terminal handoff, cleanup
+helpers, and optional Claude/Codex session visibility.
 
-Git-Warp combines instantaneous Copy-on-Write worktree creation with rich user experience, terminal integration, and AI agent monitoring. Built in Rust for maximum performance and reliability.
+Git-Warp is a Rust CLI for creating, switching, listing, and cleaning Git
+worktrees. On macOS/APFS it can use Copy-on-Write cloning for faster worktree
+creation, and it falls back to normal `git worktree` creation when CoW is not
+available.
 
-## 🚀 What Makes Git-Warp Special
+## What It Does Today
 
-- **⚡ Instant worktree creation** using Copy-on-Write (CoW) on supported filesystems
-- **🤖 AI agent integration** with live Claude Code monitoring and hooks
-- **🖥️ Rich terminal integration** with automatic tab/window switching  
-- **🧹 Interactive cleanup** with intelligent branch analysis
-- **⚙️ Comprehensive configuration** system with multiple layers
-- **🔍 Process management** with safety checks and cleanup
-- **📊 Live dashboards** for real-time agent activity monitoring
+- Creates or switches to branch worktrees with `warp switch <branch>` or the
+  short form `warp <branch>`.
+- Opens the selected worktree in a terminal tab/window, starts a shell in the
+  current terminal, or prints the target path/command.
+- Lists worktrees with primary/current/dirty/detached/busy state.
+- Cleans up eligible worktrees with dry-run, interactive selection, process
+  checks, protected branches, and optional process termination.
+- Checks local setup with `warp doctor`.
+- Installs, removes, and reports Claude/Codex hooks for live session tracking.
+- Shows a TUI dashboard for live hook data and recent local agent sessions.
+- Generates shell completion snippets for Bash, Zsh, and Fish.
 
-## 📋 Current Status: ✅ PRODUCTION READY
+## Install
 
-### **✅ v0.1.0 - Foundation (COMPLETE)**
-- ✅ Complete CLI interface with all commands
-- ✅ Copy-on-Write engine for macOS (APFS)
-- ✅ Full Git operations using gix + CLI hybrid
-- ✅ Path rewriting for environment compatibility
-- ✅ Cross-platform terminal abstraction
-
-### **✅ v0.2.0 - Advanced Features (COMPLETE)** 
-- ✅ **Claude Code Hooks**: Complete integration with agent tracking
-- ✅ **Configuration System**: Layered config (file + env + CLI)
-- ✅ **Terminal Integration**: macOS automation with AppleScript
-- ✅ **Process Management**: Detection, termination, safety checks
-
-### **✅ v0.3.0 - Interactive Experience (COMPLETE)**
-- ✅ **Live Agent Dashboard**: Real-time Claude Code activity monitoring
-- ✅ **Interactive Cleanup**: TUI for worktree selection and management
-- ✅ **Enhanced CLI**: Rich output with emojis and progress indicators
-- ✅ **Safety Features**: Dry-run mode, process detection, confirmations
-
-## 🛠️ Installation & Setup
-
-### Prerequisites
-- **Rust**: 2024 edition (latest stable)
-- **Git**: Modern git installation  
-- **macOS**: For optimal CoW support (APFS filesystem)
-- **Claude Code**: For AI agent integration (optional)
-
-### Quick Install
 ```bash
-# Clone and build
 git clone https://github.com/denysbutenko/git-warp
 cd git-warp
 cargo build --release
-
-# Make it available globally (optional)
 cargo install --path .
+warp --help
+```
 
-# Test installation
-./target/release/warp --help
+Run the setup check before using it in another repository:
 
-# Check setup and next steps
+```bash
 warp doctor
 ```
 
-### Claude Code Integration Setup
-```bash
-# Install hooks for agent monitoring
-warp hooks-install --level user     # For all projects  
-warp hooks-install --level project  # For current project only
+## Quick Start
 
-# Verify integration
-warp hooks-status
-
-# Start monitoring dashboard
-warp agents
-```
-
-## 🎯 Complete Feature Guide
-
-### **Core Worktree Management**
+From inside any Git repository:
 
 ```bash
-# Check repo, config, CoW, terminal, and hooks setup
-warp doctor
+# Create or switch to a branch worktree
+warp switch feature/new-ui
 
-# List all worktrees with status
+# Short form for the same flow
+warp feature/new-ui
+
+# List known worktrees and their state
 warp ls
 
-# Create/switch to worktree (with CoW on APFS)
-warp switch feature/new-feature
-warp feature/new-feature  # Short form
+# Preview cleanup before deleting anything
+warp --dry-run cleanup --mode merged
 
-# Reopen the most recent or waiting agent branch
-warp switch --latest
-warp switch --waiting
-
-# Custom worktree location  
-warp switch --path /custom/location feature/branch
-
-# Force traditional Git worktree (skip CoW)
-warp switch --no-cow feature/branch
-```
-
-### **Intelligent Cleanup**
-
-```bash
-# Interactive cleanup with TUI selection
+# Clean up merged worktrees interactively
 warp cleanup --interactive
-
-# Automatic cleanup by mode
-warp cleanup --mode merged      # Clean merged branches
-warp cleanup --mode remoteless  # Clean branches without remotes  
-warp cleanup --mode all         # Clean all eligible branches
-
-# Force cleanup with process termination
-warp cleanup --mode merged --force --kill
-
-# Safe testing with dry-run
-warp cleanup --mode all --dry-run
 ```
 
-### **Claude Code Integration**
+## Terminal Modes
 
 ```bash
-# Install hooks for automatic agent tracking
-warp hooks-install --level user
+warp --terminal tab switch feature/branch      # new tab
+warp --terminal window switch feature/branch   # new window
+warp --terminal current switch feature/branch  # shell in this terminal
+warp --terminal inplace switch feature/branch  # print a cd command
+warp --terminal echo switch feature/branch     # print the target path
+```
 
-# View integration status
+Configure the macOS terminal app with `terminal.app = "auto"`, `"terminal"`,
+`"iterm2"`, or `"warp"`.
+
+## Cleanup
+
+```bash
+warp cleanup --mode merged
+warp cleanup --mode remoteless
+warp cleanup --mode all
+warp cleanup --interactive
+warp --dry-run cleanup --mode all
+warp cleanup --mode merged --kill
+warp cleanup --mode merged --force
+```
+
+Protected branches default to `main`, `master`, and `develop`. Cleanup also
+checks for dirty worktrees and running processes before removing anything.
+
+## Agent Session Dashboard
+
+The agent dashboard is optional. It shows live hook records when hooks are
+installed, plus recent local Claude/Codex session history for the current
+repository and its worktrees.
+
+```bash
+warp hooks-install --level user --runtime all
 warp hooks-status
-
-# Start live agent monitoring dashboard
 warp agents
-
-# Remove hooks if needed
-warp hooks-remove --level user
 ```
 
-### **Configuration Management**
+Use `--level project` if hooks should be written only for the current project.
+
+## Configuration
+
+Show the effective configuration:
 
 ```bash
-# View current configuration
 warp config --show
-
-# Open the config file in your editor
-warp config --edit
-
-# Terminal mode options
-warp --terminal tab switch feature/branch     # New tab (default)
-warp --terminal window switch feature/branch  # New window
-warp --terminal current switch feature/branch # Start a shell in this terminal
-warp --terminal inplace switch feature/branch # Print cd command
-warp --terminal echo switch feature/branch    # Just show path
 ```
 
-### **Advanced Features**
+Create or open the config file in `$VISUAL` or `$EDITOR`:
 
 ```bash
-# Enable auto-confirmation for scripts
-warp --auto-confirm cleanup --mode merged
-
-# Debug mode for troubleshooting
-warp --debug switch feature/debug-branch
-
-# Shell integration setup
-warp shell-config bash >> ~/.bashrc
-warp shell-config zsh >> ~/.zshrc
+warp config --edit
 ```
 
-## 🏗️ Architecture & Performance
+Default path:
 
-### **Copy-on-Write Engine**
-- **macOS APFS**: Instant filesystem-level CoW cloning
-- **Fallback Mode**: Traditional Git worktree for other filesystems
-- **Path Rewriting**: Parallel processing with `rayon` for environment fixes
-- **Process Safety**: Detects running processes before cleanup
+```text
+~/.config/git-warp/config.toml
+```
 
-### **AI Agent Integration**
-- **Real-time Hooks**: Tracks Claude Code activities via filesystem events
-- **Live Dashboard**: TUI showing agent status, activities, and timing
-- **Cross-session Monitoring**: Works across multiple Claude Code sessions
-- **Project-specific Tracking**: Per-repository status files
+Example:
 
-### **Terminal Automation**
-- **macOS AppleScript**: Automatic terminal tab/window management
-- **Cross-platform**: Abstraction layer for different terminal apps
-- **Smart Detection**: Automatically detects available terminal applications
-
-## 📊 Real-World Performance
-
-### **Benchmark Results** (on MacBook Pro M1, APFS)
-- **CoW Worktree Creation**: ~50ms vs ~2-5s traditional
-- **Large Repository (1000+ files)**: ~100ms vs ~10-30s traditional
-- **Agent Dashboard Refresh**: <10ms response time
-- **Configuration Loading**: ~5ms with full validation
-
-### **Memory & CPU Usage**
-- **Idle Memory**: ~2MB RSS
-- **Active Dashboard**: ~8MB RSS  
-- **CPU Usage**: <1% during normal operations
-- **Startup Time**: ~50ms cold start
-
-## 🔧 Configuration Reference
-
-### **Configuration File** (`~/.config/git-warp/config.toml`)
 ```toml
-# Terminal behavior
-terminal_mode = "tab"          # tab, window, current, inplace, echo
-use_cow = true                 # Enable CoW when available
-auto_confirm = false           # Skip confirmation prompts
+terminal_mode = "tab"
+use_cow = true
+auto_confirm = false
+# worktrees_path = "/Users/me/dev/worktrees"
 
 [git]
-default_branch = "main"        # Default branch for operations
-protected_branches = ["main", "master", "develop"]  # Never removed by cleanup
-auto_fetch = true              # Fetch before branch analysis
-auto_prune = true              # Prune during fetch
+default_branch = "main"
+protected_branches = ["main", "master", "develop"]
+auto_fetch = true
+auto_prune = true
 
 [process]
-check_processes = true         # Check for processes before cleanup
-auto_kill = false              # Automatically terminate processes
-kill_timeout = 5               # Timeout in seconds
+check_processes = true
+auto_kill = false
+kill_timeout = 5
 
 [terminal]
-app = "auto"                   # auto, terminal, iterm2, warp
-auto_activate = true           # Activate new macOS terminal tabs/windows
-init_commands = []             # Commands to run after cd into a worktree
+app = "auto"
+auto_activate = true
+init_commands = []
 
 [agent]
-enabled = true                 # Enable Claude Code integration
-refresh_rate = 1000           # Dashboard refresh rate (ms)
-max_activities = 100          # Max activities to track
-claude_hooks = true           # Enable Claude Code hooks
+enabled = true
+refresh_rate = 1000
+max_activities = 100
+claude_hooks = true
 ```
 
-### **Environment Variables**
+Environment overrides use the `GIT_WARP_` prefix:
+
 ```bash
 export GIT_WARP_TERMINAL_MODE=window
 export GIT_WARP_USE_COW=false
@@ -237,96 +161,50 @@ export GIT_WARP_AUTO_CONFIRM=true
 export GIT_WARP_WORKTREES_PATH=/custom/worktrees
 ```
 
-`terminal.init_commands` are emitted after Git-Warp changes into the worktree for
-terminal modes such as `tab`, `window`, `inplace`, and `echo`.
+`terminal.init_commands` run after Git-Warp changes into the worktree for
+terminal handoff modes that print or send shell commands.
 
-## 🎨 Design Philosophy
+## Shell Integration
 
-### **Performance First**
-- Copy-on-Write operations where possible
-- Parallel processing for file operations
-- Minimal overhead in common workflows
-- Sub-second response times
-
-### **User Experience**  
-- Intuitive commands that "just work"
-- Rich visual feedback with emojis and colors
-- Interactive modes for complex operations
-- Comprehensive dry-run support
-
-### **AI Integration**
-- Seamless Claude Code integration
-- Real-time activity monitoring
-- Cross-session persistence
-- Project-specific tracking
-
-### **Safety & Reliability**
-- Process detection before destructive operations
-- Comprehensive confirmation prompts
-- Git safety checks to prevent data loss
-- Extensive error handling and recovery
-
-## 🤝 Contributing & Development
-
-### **Development Commands**
 ```bash
-# Run with debug logging
-RUST_LOG=debug cargo run -- ls --debug
-
-# Run comprehensive tests
-cargo test --all-targets
-
-# Run performance benchmarks  
-cargo bench
-
-# Check code quality
-cargo clippy --all-targets
-cargo fmt
+warp shell-config bash >> ~/.bashrc
+warp shell-config zsh >> ~/.zshrc
+warp shell-config fish >> ~/.config/fish/config.fish
 ```
 
-### **Testing Real Integration**
+## Development
+
 ```bash
-# Test with actual Git repository
-cargo run -- switch test/integration
-cargo run -- agents  # Start dashboard
-cargo run -- cleanup --interactive
-cargo run -- hooks-status
+cargo fmt --check
+cargo test --test mod cli_surface_tests -- --nocapture
+cargo test --test mod terminal_switch_tests -- --nocapture
+cargo test --test mod tui_tests -- --nocapture
+git diff --check
 ```
 
-## 🚀 What's Next: v0.4.0 Roadmap
+Useful manual checks:
 
-### **Platform Expansion**
-- [ ] **Linux Support**: overlayfs-based CoW implementation
-- [ ] **Windows Support**: Basic worktree management
-- [ ] **CI/CD Integration**: GitHub Actions, GitLab CI support
+```bash
+cargo run -- --help
+cargo run -- doctor
+cargo run -- --dry-run switch docs-check
+cargo run -- --dry-run cleanup --mode merged
+```
 
-### **Advanced Features**
-- [ ] **Multi-repository Management**: Handle multiple repos
-- [ ] **Team Collaboration**: Shared worktree management
-- [ ] **Plugin System**: Custom hook and command plugins
-- [ ] **Performance Analytics**: Detailed timing and usage metrics
+## Documentation
 
-## 📝 License
+- [User Guide](docs/user-guide.md)
+- [Technical Overview](docs/technical-overview.md)
+- [Documentation Index](docs/README.md)
+- [Original autowt reference](docs/autowt.txt)
+- [Original coworktree reference](docs/coworktree.txt)
 
-MIT License - see [LICENSE](LICENSE) file for details.
+## Status
 
-## 🙏 Acknowledgments
+Git-Warp is usable for local worktree workflows, but it is still evolving. Prefer
+`warp doctor`, `--dry-run`, and focused command help (`warp <command> --help`)
+when setting it up on a new machine or repository.
 
-This project successfully combines and enhances concepts from:
-- **autowt**: Advanced UX, agent integration, and terminal automation
-- **coworktree**: High-performance CoW implementation and Git operations
+## License
 
-**Built with ❤️ in Rust 🦀**
-
----
-
-## 🎉 Success Story
-
-Git-Warp has successfully evolved from a concept to a **production-ready tool** that combines the best of both worlds:
-
-✅ **Fast as CoW** - Instant worktree creation on supported filesystems  
-✅ **Smart as AI** - Deep Claude Code integration with real-time monitoring  
-✅ **Rich as TUI** - Interactive dashboards and cleanup interfaces  
-✅ **Safe as Git** - Comprehensive safety checks and process management  
-
-**Ready to revolutionize your Git workflow!** 🚀
+MIT.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,324 +1,76 @@
 # Git-Warp Documentation
 
-**Complete documentation for the high-performance Git worktree manager**
+This directory contains user-facing guides, technical notes, historical planning
+material, and original reference documents for Git-Warp.
 
-Welcome to the Git-Warp documentation! This directory contains comprehensive guides covering everything from basic usage to advanced technical details.
+## Start Here
 
-## 📚 Documentation Overview
+- [User Guide](user-guide.md): installation, daily commands, configuration, and
+  troubleshooting.
+- [Technical Overview](technical-overview.md): architecture, modules, and
+  implementation notes.
+- [Root README](../README.md): short project overview and verified quick start.
 
-### For Users
+## Reference Documents
 
-**[User Guide](user-guide.md)** - *Start Here!*
-- Complete how-to guide for using Git-Warp
-- Quick start tutorial
-- All features explained with examples
-- Configuration and troubleshooting
-- Best practices and workflows
+- [autowt.txt](autowt.txt): UX-focused Python predecessor reference.
+- [coworktree.txt](coworktree.txt): CoW-focused Go predecessor reference.
+- [implement-plan-v1.md](implement-plan-v1.md): early implementation plan.
+- [implement-plan-v2.md](implement-plan-v2.md): later implementation plan.
 
-### For Developers & Contributors
+The implementation plans and predecessor references are historical context. The
+current CLI behavior is best checked with `warp --help`, `warp <command> --help`,
+and the current README/user guide.
 
-**[Technical Overview](technical-overview.md)**
-- Architecture and design decisions
-- Implementation details
-- Performance characteristics
-- Module documentation
-- Testing strategies
+## Common Paths
 
-### Project History
-
-**[Implementation Plans](implement-plan-v1.md) & [Implementation Plans v2](implement-plan-v2.md)**
-- Original project vision and requirements
-- Detailed implementation roadmap
-- Technical specifications
-
-**[Original Project References]()**
-- [`autowt.txt`](autowt.txt) - Python-based UX-focused predecessor
-- [`coworktree.txt`](coworktree.txt) - Go-based performance-focused predecessor
-
----
-
-## 🚀 Quick Start
-
-New to Git-Warp? Start with these essential commands:
+### First Setup
 
 ```bash
-# Create your first worktree (instant with CoW!)
-warp feature/amazing-new-feature
+cargo install --path .
+warp doctor
+warp --help
+```
 
-# List all worktrees
+### Daily Worktree Flow
+
+```bash
+warp switch feature/my-change
 warp ls
-
-# Clean up merged branches safely
-warp cleanup --mode merged
-
-# View configuration
-warp config --show
-```
-
-**→ [Full Quick Start Guide](user-guide.md#quick-start)**
-
----
-
-## 🎯 What Makes Git-Warp Special?
-
-### ⚡ **Instant Performance**
-- **Copy-on-Write**: Create worktrees in milliseconds, not minutes
-- **Smart Caching**: Intelligent reuse of dependencies and build artifacts
-- **Parallel Processing**: Multi-threaded file operations
-
-### 🛡️ **Safety First**
-- **Process Detection**: Never break running services
-- **Dry-Run Mode**: Preview all operations safely
-- **Graceful Recovery**: Intelligent error handling and recovery
-
-### 🤖 **AI Integration**
-- **Claude Code Monitoring**: Live dashboard of AI agent activities
-- **Hook System**: Seamless integration with AI development workflows
-- **Intelligent Suggestions**: AI-powered workflow optimizations
-
-### 🖥️ **Rich Experience**
-- **Terminal Integration**: Automatic tab/window switching (macOS)
-- **Beautiful CLI**: Emoji-enhanced, informative output
-- **Live Dashboards**: Real-time TUI interfaces
-
----
-
-## 📖 Documentation Structure
-
-### User Documentation
-
-| Document | Purpose | Audience |
-|----------|---------|----------|
-| **[User Guide](user-guide.md)** | Complete usage guide | All users |
-| Quick Reference | Command cheatsheet | Daily users |
-| Configuration Reference | All settings explained | Power users |
-| Troubleshooting Guide | Common issues & solutions | All users |
-
-### Technical Documentation  
-
-| Document | Purpose | Audience |
-|----------|---------|----------|
-| **[Technical Overview](technical-overview.md)** | Architecture & implementation | Developers |
-| API Documentation | Internal API reference | Contributors |
-| Performance Guide | Optimization details | DevOps/SRE |
-| Contributing Guide | Development workflow | Contributors |
-
-### Project Documentation
-
-| Document | Purpose | Audience |
-|----------|---------|----------|
-| **[Implementation Plans](implement-plan-v2.md)** | Project roadmap | Project managers |
-| Change Log | Version history | All users |
-| Migration Guide | Upgrade instructions | Existing users |
-
----
-
-## 🔍 Find What You Need
-
-### I want to...
-
-**Learn Git-Warp basics**
-→ [User Guide: Quick Start](user-guide.md#quick-start)
-
-**Understand how CoW works**
-→ [Technical Overview: Copy-on-Write Implementation](technical-overview.md#copy-on-write-implementation)
-
-**Configure Git-Warp for my team**
-→ [User Guide: Configuration](user-guide.md#configuration)
-
-**Troubleshoot an issue**
-→ [User Guide: Troubleshooting](user-guide.md#troubleshooting)
-
-**Contribute to the project**
-→ [Technical Overview: Module Design](technical-overview.md#module-design)
-
-**Understand the architecture**
-→ [Technical Overview: Architecture Overview](technical-overview.md#architecture-overview)
-
-**See performance benchmarks**
-→ [Technical Overview: Performance Benchmarks](technical-overview.md#performance-benchmarks)
-
-**Learn about AI integration**
-→ [User Guide: AI Agent Monitoring](user-guide.md#ai-agent-monitoring)
-
----
-
-## 🎯 Common Use Cases
-
-### Individual Developer
-
-```bash
-# Daily workflow
-warp switch main && git pull
-warp feature/user-authentication
-# Work, commit, push
-warp cleanup --mode merged
-```
-
-**→ [User Guide: Daily Workflow](user-guide.md#daily-workflow)**
-
-### Team Development
-
-```bash
-# Team-safe settings
-export GIT_WARP_AUTO_CONFIRM=false
-export GIT_WARP_TERMINAL_MODE=window
+warp --dry-run cleanup --mode merged
 warp cleanup --interactive
 ```
 
-**→ [User Guide: Team Collaboration](user-guide.md#team-collaboration)**
-
-### Large Monorepos
+### Agent Session Visibility
 
 ```bash
-# Optimized for large repos
-export GIT_WARP_WORKTREES_PATH=/fast-ssd/worktrees
-warp config --show  # Verify settings
+warp hooks-install --level user --runtime all
+warp hooks-status
+warp agents
 ```
 
-**→ [User Guide: Large Monorepos](user-guide.md#large-monorepos)**
+Live agent rows require hooks or local session history that Git-Warp can read.
+Without those inputs, the dashboard opens with an empty state.
 
-### AI-Assisted Development
+## Find What You Need
 
-```bash
-# Monitor Claude Code activities
-warp agents &
-# Work with AI assistance while monitoring
-warp feature/ai-integration
-```
+- Basics: [User Guide: Quick Start](user-guide.md#quick-start)
+- Configuration: [User Guide: Configuration](user-guide.md#configuration)
+- Troubleshooting: [User Guide: Troubleshooting](user-guide.md#troubleshooting)
+- Copy-on-Write internals:
+  [Technical Overview: Copy-on-Write Implementation](technical-overview.md#copy-on-write-implementation)
+- Process safety:
+  [Technical Overview: Process Management](technical-overview.md#process-management)
+- Performance notes:
+  [Technical Overview: Performance Benchmarks](technical-overview.md#performance-benchmarks)
 
-**→ [User Guide: AI Integration](user-guide.md#advanced-usage)**
+## Documentation Maintenance
 
----
+When editing docs:
 
-## 💡 Key Concepts
-
-### Copy-on-Write (CoW)
-
-Git-Warp's secret weapon for instant worktree creation. Instead of copying files, CoW creates instant snapshots using filesystem-level cloning.
-
-**Benefits:**
-- **Speed**: 30-180x faster than traditional methods
-- **Space Efficient**: Shared data until files are modified
-- **Reliability**: Atomic operations prevent corruption
-
-**→ [Technical Deep Dive](technical-overview.md#copy-on-write-implementation)**
-
-### Intelligent Process Management
-
-Git-Warp prevents disasters by detecting and managing processes running in worktrees before cleanup.
-
-**Features:**
-- **Detection**: Find all processes in worktree directories
-- **Graceful Termination**: SIGTERM → SIGKILL progression
-- **User Control**: Interactive confirmation and bypass options
-
-**→ [Implementation Details](technical-overview.md#process-management)**
-
-### Layered Configuration
-
-Sophisticated configuration system with clear precedence rules.
-
-**Layers (highest to lowest priority):**
-1. Command-line arguments
-2. Environment variables (`GIT_WARP_*`)
-3. Configuration file (`~/.config/git-warp/config.toml`)
-4. Built-in defaults
-
-**→ [Configuration Guide](user-guide.md#configuration)**
-
----
-
-## 🚦 Getting Help
-
-### Documentation Issues
-
-- **Missing information?** [Open an issue](https://github.com/denysbutenko/git-warp/issues/new?template=documentation.md)
-- **Found an error?** Submit a PR with the fix
-- **Need clarification?** Start a [discussion](https://github.com/denysbutenko/git-warp/discussions)
-
-### Technical Support
-
-1. **Check the [Troubleshooting Guide](user-guide.md#troubleshooting)**
-2. **Enable debug mode**: `RUST_LOG=debug warp --debug <command>`
-3. **Search [existing issues](https://github.com/denysbutenko/git-warp/issues)**
-4. **Create a new issue** with debug output
-
-### Feature Requests
-
-We love hearing about new use cases! 
-
-1. **Check the [roadmap](implement-plan-v2.md)** 
-2. **Search [existing requests](https://github.com/denysbutenko/git-warp/issues?q=is%3Aissue+label%3Aenhancement)**
-3. **Open a feature request** with your use case
-
----
-
-## 🤝 Contributing to Documentation
-
-Documentation improvements are always welcome!
-
-### Quick Fixes
-- Fix typos, broken links, or unclear instructions
-- Add missing examples or clarifications
-- Improve formatting or structure
-
-### Major Contributions
-- New guides or tutorials
-- Architecture documentation
-- Performance analysis
-- Integration guides
-
-### Documentation Standards
-
-- **Clear and Concise**: Prefer simple, direct language
-- **Example-Driven**: Include working code examples
-- **User-Focused**: Write from the user's perspective
-- **Comprehensive**: Cover edge cases and gotchas
-- **Tested**: Verify all examples work as described
-
----
-
-## 📊 Documentation Stats
-
-| Document | Lines | Words | Last Updated |
-|----------|-------|--------|--------------|
-| User Guide | 850+ | 12,000+ | Latest |
-| Technical Overview | 750+ | 10,000+ | Latest |
-| Implementation Plans | 400+ | 6,000+ | v2.0 |
-| Project References | 300+ | 4,000+ | Historical |
-
-**Total Documentation**: 2,300+ lines, 32,000+ words
-
----
-
-## 🎉 Success Stories
-
-> *"Git-Warp reduced our feature branch setup time from 5 minutes to 3 seconds. Game changer for our team!"*  
-> — Senior Developer, Tech Startup
-
-> *"The CoW technology is incredible. We're working on a 10GB monorepo and worktree creation is instant."*  
-> — DevOps Engineer, Enterprise
-
-> *"The AI integration dashboard helps us understand what Claude is doing across different branches. Brilliant!"*  
-> — ML Engineer, AI Company
-
----
-
-## 🔮 What's Next?
-
-Git-Warp is continuously evolving. Check out our [roadmap](implement-plan-v2.md) to see what's coming:
-
-- **Interactive TUI Interfaces**: Enhanced cleanup and configuration
-- **Plugin System**: Extensible architecture for custom workflows  
-- **Multi-Platform CoW**: Linux overlayfs support
-- **Enhanced AI Integration**: More sophisticated agent monitoring
-- **Team Features**: Shared configuration and policies
-
----
-
-**Ready to transform your Git workflow?**
-
-**→ [Get Started with the User Guide](user-guide.md)**
-
-**Happy warping! 🚀**
+- Prefer examples verified against the current CLI help.
+- Do not link to missing pages or planned guides.
+- Mark historical material as historical so users do not treat old plans as the
+  shipped command surface.
+- Keep setup examples safe: use `warp doctor`, `--dry-run`, and non-destructive
+  commands before cleanup examples.

--- a/docs/superpowers/plans/2026-04-26-docs-align.md
+++ b/docs/superpowers/plans/2026-04-26-docs-align.md
@@ -1,0 +1,107 @@
+# Docs Alignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Align Git-Warp README and docs with the current shipped CLI surface.
+
+**Architecture:** This is a docs-only change. The root README becomes the short
+source of truth, `docs/README.md` becomes a real index of existing documents,
+and `docs/user-guide.md` becomes a concise command guide grounded in current
+help output.
+
+**Tech Stack:** Markdown, Git-Warp CLI help, shell verification.
+
+---
+
+### Task 1: Verify Current CLI Surface
+
+**Files:**
+- Read: `src/cli.rs`
+- Read: `README.md`
+- Read: `docs/README.md`
+- Read: `docs/user-guide.md`
+
+- [x] **Step 1: Fetch command help**
+
+Run:
+
+```bash
+cargo run --quiet -- --help
+cargo run --quiet -- config --help
+cargo run --quiet -- cleanup --help
+cargo run --quiet -- hooks-install --help
+```
+
+Expected: command help lists the shipped command names and options used in the
+docs examples.
+
+- [x] **Step 2: Identify stale documentation**
+
+Run:
+
+```bash
+rg -n "production|success|AI-powered|Quick Reference|API Documentation|Migration Guide|Change Log|interactive config|Live Dashboard|LICENSE" README.md docs/*.md
+```
+
+Expected: stale launch-style claims, missing page references, and broken links
+are visible before editing.
+
+### Task 2: Rewrite Public Docs
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/README.md`
+- Modify: `docs/user-guide.md`
+
+- [x] **Step 1: Rewrite README**
+
+Replace the launch-style README with a concise current-state overview covering
+install, quick start, terminal modes, cleanup, agent dashboard, config, shell
+integration, development checks, docs links, status, and license.
+
+- [x] **Step 2: Rewrite docs index**
+
+Keep only links to existing docs and valid anchors. Mark implementation plans
+and predecessor documents as historical context.
+
+- [x] **Step 3: Rewrite user guide**
+
+Keep examples to shipped commands and explain limits clearly: CoW is
+macOS/APFS-specific acceleration, agent visibility depends on hooks/session
+history, and `config --edit` opens the config in an editor.
+
+### Task 3: Verify Documentation
+
+**Files:**
+- Read: `README.md`
+- Read: `docs/README.md`
+- Read: `docs/user-guide.md`
+
+- [x] **Step 1: Check local links**
+
+Run a Markdown link checker over the edited files. Expected: no missing local
+files and no missing local anchors.
+
+- [x] **Step 2: Check formatting whitespace**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: exit 0.
+
+- [x] **Step 3: Re-run command help used as source of truth**
+
+Run:
+
+```bash
+cargo run --quiet -- --help
+cargo run --quiet -- config --help
+cargo run --quiet -- cleanup --help
+cargo run --quiet -- hooks-install --help
+```
+
+Expected: exit 0 for each command; warnings are allowed if they are existing
+Rust warnings unrelated to the docs change.

--- a/docs/superpowers/specs/2026-04-26-docs-align-design.md
+++ b/docs/superpowers/specs/2026-04-26-docs-align-design.md
@@ -1,0 +1,43 @@
+# Docs Alignment Design
+
+GitHub issue #10, "[P2] Align README and docs with the shipped feature set",
+asks the public docs to stop overstating readiness, remove missing or broken
+document references, and keep quick-start examples on implemented commands.
+
+## Context
+
+The current CLI exposes `switch`, `ls`, `cleanup`, `config`, `agents`,
+`doctor`, hook commands, and `shell-config`. `config --edit` is implemented as
+"open the config file in an editor", while the old docs implied broader
+interactive configuration and linked to pages that do not exist. The README and
+docs index also used production-ready and success-story language that reads more
+like a launch page than setup documentation.
+
+## Approach
+
+Use a docs-only patch. Replace the root README, docs index, and user guide with
+shorter current-state documentation grounded in the real CLI help. Keep existing
+historical documents, but label them as historical context so users do not treat
+old plans as the shipped command surface.
+
+## Decisions
+
+- Keep examples to verified commands: `warp doctor`, `warp switch`, short-form
+  branch switching, `warp ls`, `warp cleanup`, `warp config`, hooks, `agents`,
+  and `shell-config`.
+- Describe the agent dashboard as optional visibility based on hooks and local
+  session history, not guaranteed live monitoring in every setup.
+- Describe Copy-on-Write as macOS/APFS acceleration with traditional Git
+  fallback, not universal instant readiness.
+- Remove links to missing standalone pages such as quick reference,
+  troubleshooting guide, API docs, changelog, and migration guide.
+- Keep `config --edit` documented accurately as editor-based config opening.
+
+## Testing
+
+Verification should include:
+
+- CLI help checks for the commands used in examples.
+- A local Markdown link check for relative files and anchors in `README.md`,
+  `docs/README.md`, and `docs/user-guide.md`.
+- `git diff --check`.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,673 +1,311 @@
 # Git-Warp User Guide
 
-**The Ultimate Git Worktree Manager: Lightning-Fast, AI-Integrated, and Developer-Friendly**
+Git-Warp is a Rust CLI for working with Git worktrees. It focuses on fast
+worktree creation, terminal handoff, safe cleanup, and optional Claude/Codex
+session visibility.
 
 ## Table of Contents
 
-1. [What is Git-Warp?](#what-is-git-warp)
-2. [Why Use Git-Warp?](#why-use-git-warp)
-3. [Installation](#installation)
-4. [Quick Start](#quick-start)
-5. [Core Features](#core-features)
-6. [Advanced Usage](#advanced-usage)
+1. [Installation](#installation)
+2. [Quick Start](#quick-start)
+3. [Switching Worktrees](#switching-worktrees)
+4. [Listing Worktrees](#listing-worktrees)
+5. [Cleanup](#cleanup)
+6. [Agent Session Dashboard](#agent-session-dashboard)
 7. [Configuration](#configuration)
 8. [Troubleshooting](#troubleshooting)
 9. [Best Practices](#best-practices)
-
----
-
-## What is Git-Warp?
-
-Git-Warp is a high-performance Git worktree manager that revolutionizes how developers work with multiple branches simultaneously. Built in Rust for maximum speed and reliability, it combines:
-
-- **⚡ Instant Worktree Creation**: Copy-on-Write (CoW) technology creates worktrees in milliseconds
-- **🤖 AI Integration**: Live monitoring of Claude Code agent activities
-- **🛡️ Process Safety**: Intelligent process detection and management
-- **🖥️ Terminal Integration**: Seamless switching between worktrees in your favorite terminal
-- **⚙️ Rich Configuration**: Powerful, layered configuration system
-
-### The Problem Git-Warp Solves
-
-Traditional Git workflows force developers to choose between:
-- **Stashing/Committing**: Interrupting current work to switch branches
-- **Multiple Repositories**: Managing separate clones (disk space, sync issues)
-- **Manual Worktrees**: Complex `git worktree` commands with cleanup headaches
-
-Git-Warp eliminates these compromises by making worktrees effortless, instant, and intelligent.
-
----
-
-## Why Use Git-Warp?
-
-### 🚀 **Speed That Changes Everything**
-
-```bash
-# Traditional approach (30+ seconds)
-git stash
-git checkout feature-branch
-npm install
-# Work on feature
-git checkout main
-git stash pop
-
-# Git-Warp approach (< 1 second)
-warp feature-branch
-# Instantly ready to work - dependencies already installed!
-```
-
-### 🧠 **Intelligence Built-In**
-
-- **Process Detection**: Never accidentally break running services
-- **Branch Analysis**: Automatic detection of merged/stale branches
-- **Agent Monitoring**: See what Claude Code is doing in real-time
-- **Smart Cleanup**: AI-powered suggestions for worktree maintenance
-
-### 💎 **Developer Experience**
-
-- **Zero Configuration**: Works perfectly out-of-the-box
-- **Rich Feedback**: Beautiful, informative CLI output
-- **Error Prevention**: Dry-run mode for all destructive operations
-- **Terminal Magic**: Automatic tab/window switching
-
----
+10. [Advanced Scenarios](#advanced-scenarios)
 
 ## Installation
 
 ### Prerequisites
 
-- **Rust**: 2024 edition (latest stable)
-- **Git**: Any modern version
-- **macOS**: Required for Copy-on-Write support (APFS filesystem)
+- Rust, latest stable toolchain.
+- Git.
+- macOS/APFS for Copy-on-Write acceleration. Other platforms and filesystems use
+  traditional Git worktree creation.
 
 ### Build from Source
 
 ```bash
-# Clone the repository
 git clone https://github.com/denysbutenko/git-warp
 cd git-warp
-
-# Build optimized binary
 cargo build --release
-
-# The binary will be at target/release/warp
-# Optionally, add to your PATH
-sudo ln -sf $(pwd)/target/release/warp /usr/local/bin/warp
+cargo install --path .
+warp --version
 ```
 
-### Verify Installation
+### Check Setup
 
 ```bash
-warp --version
-# Should output: warp 0.1.0
+warp doctor
 ```
 
----
+`warp doctor` checks repository detection, config path, worktree base path, CoW
+support, terminal mode, and hook setup.
 
 ## Quick Start
 
-### Your First Worktree
+Run these commands from inside a Git repository:
 
 ```bash
-# Navigate to any Git repository
-cd your-project
+# Create or switch to a worktree for a branch
+warp switch feature/amazing-new-feature
 
-# Create and switch to a new feature branch (instant!)
+# Short form
 warp feature/amazing-new-feature
 
-# List all worktrees
+# List worktrees
 warp ls
 
-# Work normally - everything is ready to go!
+# Preview cleanup
+warp --dry-run cleanup --mode merged
+
+# Pick cleanup candidates interactively
+warp cleanup --interactive
 ```
 
-### Essential Commands
+## Switching Worktrees
 
 ```bash
-# Switch to existing branch
-warp switch existing-branch
-
-# Switch to the most recent or waiting agent branch
-warp switch --latest
-warp switch --waiting
-
-# List worktrees with details
-warp ls --debug
-
-# Clean up merged branches
-warp cleanup --mode merged
-
-# View configuration
-warp config --show
-
-# Monitor AI agents (if using Claude Code)
-warp agents
-```
-
----
-
-## Core Features
-
-### 1. Instant Worktree Creation
-
-Git-Warp uses Copy-on-Write technology to create worktrees instantly:
-
-```bash
-# Creates worktree in milliseconds vs. minutes
-warp feature/user-authentication
+# Existing or new branch
+warp switch feature/user-authentication
 
 # Custom path
-warp switch feature/ui-redesign --path /custom/path
+warp switch feature/ui-redesign --path /tmp/ui-redesign
 
-# Force traditional method (skip CoW)
+# Skip Copy-on-Write checks and use normal Git worktree creation
 warp switch testing-branch --no-cow
+
+# Jump to agent-related branches when local session data is available
+warp switch --latest
+warp switch --waiting
 ```
 
-**How it Works**: On APFS filesystems (macOS), Git-Warp clones your repository's file tree instantly using CoW, then intelligently rewrites absolute paths in configuration files.
+Terminal handoff modes:
 
-### 2. Intelligent Worktree Management
+```bash
+warp --terminal tab switch feature-branch
+warp --terminal window switch feature-branch
+warp --terminal current switch feature-branch
+warp --terminal inplace switch feature-branch
+warp --terminal echo switch feature-branch
+```
 
-**List Worktrees**:
+## Listing Worktrees
+
 ```bash
 warp ls
-# Output:
-# 📁 Git Worktrees:
-# 
-# 🏠  main /Users/you/project
-# 🌿  feature-branch /Users/you/project/../worktrees/feature-branch
-# 🌿  hotfix-123 /Users/you/project/../worktrees/hotfix-123
-# 
-# 📊 Total: 3 worktrees
-```
-
-**Advanced Listing**:
-```bash
 warp ls --debug
-# Shows HEAD commits, branch status, and more details
 ```
 
-### 3. Smart Cleanup
+The list output marks useful state such as primary, current, dirty, detached,
+and busy worktrees. `--debug` includes additional details for diagnostics.
 
-Git-Warp analyzes your branches intelligently:
+## Cleanup
+
+Git-Warp analyzes worktrees before removal. Protected branches default to
+`main`, `master`, and `develop`.
 
 ```bash
-# Clean up merged branches
 warp cleanup --mode merged
-
-# Clean up branches without remotes
 warp cleanup --mode remoteless
-
-# Interactive cleanup (TUI interface)
+warp cleanup --mode all
 warp cleanup --interactive
-
-# Dry-run to see what would be cleaned
 warp --dry-run cleanup --mode all
 ```
 
-**Cleanup Modes**:
-- `merged`: Branches merged into main/master
-- `remoteless`: Branches without remote tracking
-- `all`: All non-main worktrees (use with caution!)
-- `interactive`: Choose which worktrees to remove
-
-### 4. Process Safety
-
-Git-Warp prevents disasters by detecting running processes:
+Process and dirty-worktree handling:
 
 ```bash
-# Automatically detects processes in worktrees
-warp cleanup --mode merged
-
-# If processes are found:
-# ⚠️  Found 2 processes in worktree
-#   • PID 1234: npm (CPU: 15.2%, Mem: 45MB)
-#     Working dir: /project/worktrees/feature-branch
-#   • PID 5678: webpack-dev-server (CPU: 8.1%, Mem: 120MB)
-#     Command: node webpack serve --mode development
-
-# Kill processes automatically
+# Terminate blocking processes before removal
 warp cleanup --mode merged --kill
 
-# Force cleanup ignoring processes
+# Ignore safety blocks only when you have checked the candidate
 warp cleanup --mode merged --force
+
+# Override config that would otherwise kill processes
+warp cleanup --mode merged --no-kill
 ```
 
-### 5. Terminal Integration
+Use `--dry-run` first when you are unsure what a cleanup mode will select.
 
-Seamless integration with macOS terminals:
+## Agent Session Dashboard
 
-```bash
-# Open new tab (default)
-warp switch feature-branch
-
-# Open new window
-warp switch --terminal window feature-branch
-
-# Echo commands instead of switching
-warp switch --terminal echo feature-branch
-
-# Start a shell in the current terminal tab
-warp switch --terminal current feature-branch
-
-# Print a cd command for the worktree
-warp switch --terminal inplace feature-branch
-```
-
-### 6. AI Agent Monitoring
-
-Real-time monitoring of Claude Code activities:
+The `agents` command opens a TUI dashboard for live hook records and recent local
+Claude/Codex session history scoped to the current repository and its worktrees.
 
 ```bash
-# Launch live dashboard
+warp hooks-install --level user --runtime all
+warp hooks-status
 warp agents
 ```
 
-**Dashboard Features**:
-- Live agent activity feed
-- CPU and memory usage
-- Activity statistics
-- Interactive navigation (↑↓ keys, r to refresh)
-
----
-
-## Advanced Usage
-
-### Configuration Management
-
-**View Current Settings**:
-```bash
-warp config --show
-# Shows all configuration with current values
-```
-
-**Open the Config File**:
-```bash
-warp config --edit
-# Creates the default config if needed, then opens it in your editor
-```
-
-**Environment Variables** (Override any setting):
-```bash
-export GIT_WARP_TERMINAL_MODE=window
-export GIT_WARP_USE_COW=true
-export GIT_WARP_AUTO_CONFIRM=false
-export GIT_WARP_WORKTREES_PATH=/custom/worktrees
-```
-
-### Dry-Run Mode
-
-Preview all operations safely:
+Use `--level project` to install hooks only for the current project:
 
 ```bash
-# See what would be done
-warp --dry-run switch feature-branch
-warp --dry-run cleanup --mode all
-warp --dry-run --terminal window switch testing
+warp hooks-install --level project --runtime all
 ```
 
-### Branch Naming & Patterns
-
-Git-Warp handles complex branch names gracefully:
-
-```bash
-# Forward slashes (creates nested structure)
-warp feature/user-auth/login-form
-
-# Special characters
-warp "hotfix/issue-#123"
-
-# Automatic sanitization for filesystem paths
-warp "feature branch with spaces"  # → feature-branch-with-spaces
-```
-
-### Custom Worktree Paths
-
-```bash
-# Specific path
-warp switch mybranch --path /tmp/quick-test
-
-# Pattern-based paths (configured)
-# ~/worktrees/project-name/branch-name
-```
-
-### Integration with Development Workflow
-
-**With Package Managers**:
-```bash
-# Dependencies are already installed via CoW!
-warp feature/new-ui
-cd ../worktrees/feature-new-ui
-npm start  # Works immediately
-```
-
-**With Claude Code**:
-```bash
-# Monitor AI agent activity while developing
-warp agents &  # Background monitoring
-warp switch ai-integration
-# Work with Claude Code while monitoring agent activities
-```
-
-**With Docker/Services**:
-```bash
-# Safe service management
-warp cleanup --kill --mode merged  # Stops services in cleaned worktrees
-warp switch main
-docker-compose up  # Start services in main worktree
-```
-
----
+If no hook records or readable session history exists, the dashboard shows an
+empty state with setup guidance.
 
 ## Configuration
 
-Git-Warp uses a sophisticated configuration system with three layers:
+Show the effective config:
 
-### 1. Configuration File
+```bash
+warp config --show
+```
 
-Located at: `~/.config/git-warp/config.toml`
+Create or open the config file in `$VISUAL` or `$EDITOR`:
+
+```bash
+warp config --edit
+```
+
+Default config path:
+
+```text
+~/.config/git-warp/config.toml
+```
+
+Example:
 
 ```toml
-# Terminal mode: tab, window, current, inplace, echo
 terminal_mode = "tab"
-
-# Use Copy-on-Write when available
 use_cow = true
-
-# Auto-confirm destructive operations
 auto_confirm = false
-
-# Custom worktrees directory (optional)
 # worktrees_path = "/custom/path/to/worktrees"
 
 [git]
-# Default main branch name
 default_branch = "main"
-
-# Branches cleanup must never remove
 protected_branches = ["main", "master", "develop"]
-
-# Auto-fetch before operations
 auto_fetch = true
-
-# Auto-prune remote tracking branches
 auto_prune = true
 
 [process]
-# Check for processes before cleanup
 check_processes = true
-
-# Auto-kill processes during cleanup
 auto_kill = false
-
-# Grace period before force killing (seconds)
 kill_timeout = 5
 
 [terminal]
-# Terminal app: auto, iterm2, terminal, warp
 app = "auto"
-
-# Auto-activate new macOS terminal tabs/windows
 auto_activate = true
-
-# Commands to run after Git-Warp changes into the worktree
 init_commands = []
 
 [agent]
-# Enable agent monitoring
 enabled = true
-
-# Refresh rate for agent dashboard (milliseconds)
 refresh_rate = 1000
-
-# Maximum activities to track
 max_activities = 100
-
-# Enable Claude Code hooks integration
 claude_hooks = true
 ```
 
-### 2. Environment Variables
-
-Override any setting with `GIT_WARP_` prefix:
+Environment variables override config file values:
 
 ```bash
-# Terminal behavior
 export GIT_WARP_TERMINAL_MODE=window
-export GIT_WARP_AUTO_CONFIRM=true
-
-# Performance
-export GIT_WARP_USE_COW=false  # Disable CoW
-
-# Paths
+export GIT_WARP_USE_COW=false
+export GIT_WARP_AUTO_CONFIRM=false
 export GIT_WARP_WORKTREES_PATH=/Users/me/dev/worktrees
 ```
 
-### 3. Command-Line Options
-
-Highest priority, overrides everything:
+Command-line options have the highest priority:
 
 ```bash
 warp --terminal window --auto-confirm switch feature-branch
 ```
 
-### Configuration Priority
-
-1. **Command-line options** (highest)
-2. **Environment variables** 
-3. **Configuration file**
-4. **Built-in defaults** (lowest)
-
----
-
 ## Troubleshooting
 
-### Common Issues
+### Not in a Git Repository
 
-**CoW Not Working**:
+Run Git-Warp from inside a Git repository:
+
 ```bash
-# Check filesystem type
-df -T .
-# Should show "apfs" for CoW support
+cd /path/to/repo
+warp doctor
+```
 
-# Force traditional method
+### CoW Is Not Available
+
+Git-Warp falls back to normal Git worktree creation when CoW is unsupported.
+You can skip CoW checks explicitly:
+
+```bash
 warp switch --no-cow branch-name
 ```
 
-**Terminal Integration Issues**:
-```bash
-# Check terminal support
-warp config --show
-# Look for "Terminal Integration" section
+### Terminal Handoff Fails
 
-# Try different terminal mode
+Use `echo` mode to get a plain path without terminal automation:
+
+```bash
 warp --terminal echo switch branch-name
 ```
 
-**Permission Errors**:
+Then manually `cd` into the printed path.
+
+### Cleanup Is Blocked
+
+Preview candidates and inspect blockers:
+
 ```bash
-# Check directory permissions
-ls -la ../worktrees/
-
-# Create worktrees directory manually
-mkdir -p ../worktrees
-```
-
-**Process Detection Issues**:
-```bash
-# Bypass process checks
-warp cleanup --force --mode merged
-
-# Check what processes are detected
 warp --dry-run cleanup --mode merged
+warp ls --debug
 ```
 
-### Debug Mode
+If processes are the blocker, either stop them manually or use `--kill`. Use
+`--force` only when you are intentionally bypassing dirty/process safety.
 
-Enable verbose logging:
+### Config Does Not Open
+
+`warp config --edit` needs `$VISUAL` or `$EDITOR`.
 
 ```bash
-RUST_LOG=debug warp --debug switch feature-branch
-```
-
-### Recovery Operations
-
-**Clean Up Corrupted Worktrees**:
-```bash
-# Remove broken worktree references
-git worktree prune
-
-# List remaining worktrees
-git worktree list
-
-# Manual removal if needed
-rm -rf ../worktrees/broken-branch
-git worktree remove --force broken-branch
-```
-
-**Reset Configuration**:
-```bash
-# Remove config file
-rm ~/.config/git-warp/config.toml
-
-# Recreate and open the default config
+export EDITOR=vim
 warp config --edit
 ```
-
----
 
 ## Best Practices
 
-### 1. Worktree Organization
-
-**Recommended Structure**:
-```
-your-project/
-├── .git/
-├── main-branch-files/
-└── ../worktrees/
-    ├── feature-authentication/
-    ├── hotfix-security-issue/
-    └── experimental-ui/
-```
-
-**Naming Conventions**:
-- Use descriptive, kebab-case names: `feature-user-auth`
-- Include type prefix: `feature/`, `hotfix/`, `experiment/`
-- Keep names short but clear
-
-### 2. Development Workflow
-
-**Daily Workflow**:
-```bash
-# Start of day
-warp switch main
-git pull
-
-# New feature
-warp feature/amazing-feature
-# Work, commit, push
-
-# Code review
-warp switch main
-# Review PRs
-
-# Quick hotfix
-warp hotfix/critical-bug
-# Fix, test, deploy
-
-# End of day cleanup
-warp cleanup --mode merged
-```
-
-**Team Collaboration**:
-- Share branch naming conventions
-- Use consistent worktree organization
-- Document custom configuration settings
-
-### 3. Performance Optimization
-
-**Maximize CoW Benefits**:
-- Keep `node_modules/` and build artifacts in main worktree
-- Use `.gitignore` to exclude large generated files
-- Regularly clean up old worktrees
-
-**Resource Management**:
-- Monitor disk usage: `du -sh ../worktrees/*`
-- Set reasonable limits in configuration
-- Use cleanup commands regularly
-
-### 4. Safety Practices
-
-**Before Destructive Operations**:
-```bash
-# Always dry-run first
-warp --dry-run cleanup --mode all
-
-# Check for uncommitted changes
-warp ls --debug
-
-# Backup important work
-git stash --include-untracked  # In each worktree
-```
-
-**Process Management**:
-- Always check for running processes
-- Use graceful termination (avoid --force unless necessary)
-- Monitor services that might span worktrees
-
-### 5. Integration Tips
-
-**With IDEs**:
-- Configure IDE to handle multiple project roots
-- Use workspace features for multi-worktree development
-- Set up consistent formatting/linting across worktrees
-
-**With CI/CD**:
-- Ensure CI systems understand worktree structure
-- Use relative paths in configuration files
-- Test deployment from different worktrees
-
-**With Docker**:
-- Be careful with volume mounts spanning worktrees
-- Consider worktree-specific docker-compose files
-- Clean up containers when removing worktrees
-
----
+- Run `warp doctor` after installation or config changes.
+- Prefer `warp --dry-run cleanup ...` before destructive cleanup.
+- Keep protected branch config aligned with your repo conventions.
+- Use short branch names that still identify the task.
+- Use `warp --terminal echo switch <branch>` in scripts or automation where
+  opening a terminal tab would be surprising.
 
 ## Advanced Scenarios
 
-### Large Monorepos
+### Large Repositories
+
+Use a stable worktree location on a fast disk:
 
 ```bash
-# Set custom worktree location to faster disk
 export GIT_WARP_WORKTREES_PATH=/fast-ssd/worktrees
-
-# Increase cleanup thresholds
-warp config --edit
-# Adjust max_activities and other limits
+warp switch feature/large-repo-change
 ```
 
-### Multi-Team Development
+### Team Defaults
+
+Share conservative settings through shell profile or onboarding docs:
 
 ```bash
-# Team-specific configuration
-export GIT_WARP_TERMINAL_MODE=window  # For team preference
-export GIT_WARP_AUTO_CONFIRM=false    # Safety for shared environments
-
-# Standardize worktree structure
-export GIT_WARP_WORKTREES_PATH=/teams/shared/worktrees
+export GIT_WARP_AUTO_CONFIRM=false
+export GIT_WARP_TERMINAL_MODE=window
 ```
 
-### Continuous Integration
+### CI or Non-Interactive Scripts
+
+Use terminal output modes that do not launch UI:
 
 ```bash
-# CI-friendly settings
 export GIT_WARP_AUTO_CONFIRM=true
-export GIT_WARP_USE_COW=false  # May not be available in CI
+export GIT_WARP_USE_COW=false
 export GIT_WARP_TERMINAL_MODE=echo
 ```
 
----
-
-Git-Warp transforms Git worktree management from a complex, error-prone process into an effortless, intelligent workflow. Whether you're working on small features or managing large monorepos, Git-Warp's combination of speed, safety, and intelligence makes it an indispensable tool for modern development.
-
-**Happy warping! 🚀**
+Prefer `warp --help` and `warp <command> --help` as the source of truth for the
+current command surface.


### PR DESCRIPTION
## Summary
- replace launch-style README copy with current supported commands and setup guidance
- simplify the docs index to existing pages and historical references only
- rewrite the user guide around verified CLI behavior and safer cleanup/config examples

Closes #10

## Verification
- local Markdown link check for README.md, docs/README.md, and docs/user-guide.md
- git diff --check
- cargo run --quiet -- --help / config --help / cleanup --help / hooks-install --help
- cargo test --test mod cli_surface_tests -- --nocapture - 17 passed

Note: repo labels do not include codex or codex-automation, so only the documentation label was applied.