### PR TITLE
Make cleanup candidate analysis trustworthy

### DIFF
--- a/docs/superpowers/plans/2026-04-26-cleanup-candidate-trust.md
+++ b/docs/superpowers/plans/2026-04-26-cleanup-candidate-trust.md
@@ -1,0 +1,43 @@
+# Cleanup Candidate Trust Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make cleanup candidates trustworthy and consistent across CLI and TUI flows.
+
+**Architecture:** Resolve cleanup base branch inside `GitRepository`, use it during branch analysis, and pass filtered `BranchStatus` values into the cleanup TUI. Keep reason rendering as small helper functions so CLI and TUI wording stays aligned.
+
+**Tech Stack:** Rust, clap CLI, ratatui TUI, git CLI integration, cargo tests.
+
+---
+
+### Task 1: Default-Branch Cleanup Analysis
+
+**Files:**
+- Modify: `src/git.rs`
+- Modify: `tests/unit/git_tests.rs`
+
+- [x] Add tests for a repo initialized with `trunk` where a merged feature worktree is detected against `trunk`.
+- [x] Add `cleanup_base_branch()` to prefer `origin/HEAD`, then primary worktree branch, then configured default.
+- [x] Use that base for `is_merged` and `is_identical`.
+
+### Task 2: Shared Candidate Filtering
+
+**Files:**
+- Modify: `src/cli.rs`
+- Modify: `src/tui.rs`
+- Modify: `tests/unit/tui_tests.rs`
+
+- [x] Add helper text for cleanup row reasons.
+- [x] Filter candidates once in CLI before optional interactive mode.
+- [x] Make `CleanupTui` accept the filtered candidates so interactive and non-interactive flows share the same candidate set.
+
+### Task 3: Verification and Publish
+
+**Files:**
+- Modify: implementation and test files above
+- Create: spec and plan docs for issue #4
+
+- [x] Run targeted failing tests before implementation.
+- [x] Run targeted passing tests after implementation.
+- [x] Run formatting and whitespace checks.
+- [x] Commit, push, and open a ready PR closing issue #4.

