### PR TITLE
Add release validation command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- `warp release-check` validates release metadata and runs the maintainer
+  release verification flow before tagging.
 - Prebuilt release binary workflow for macOS and Linux targets.
 - Root `install.sh` now installs prebuilt release binaries by default, with
   Cargo available only as an explicit fallback.

--- a/README.md
+++ b/README.md
@@ -202,6 +202,12 @@ cargo test --test mod tui_tests -- --nocapture
 git diff --check
 ```
 
+Before tagging a release, run the release validation flow:
+
+```bash
+warp release-check --version v0.3.0
+```
+
 Useful manual checks:
 
 ```bash
@@ -214,6 +220,7 @@ cargo run -- --dry-run cleanup --mode merged
 ## Documentation
 
 - [Install Git-Warp](docs/install.md)
+- [Release Check](docs/release-check.md)
 - [User Guide](docs/user-guide.md)
 - [Technical Overview](docs/technical-overview.md)
 - [Documentation Index](docs/README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,8 @@ material, and original reference documents for Git-Warp.
 
 - [Install Git-Warp](install.md): one-command install, PATH setup, and
   version/install-directory options.
+- [Release Check](release-check.md): release metadata validation and pre-tag
+  smoke checks.
 - [User Guide](user-guide.md): daily commands, configuration, and
   troubleshooting.
 - [Technical Overview](technical-overview.md): architecture, modules, and

--- a/docs/release-check.md
+++ b/docs/release-check.md
@@ -1,0 +1,45 @@
+# Release Check
+
+Run the release check before tagging a Git-Warp release.
+
+```bash
+warp release-check --version v0.3.0
+```
+
+The command validates release metadata first, then runs the release verification
+commands. It stops at the first failing command.
+
+## Metadata Checks
+
+`warp release-check --version v0.3.0` verifies that:
+
+- `Cargo.toml` has package version `0.3.0`.
+- `CHANGELOG.md` has a `v0.3.0` release heading.
+- `docs/releases/v0.3.0.md` exists.
+- `docs/install.md` mentions `GIT_WARP_VERSION=v0.3.0`.
+- `install.sh` defaults `GIT_WARP_VERSION` to `v0.3.0`.
+
+Use the fast metadata-only mode while preparing notes:
+
+```bash
+warp release-check --metadata-only --version v0.3.0
+```
+
+## Full Verification
+
+After metadata passes, the full command runs:
+
+```bash
+cargo fmt --check
+cargo test
+cargo build --release --bin warp
+./target/release/warp --version
+./target/release/warp --help
+./target/release/warp switch --help
+./target/release/warp cleanup --help
+./target/release/warp doctor
+```
+
+For source builds, this covers the contributor path. For public installs, the
+metadata checks cover the install script default, pinned install docs, release
+notes, and changelog before the tag is created.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -99,6 +99,16 @@ pub enum Commands {
     /// Check Git-Warp setup and print next steps
     Doctor,
 
+    /// Validate release metadata and smoke checks
+    ReleaseCheck {
+        /// Expected release version, for example v0.3.0
+        #[arg(long)]
+        version: Option<String>,
+        /// Only validate version, changelog, release notes, install docs, and install script
+        #[arg(long)]
+        metadata_only: bool,
+    },
+
     /// Install agent hooks
     HooksInstall {
         /// Installation level: user, project, console
@@ -285,6 +295,13 @@ impl Cli {
             Commands::Config { show, edit } => self.handle_config(*show, *edit),
             Commands::Agents => self.handle_agents(),
             Commands::Doctor => self.handle_doctor(),
+            Commands::ReleaseCheck {
+                version,
+                metadata_only,
+            } => crate::release::run_release_check(crate::release::ReleaseCheckOptions {
+                version: version.clone(),
+                metadata_only: *metadata_only,
+            }),
             Commands::HooksInstall { level, runtime } => {
                 self.handle_hooks_install(level.as_deref(), runtime)
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod git;
 mod hooks;
 mod post_create;
 mod process;
+mod release;
 mod rewrite;
 mod terminal;
 mod tui;

--- a/src/release.rs
+++ b/src/release.rs
@@ -1,0 +1,299 @@
+use anyhow::{Context, Result, bail};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub struct ReleaseCheckOptions {
+    pub version: Option<String>,
+    pub metadata_only: bool,
+}
+
+struct ReleaseVersion {
+    number: String,
+    tag: String,
+}
+
+struct ReleaseCheck {
+    label: &'static str,
+    ok: bool,
+    detail: String,
+}
+
+impl ReleaseCheck {
+    fn pass(label: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            label,
+            ok: true,
+            detail: detail.into(),
+        }
+    }
+
+    fn fail(label: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            label,
+            ok: false,
+            detail: detail.into(),
+        }
+    }
+}
+
+pub fn run_release_check(options: ReleaseCheckOptions) -> Result<()> {
+    let repo_root = std::env::current_dir().context("failed to read current directory")?;
+    let cargo_version = read_package_version(&repo_root)?;
+    let expected = resolve_version(options.version.as_deref(), &cargo_version)?;
+    let checks = collect_metadata_checks(&repo_root, &expected, &cargo_version)?;
+
+    print_metadata_checks(&checks);
+
+    let failures = checks
+        .iter()
+        .filter(|check| !check.ok)
+        .map(|check| check.detail.as_str())
+        .collect::<Vec<_>>();
+
+    if !failures.is_empty() {
+        bail!(
+            "Release metadata checks failed:\n- {}",
+            failures.join("\n- ")
+        );
+    }
+
+    println!("Release metadata checks passed for {}", expected.tag);
+
+    if options.metadata_only {
+        return Ok(());
+    }
+
+    run_release_commands(&repo_root, &expected)
+}
+
+fn resolve_version(version: Option<&str>, cargo_version: &str) -> Result<ReleaseVersion> {
+    let raw = version.unwrap_or(cargo_version).trim();
+    let number = raw.strip_prefix('v').unwrap_or(raw);
+
+    if number.is_empty() {
+        bail!("release version cannot be empty");
+    }
+
+    Ok(ReleaseVersion {
+        number: number.to_string(),
+        tag: format!("v{number}"),
+    })
+}
+
+fn read_package_version(repo_root: &Path) -> Result<String> {
+    let cargo_toml_path = repo_root.join("Cargo.toml");
+    let cargo_toml = fs::read_to_string(&cargo_toml_path)
+        .with_context(|| format!("failed to read {}", cargo_toml_path.display()))?;
+    let cargo_toml: toml::Value = toml::from_str(&cargo_toml)
+        .with_context(|| format!("failed to parse {}", cargo_toml_path.display()))?;
+
+    cargo_toml
+        .get("package")
+        .and_then(|package| package.get("version"))
+        .and_then(|version| version.as_str())
+        .map(ToOwned::to_owned)
+        .context("Cargo.toml is missing package.version")
+}
+
+fn collect_metadata_checks(
+    repo_root: &Path,
+    expected: &ReleaseVersion,
+    cargo_version: &str,
+) -> Result<Vec<ReleaseCheck>> {
+    let changelog = read_optional(repo_root.join("CHANGELOG.md"))?;
+    let install_doc = read_optional(repo_root.join("docs").join("install.md"))?;
+    let install_script = read_optional(repo_root.join("install.sh"))?;
+    let release_notes_path = repo_root
+        .join("docs")
+        .join("releases")
+        .join(format!("{}.md", expected.tag));
+
+    let mut checks = Vec::new();
+
+    if cargo_version == expected.number {
+        checks.push(ReleaseCheck::pass(
+            "Cargo.toml",
+            format!("package version is {}", expected.number),
+        ));
+    } else {
+        checks.push(ReleaseCheck::fail(
+            "Cargo.toml",
+            format!(
+                "Cargo.toml package version is {}, expected {}",
+                cargo_version, expected.number
+            ),
+        ));
+    }
+
+    if changelog.contains(&format!("## {} ", expected.tag))
+        || changelog.contains(&format!("## {}\n", expected.tag))
+    {
+        checks.push(ReleaseCheck::pass(
+            "CHANGELOG.md",
+            format!("has a {} release heading", expected.tag),
+        ));
+    } else {
+        checks.push(ReleaseCheck::fail(
+            "CHANGELOG.md",
+            format!("CHANGELOG.md is missing a {} release heading", expected.tag),
+        ));
+    }
+
+    if release_notes_path.exists() {
+        checks.push(ReleaseCheck::pass(
+            "release notes",
+            format!(
+                "{} exists",
+                display_relative(repo_root, &release_notes_path)
+            ),
+        ));
+    } else {
+        checks.push(ReleaseCheck::fail(
+            "release notes",
+            format!(
+                "{} is missing",
+                display_relative(repo_root, &release_notes_path)
+            ),
+        ));
+    }
+
+    if install_doc.contains(&format!("GIT_WARP_VERSION={}", expected.tag)) {
+        checks.push(ReleaseCheck::pass(
+            "docs/install.md",
+            format!("mentions GIT_WARP_VERSION={}", expected.tag),
+        ));
+    } else {
+        checks.push(ReleaseCheck::fail(
+            "docs/install.md",
+            format!(
+                "docs/install.md does not mention GIT_WARP_VERSION={}",
+                expected.tag
+            ),
+        ));
+    }
+
+    if install_script.contains(&format!(
+        "version=\"${{GIT_WARP_VERSION:-{}}}\"",
+        expected.tag
+    )) {
+        checks.push(ReleaseCheck::pass(
+            "install.sh",
+            format!("defaults to {}", expected.tag),
+        ));
+    } else {
+        checks.push(ReleaseCheck::fail(
+            "install.sh",
+            format!(
+                "install.sh default GIT_WARP_VERSION is not {}",
+                expected.tag
+            ),
+        ));
+    }
+
+    Ok(checks)
+}
+
+fn read_optional(path: PathBuf) -> Result<String> {
+    match fs::read_to_string(&path) {
+        Ok(content) => Ok(content),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(String::new()),
+        Err(error) => Err(error).with_context(|| format!("failed to read {}", path.display())),
+    }
+}
+
+fn print_metadata_checks(checks: &[ReleaseCheck]) {
+    println!("Release metadata:");
+
+    for check in checks {
+        let status = if check.ok { "ok" } else { "missing" };
+        println!("- {status}: {} - {}", check.label, check.detail);
+    }
+}
+
+fn run_release_commands(repo_root: &Path, expected: &ReleaseVersion) -> Result<()> {
+    let release_binary = repo_root.join("target").join("release").join("warp");
+    let release_binary = release_binary.to_string_lossy().into_owned();
+
+    let steps = [
+        ReleaseCommand::new("cargo fmt --check", "cargo", &["fmt", "--check"]),
+        ReleaseCommand::new("cargo test", "cargo", &["test"]),
+        ReleaseCommand::new(
+            "cargo build --release --bin warp",
+            "cargo",
+            &["build", "--release", "--bin", "warp"],
+        ),
+        ReleaseCommand::new(
+            "./target/release/warp --version",
+            release_binary.as_str(),
+            &["--version"],
+        ),
+        ReleaseCommand::new(
+            "./target/release/warp --help",
+            release_binary.as_str(),
+            &["--help"],
+        ),
+        ReleaseCommand::new(
+            "./target/release/warp switch --help",
+            release_binary.as_str(),
+            &["switch", "--help"],
+        ),
+        ReleaseCommand::new(
+            "./target/release/warp cleanup --help",
+            release_binary.as_str(),
+            &["cleanup", "--help"],
+        ),
+        ReleaseCommand::new(
+            "./target/release/warp doctor",
+            release_binary.as_str(),
+            &["doctor"],
+        ),
+    ];
+
+    println!("Release command checks:");
+
+    for step in steps {
+        run_step(repo_root, step)?;
+    }
+
+    println!("Release checks passed for {}", expected.tag);
+    Ok(())
+}
+
+struct ReleaseCommand<'a> {
+    label: &'static str,
+    program: &'a str,
+    args: &'a [&'a str],
+}
+
+impl<'a> ReleaseCommand<'a> {
+    fn new(label: &'static str, program: &'a str, args: &'a [&'a str]) -> Self {
+        Self {
+            label,
+            program,
+            args,
+        }
+    }
+}
+
+fn run_step(repo_root: &Path, step: ReleaseCommand<'_>) -> Result<()> {
+    println!("$ {}", step.label);
+    let status = Command::new(step.program)
+        .args(step.args)
+        .current_dir(repo_root)
+        .status()
+        .with_context(|| format!("failed to run {}", step.label))?;
+
+    if !status.success() {
+        bail!("{} failed with status {}", step.label, status);
+    }
+
+    Ok(())
+}
+
+fn display_relative(repo_root: &Path, path: &Path) -> String {
+    path.strip_prefix(repo_root)
+        .unwrap_or(path)
+        .display()
+        .to_string()
+}

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -150,6 +150,66 @@ fn test_root_help_shows_doctor_command() {
 }
 
 #[test]
+fn test_root_help_shows_release_check_command() {
+    let output = Command::new(env!("CARGO_BIN_EXE_warp"))
+        .arg("--help")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success());
+    assert!(stdout.contains("release-check"));
+    assert!(stdout.contains("Validate release metadata and smoke checks"));
+}
+
+#[test]
+fn test_release_check_metadata_only_accepts_current_release_metadata() {
+    let output = Command::new(env!("CARGO_BIN_EXE_warp"))
+        .args([
+            "release-check",
+            "--metadata-only",
+            "--version",
+            concat!("v", env!("CARGO_PKG_VERSION")),
+        ])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "{stdout}{stderr}");
+    assert!(
+        stdout.contains("Release metadata checks passed"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains(concat!("v", env!("CARGO_PKG_VERSION"))),
+        "{stdout}"
+    );
+}
+
+#[test]
+fn test_release_check_metadata_only_rejects_missing_future_release_updates() {
+    let output = Command::new(env!("CARGO_BIN_EXE_warp"))
+        .args(["release-check", "--metadata-only", "--version", "v0.3.0"])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success(), "{stdout}");
+    assert!(
+        stderr.contains("Cargo.toml package version is 0.2.0, expected 0.3.0"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("docs/releases/v0.3.0.md is missing"),
+        "{stderr}"
+    );
+}
+
+#[test]
 fn test_doctor_outside_repo_prints_recovery_guidance() {
     let temp_dir = tempdir().unwrap();
     let home_dir = tempdir().unwrap();


### PR DESCRIPTION
## Summary
- add `warp release-check` with metadata validation for Cargo version, changelog, release notes, install docs, and install script
- run the full maintainer release flow after metadata passes: fmt, tests, release build, version, help, and doctor smoke checks
- document the pre-tag release flow and cover metadata behavior in CLI surface tests

Closes #31

## Verification
- `cargo fmt --check`
- `cargo test --test mod release_check -- --nocapture`
- `cargo test --test mod cli_surface_tests -- --nocapture`
- `cargo run -- release-check --metadata-only`
- `cargo run -- release-check --metadata-only --version v0.3.0` failed as expected with missing v0.3.0 metadata
- `cargo build --release --bin warp`
- `./target/release/warp --version`
- `./target/release/warp --help`, `switch --help`, `cleanup --help`, `doctor`
- `git diff --check`
- `git diff --cached --check`

Note: repo labels do not include `codex` or `codex-automation`.