--- a/docs/superpowers/specs/2026-04-26-cleanup-candidate-trust-design.md
+++ b/docs/superpowers/specs/2026-04-26-cleanup-candidate-trust-design.md
@@ -1,0 +1,15 @@
+# Cleanup Candidate Trust Design
+
+## Goal
+
+Make `warp cleanup` explain and remove the same branches in non-interactive and interactive flows, using the repository's actual cleanup base branch instead of guessing common branch names.
+
+## Design
+
+Cleanup analysis resolves a single base branch from live repository state. It prefers `origin/HEAD` when available, then falls back to the primary worktree branch, then the configured `git.default_branch` only when neither live signal is available. Protected branches remain excluded from cleanup, but they no longer drive merged/identical decisions.
+
+CLI cleanup builds one filtered candidate list for the chosen mode. The list includes plain reason labels such as `merged`, `identical`, `no remote`, `clean`, or `dirty`, so the user can see why a branch is eligible or why a branch is skipped. Interactive cleanup receives that already-filtered candidate list, so the TUI cannot show a branch that the CLI flow would later discard.
+
+## Testing
+
+Add regression coverage for a repository whose primary branch is not `main`, proving a merged branch is recognized against that real base branch. Add unit coverage that cleanup row text exposes the same reason labels used by CLI and TUI rendering.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -920,7 +920,7 @@ impl Cli {
 
         let git_repo = GitRepository::find().map_err(|_| Self::not_in_git_repo_error())?;
         let config_manager = ConfigManager::new()?;
-        let protected_branches = config_manager.get().git.protected_branches.clone();
+        let git_config = config_manager.get().git.clone();
         let mut process_manager = ProcessManager::new();
 
         if self.dry_run {
@@ -935,10 +935,8 @@ impl Cli {
         }
 
         let worktrees = git_repo.list_worktrees()?;
-        let branch_statuses = git_repo.analyze_branches_for_cleanup_with_protected_branches(
-            &worktrees,
-            &protected_branches,
-        )?;
+        let branch_statuses =
+            git_repo.analyze_branches_for_cleanup_with_config(&worktrees, &git_config)?;
 
         if branch_statuses.is_empty() {
             println!("✨ No worktrees to clean up");
@@ -946,9 +944,10 @@ impl Cli {
         }
 
         let mut candidates = Vec::new();
+        let mut blocked = Vec::new();
 
         // Filter based on mode
-        for status in &branch_statuses {
+        for status in branch_statuses {
             let should_include = match mode {
                 "all" => true,
                 "merged" => status.is_merged,
@@ -960,9 +959,26 @@ impl Cli {
                 }
             };
 
-            if should_include && (!status.has_uncommitted_changes || force) {
-                candidates.push(status);
+            if should_include {
+                if status.has_uncommitted_changes && !force {
+                    blocked.push(status);
+                } else {
+                    candidates.push(status);
+                }
             }
+        }
+
+        if !blocked.is_empty() {
+            println!("🚧 Skipped cleanup branches:");
+            for branch in &blocked {
+                println!(
+                    "  • {} at {} [{}; dirty; use --force to include]",
+                    branch.branch,
+                    branch.path.display(),
+                    crate::tui::cleanup_reason_label(branch)
+                );
+            }
+            println!();
         }
 
         if candidates.is_empty() {
@@ -973,18 +989,23 @@ impl Cli {
         // Show what would be cleaned up
         println!("🧹 Cleanup candidates:");
         for candidate in &candidates {
-            let uncommitted = if candidate.has_uncommitted_changes {
-                " (⚠️  uncommitted)"
+            let remote = if candidate.has_remote {
+                "remote"
             } else {
-                ""
+                "no remote"
             };
-            let merged = if candidate.is_merged { " [merged]" } else { "" };
+            let dirty = if candidate.has_uncommitted_changes {
+                "dirty"
+            } else {
+                "clean"
+            };
             println!(
-                "  • {} at {}{}{}",
+                "  • {} at {} [{}; {}; {}]",
                 candidate.branch,
                 candidate.path.display(),
-                merged,
-                uncommitted
+                crate::tui::cleanup_reason_label(candidate),
+                remote,
+                dirty
             );
         }
 
@@ -992,7 +1013,7 @@ impl Cli {
             use crate::tui::CleanupTui;
 
             println!("\n🤖 Starting interactive cleanup...");
-            let cleanup_tui = CleanupTui::new();
+            let cleanup_tui = CleanupTui::with_candidates(candidates.clone());
             let selected_branches = cleanup_tui.run()?;
 
             if selected_branches.is_empty() {

--- a/src/git.rs
+++ b/src/git.rs
@@ -271,10 +271,8 @@ impl GitRepository {
         &self,
         worktrees: &[WorktreeInfo],
     ) -> Result<Vec<BranchStatus>> {
-        self.analyze_branches_for_cleanup_with_protected_branches(
-            worktrees,
-            &GitConfig::default().protected_branches,
-        )
+        let config = GitConfig::default();
+        self.analyze_branches_for_cleanup_with_config(worktrees, &config)
     }
 
     /// Analyze branches for cleanup using an explicit protected branch list
@@ -283,13 +281,67 @@ impl GitRepository {
         worktrees: &[WorktreeInfo],
         protected_branches: &[String],
     ) -> Result<Vec<BranchStatus>> {
+        self.analyze_branches_for_cleanup_with_options(
+            worktrees,
+            protected_branches,
+            &GitConfig::default().default_branch,
+        )
+    }
+
+    /// Analyze branches for cleanup using full git configuration
+    pub fn analyze_branches_for_cleanup_with_config(
+        &self,
+        worktrees: &[WorktreeInfo],
+        config: &GitConfig,
+    ) -> Result<Vec<BranchStatus>> {
+        self.analyze_branches_for_cleanup_with_options(
+            worktrees,
+            &config.protected_branches,
+            &config.default_branch,
+        )
+    }
+
+    /// Resolve the branch cleanup compares candidates against
+    pub fn cleanup_base_branch(
+        &self,
+        worktrees: &[WorktreeInfo],
+        configured_default_branch: &str,
+    ) -> Result<String> {
+        if let Some(remote_default) = self.remote_default_branch()? {
+            return Ok(remote_default);
+        }
+
+        if let Some(primary_branch) = worktrees
+            .iter()
+            .find(|worktree| worktree.is_primary && !worktree.branch.trim().is_empty())
+            .map(|worktree| worktree.branch.clone())
+        {
+            return Ok(primary_branch);
+        }
+
+        let configured_default_branch = configured_default_branch.trim();
+        if !configured_default_branch.is_empty() {
+            return Ok(configured_default_branch.to_string());
+        }
+
+        self.get_main_branch()
+    }
+
+    fn analyze_branches_for_cleanup_with_options(
+        &self,
+        worktrees: &[WorktreeInfo],
+        protected_branches: &[String],
+        configured_default_branch: &str,
+    ) -> Result<Vec<BranchStatus>> {
         use std::process::Command;
 
         let mut branch_statuses = Vec::new();
+        let cleanup_base_branch = self.cleanup_base_branch(worktrees, configured_default_branch)?;
 
         for worktree in worktrees {
             if worktree.is_primary
                 || worktree.branch.is_empty()
+                || worktree.branch == cleanup_base_branch
                 || is_protected_branch(&worktree.branch, protected_branches)
             {
                 continue;
@@ -309,34 +361,18 @@ impl GitRepository {
                 output.status.success() && !output.stdout.is_empty()
             };
 
-            // Check if branch is merged to a protected base branch
-            let is_merged = {
-                let mut merged = false;
+            // Check if branch is merged to the repo's actual cleanup base branch
+            let is_merged = Command::new("git")
+                .args(["merge-base", "--is-ancestor", branch, &cleanup_base_branch])
+                .current_dir(&self.repo_path)
+                .output()
+                .map(|output| output.status.success())
+                .unwrap_or(false);
 
-                for main_branch in protected_branches {
-                    if branch == main_branch {
-                        continue;
-                    }
-
-                    let output = Command::new("git")
-                        .args(&["merge-base", "--is-ancestor", branch, main_branch])
-                        .current_dir(&self.repo_path)
-                        .output();
-
-                    if let Ok(output) = output {
-                        if output.status.success() {
-                            merged = true;
-                            break;
-                        }
-                    }
-                }
-                merged
-            };
-
-            // Check if branch is identical to main
+            // Check if branch is identical to the repo's actual cleanup base branch
             let is_identical = {
                 let output = Command::new("git")
-                    .args(&["diff", "--quiet", "main", branch])
+                    .args(["diff", "--quiet", &cleanup_base_branch, branch])
                     .current_dir(&self.repo_path)
                     .output();
 
@@ -364,6 +400,26 @@ impl GitRepository {
         }
 
         Ok(branch_statuses)
+    }
+
+    fn remote_default_branch(&self) -> Result<Option<String>> {
+        use std::process::Command;
+
+        let output = Command::new("git")
+            .args(["symbolic-ref", "refs/remotes/origin/HEAD"])
+            .current_dir(&self.repo_path)
+            .output()
+            .map_err(|e| anyhow::anyhow!("Failed to inspect remote default branch: {}", e))?;
+
+        if !output.status.success() {
+            return Ok(None);
+        }
+
+        let branch_ref = String::from_utf8_lossy(&output.stdout);
+        Ok(branch_ref
+            .trim()
+            .strip_prefix("refs/remotes/origin/")
+            .map(str::to_string))
     }
 
     /// Fetch from remote

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1036,21 +1036,31 @@ pub fn next_bulk_selection_state(selected: &[bool]) -> bool {
     !selected.is_empty() && !selected.iter().all(|is_selected| *is_selected)
 }
 
-fn cleanup_reason_label(status: &BranchStatus) -> &'static str {
+pub fn cleanup_reason_label(status: &BranchStatus) -> &'static str {
     if status.is_merged {
         "merged"
     } else if status.is_identical {
         "identical"
+    } else if !status.has_remote {
+        "no remote"
     } else {
         "candidate"
     }
 }
 
-pub struct CleanupTui;
+pub struct CleanupTui {
+    candidates: Option<Vec<BranchStatus>>,
+}
 
 impl CleanupTui {
     pub fn new() -> Self {
-        Self
+        Self { candidates: None }
+    }
+
+    pub fn with_candidates(candidates: Vec<BranchStatus>) -> Self {
+        Self {
+            candidates: Some(candidates),
+        }
     }
 
     pub fn run(&self) -> Result<Vec<String>> {
@@ -1076,12 +1086,12 @@ impl CleanupTui {
         let git_repo =
             GitRepository::find().map_err(|_| anyhow::anyhow!("Not in a git repository"))?;
         let config_manager = ConfigManager::new()?;
-        let protected_branches = config_manager.get().git.protected_branches.clone();
+        let config = config_manager.get().git.clone();
         let worktrees = git_repo.list_worktrees()?;
-        let branch_statuses = git_repo.analyze_branches_for_cleanup_with_protected_branches(
-            &worktrees,
-            &protected_branches,
-        )?;
+        let branch_statuses = match &self.candidates {
+            Some(candidates) => candidates.clone(),
+            None => git_repo.analyze_branches_for_cleanup_with_config(&worktrees, &config)?,
+        };
 
         if branch_statuses.is_empty() {
             println!("✨ No worktrees found that can be cleaned up!");

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -19,10 +19,14 @@ fn run_git(repo_path: &Path, args: &[&str]) {
 }
 
 fn setup_test_repo() -> tempfile::TempDir {
+    setup_test_repo_with_initial_branch("main")
+}
+
+fn setup_test_repo_with_initial_branch(initial_branch: &str) -> tempfile::TempDir {
     let temp_dir = tempdir().unwrap();
     let repo_path = temp_dir.path();
 
-    run_git(repo_path, &["init", "-b", "main"]);
+    run_git(repo_path, &["init", "-b", initial_branch]);
     run_git(repo_path, &["config", "user.email", "test@example.com"]);
     run_git(repo_path, &["config", "user.name", "Test User"]);
 
@@ -354,6 +358,34 @@ fn test_bare_warp_dry_run_marks_only_nested_worktree_current() {
     assert!(output.status.success(), "{stdout}");
     assert!(!stdout.contains("main [current"));
     assert!(stdout.contains("feature/default-picker [current"));
+}
+
+#[test]
+fn test_cleanup_uses_primary_branch_as_base_and_prints_candidate_reasons() {
+    let temp_dir = setup_test_repo_with_initial_branch("trunk");
+    let repo_path = temp_dir.path();
+    let worktree_path = create_worktree(repo_path, "feature/merged");
+
+    let output = warp_command(repo_path)
+        .args(["--auto-confirm", "cleanup", "--mode", "merged", "--no-kill"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{stdout}");
+    assert!(
+        stdout.contains("feature/merged at"),
+        "candidate branch should be printed: {stdout}"
+    );
+    assert!(
+        stdout.contains("[merged; no remote; clean]"),
+        "candidate reasons should be visible: {stdout}"
+    );
+    assert!(
+        stdout.contains("Removed worktree and branch: feature/merged"),
+        "cleanup should remove the merged worktree and branch: {stdout}"
+    );
+    assert!(!worktree_path.exists());
 }
 
 #[test]

--- a/tests/unit/git_tests.rs
+++ b/tests/unit/git_tests.rs
@@ -4,12 +4,16 @@ use std::process::Command;
 use tempfile::tempdir;
 
 fn setup_test_repo() -> tempfile::TempDir {
+    setup_test_repo_with_initial_branch("main")
+}
+
+fn setup_test_repo_with_initial_branch(initial_branch: &str) -> tempfile::TempDir {
     let temp_dir = tempdir().unwrap();
     let repo_path = temp_dir.path();
 
     // Initialize git repo
     Command::new("git")
-        .args(&["init", "--initial-branch", "main"])
+        .args(&["init", "--initial-branch", initial_branch])
         .current_dir(repo_path)
         .output()
         .unwrap();
@@ -323,6 +327,42 @@ fn test_analyze_branches_for_cleanup() {
         assert!(!status.has_uncommitted_changes); // Should be clean
         assert!(!status.has_remote); // No remotes configured
     }
+}
+
+#[test]
+fn test_cleanup_analysis_uses_primary_worktree_branch_when_default_is_not_main() {
+    let temp_dir = setup_test_repo_with_initial_branch("trunk");
+    let repo_path = temp_dir.path();
+    std::env::set_current_dir(repo_path).unwrap();
+
+    let git_repo = GitRepository::find().unwrap();
+
+    Command::new("git")
+        .args(&["branch", "feature-done"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    let feature_path = repo_path.join("worktrees").join("feature-done");
+    git_repo
+        .create_worktree_and_branch("feature-done", &feature_path, Some("feature-done"))
+        .unwrap();
+
+    let worktrees = git_repo.list_worktrees().unwrap();
+    let branch_statuses = git_repo.analyze_branches_for_cleanup(&worktrees).unwrap();
+    let feature_status = branch_statuses
+        .iter()
+        .find(|status| status.branch == "feature-done")
+        .expect("feature worktree should be analyzed");
+
+    assert!(
+        feature_status.is_merged,
+        "feature branch should be merged into the primary trunk branch"
+    );
+    assert!(
+        feature_status.is_identical,
+        "feature branch should be identical to the primary trunk branch"
+    );
 }
 
 #[test]

--- a/tests/unit/tui_tests.rs
+++ b/tests/unit/tui_tests.rs
@@ -363,6 +363,27 @@ fn test_build_cleanup_rows_explains_candidate_status_with_text() {
 }
 
 #[test]
+fn test_build_cleanup_rows_explains_remoteless_candidates() {
+    let rows = build_cleanup_rows(
+        &[BranchStatus {
+            branch: "feature/local-only".to_string(),
+            path: PathBuf::from("/repo/.worktrees/local-only"),
+            has_remote: false,
+            is_merged: false,
+            is_identical: false,
+            has_uncommitted_changes: false,
+        }],
+        &[false],
+    );
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].reason_label, "no remote");
+    assert_eq!(rows[0].remote_label, "no remote");
+    assert_eq!(rows[0].dirty_label, "clean");
+    assert!(rows[0].display_line.contains("no remote"));
+}
+
+#[test]
 fn test_next_bulk_selection_state_selects_all_unless_all_are_selected() {
     assert!(next_bulk_selection_state(&[false, false]));
     assert!(next_bulk_selection_state(&[true, false]));


### PR DESCRIPTION
## Summary
- resolve cleanup comparisons from the repo's actual default branch, falling back to the primary worktree branch
- show cleanup reasons for eligible and dirty-skipped branches
- feed the CLI-filtered candidate set into interactive cleanup so both flows agree

Closes #4

## Verification
- cargo test test_cleanup_analysis_uses_primary_worktree_branch_when_default_is_not_main -- --nocapture --test-threads=1
- cargo test test_build_cleanup_rows_explains_remoteless_candidates -- --nocapture
- cargo test test_cleanup_uses_primary_branch_as_base_and_prints_candidate_reasons -- --nocapture --test-threads=1
- cargo fmt --check
- git diff --check
- git diff --cached --check
- cargo test unit::git_tests -- --nocapture --test-threads=1 - 16 passed
- cargo test unit::tui_tests -- --nocapture - 15 passed
- cargo test integration::cli_surface_tests -- --nocapture --test-threads=1 - 18 passed

Note: repo labels do not include codex or codex-automation.