### PR TITLE
Harden installer failure messaging

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,8 +19,39 @@ fail() {
   exit 1
 }
 
+supported_targets() {
+  cat >&2 <<'EOF'
+Supported prebuilt targets:
+  - macOS Apple Silicon: aarch64-apple-darwin
+  - macOS Intel: x86_64-apple-darwin
+  - Linux arm64: aarch64-unknown-linux-gnu
+  - Linux x64: x86_64-unknown-linux-gnu
+EOF
+}
+
+cargo_fallback_hint() {
+  cat >&2 <<EOF
+If you have Rust and Cargo installed, retry with:
+  curl -fsSL ${repo_url}/raw/main/install.sh | GIT_WARP_INSTALL_METHOD=cargo sh
+EOF
+}
+
+fail_unsupported_target() {
+  echo "error: unsupported $1: $2" >&2
+  supported_targets
+  cargo_fallback_hint
+  exit 1
+}
+
+fail_download() {
+  echo "error: failed to download $1" >&2
+  echo "The release asset may not exist yet for this platform or version." >&2
+  cargo_fallback_hint
+  exit 1
+}
+
 need_cmd() {
-  command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+  command -v "$1" >/dev/null 2>&1 || fail "$1 is required for Git-Warp installation"
 }
 
 download() {
@@ -28,11 +59,13 @@ download() {
   output="$2"
 
   if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$url" -o "$output"
+    curl -fsSL "$url" -o "$output" || fail_download "$url"
   elif command -v wget >/dev/null 2>&1; then
-    wget -q "$url" -O "$output"
+    wget -q "$url" -O "$output" || fail_download "$url"
   else
-    fail "curl or wget is required to download Git-Warp"
+    echo "error: curl or wget is required to download Git-Warp release assets" >&2
+    cargo_fallback_hint
+    exit 1
   fi
 }
 
@@ -43,13 +76,13 @@ target_triple() {
   case "$os" in
     Darwin) os_part="apple-darwin" ;;
     Linux) os_part="unknown-linux-gnu" ;;
-    *) fail "unsupported operating system: $os" ;;
+    *) fail_unsupported_target "operating system" "$os" ;;
   esac
 
   case "$arch" in
     arm64 | aarch64) arch_part="aarch64" ;;
     x86_64 | amd64) arch_part="x86_64" ;;
-    *) fail "unsupported CPU architecture: $arch" ;;
+    *) fail_unsupported_target "CPU architecture" "$arch" ;;
   esac
 
   printf '%s-%s\n' "$arch_part" "$os_part"
@@ -70,10 +103,13 @@ install_from_binary() {
   echo "Downloading Git-Warp ${version} for ${target}"
   download "$url" "$archive"
 
-  tar -xzf "$archive" -C "$tmp_dir"
+  tar -xzf "$archive" -C "$tmp_dir" || fail "failed to extract ${archive}; the download may be incomplete or corrupt"
 
   if [ ! -f "${tmp_dir}/warp" ]; then
-    fail "release archive did not contain a warp binary"
+    echo "error: release archive did not contain a warp binary" >&2
+    echo "Check that ${asset} is the expected Git-Warp release asset." >&2
+    cargo_fallback_hint
+    exit 1
   fi
 
   mkdir -p "$install_dir"
@@ -94,13 +130,17 @@ install_from_cargo() {
 
   set -- "$@" git-warp
 
-  "$@"
+  "$@" || {
+    echo "error: Cargo install failed for Git-Warp ${version}." >&2
+    echo "Check the Cargo output above, then retry after fixing the reported build or network issue." >&2
+    exit 1
+  }
 }
 
 case "$method" in
   binary) install_from_binary ;;
   cargo) install_from_cargo ;;
-  *) fail "unsupported install method: $method" ;;
+  *) fail "unsupported install method: ${method}; use 'binary' or 'cargo'" ;;
 esac
 
 echo
@@ -115,7 +155,11 @@ fi
 
 case ":${PATH}:" in
   *":${install_dir}:"*) ;;
-  *) echo "Add ${install_dir} to PATH if your shell cannot find 'warp'." ;;
+  *)
+    echo "Add ${install_dir} to PATH so your shell can find 'warp':"
+    echo "  export PATH=\"${install_dir}:\$PATH\""
+    echo "Open a new terminal or run 'warp doctor' after updating PATH."
+    ;;
 esac
 
 echo "Run 'warp doctor' to check your setup."

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -3,6 +3,9 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::tempdir;
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
 fn run_git(repo_path: &Path, args: &[&str]) {
     let output = Command::new("git")
         .args(args)
@@ -121,6 +124,244 @@ fn expected_config_path(home: &Path) -> PathBuf {
     } else {
         home.join(".config").join("git-warp").join("config.toml")
     }
+}
+
+#[cfg(unix)]
+fn write_executable(path: &Path, content: &str) {
+    fs::write(path, content).unwrap();
+    let mut permissions = fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap();
+}
+
+#[cfg(unix)]
+fn install_script_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("install.sh")
+}
+
+#[cfg(unix)]
+fn installer_command(path_dir: &Path, home_dir: &Path) -> Command {
+    let mut command = Command::new("/bin/sh");
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    command
+        .arg(install_script_path())
+        .env("HOME", home_dir)
+        .env("PATH", format!("{}:{original_path}", path_dir.display()))
+        .env("GIT_WARP_VERSION", "v9.9.9");
+    command
+}
+
+#[cfg(unix)]
+#[test]
+fn test_installer_explains_unsupported_platform() {
+    let fake_bin = tempdir().unwrap();
+    let home_dir = tempdir().unwrap();
+
+    write_executable(
+        &fake_bin.path().join("uname"),
+        r#"#!/bin/sh
+if [ "$1" = "-s" ]; then
+  echo Plan9
+else
+  echo sparc
+fi
+"#,
+    );
+
+    let output = installer_command(fake_bin.path(), home_dir.path())
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success(), "{stderr}");
+    assert!(
+        stderr.contains("unsupported operating system: Plan9"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("Supported prebuilt targets:"), "{stderr}");
+    assert!(stderr.contains("GIT_WARP_INSTALL_METHOD=cargo"), "{stderr}");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_installer_explains_unsupported_architecture() {
+    let fake_bin = tempdir().unwrap();
+    let home_dir = tempdir().unwrap();
+
+    write_executable(
+        &fake_bin.path().join("uname"),
+        r#"#!/bin/sh
+if [ "$1" = "-s" ]; then
+  echo Darwin
+else
+  echo powerpc
+fi
+"#,
+    );
+
+    let output = installer_command(fake_bin.path(), home_dir.path())
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success(), "{stderr}");
+    assert!(
+        stderr.contains("unsupported CPU architecture: powerpc"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("Supported prebuilt targets:"), "{stderr}");
+    assert!(stderr.contains("GIT_WARP_INSTALL_METHOD=cargo"), "{stderr}");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_installer_explains_failed_binary_download() {
+    let fake_bin = tempdir().unwrap();
+    let home_dir = tempdir().unwrap();
+
+    write_executable(
+        &fake_bin.path().join("uname"),
+        r#"#!/bin/sh
+if [ "$1" = "-s" ]; then
+  echo Darwin
+else
+  echo arm64
+fi
+"#,
+    );
+    write_executable(
+        &fake_bin.path().join("curl"),
+        r#"#!/bin/sh
+echo "not found" >&2
+exit 22
+"#,
+    );
+
+    let output = installer_command(fake_bin.path(), home_dir.path())
+        .env("GIT_WARP_DOWNLOAD_BASE", "https://example.invalid/releases")
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success(), "{stderr}");
+    assert!(
+        stderr.contains(
+            "failed to download https://example.invalid/releases/git-warp-v9.9.9-aarch64-apple-darwin.tar.gz"
+        ),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("The release asset may not exist yet for this platform or version."),
+        "{stderr}"
+    );
+    assert!(stderr.contains("GIT_WARP_INSTALL_METHOD=cargo"), "{stderr}");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_installer_explains_cargo_fallback_failure() {
+    let fake_bin = tempdir().unwrap();
+    let home_dir = tempdir().unwrap();
+
+    write_executable(
+        &fake_bin.path().join("cargo"),
+        r#"#!/bin/sh
+echo "cargo exploded" >&2
+exit 101
+"#,
+    );
+
+    let output = installer_command(fake_bin.path(), home_dir.path())
+        .env("GIT_WARP_INSTALL_METHOD", "cargo")
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success(), "{stderr}");
+    assert!(stderr.contains("cargo exploded"), "{stderr}");
+    assert!(
+        stderr.contains("Cargo install failed for Git-Warp v9.9.9."),
+        "{stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_installer_prints_actionable_path_guidance() {
+    let fake_bin = tempdir().unwrap();
+    let home_dir = tempdir().unwrap();
+    let install_dir = tempdir().unwrap();
+
+    write_executable(
+        &fake_bin.path().join("uname"),
+        r#"#!/bin/sh
+if [ "$1" = "-s" ]; then
+  echo Linux
+else
+  echo x86_64
+fi
+"#,
+    );
+    write_executable(
+        &fake_bin.path().join("curl"),
+        r#"#!/bin/sh
+output=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    output="$1"
+  fi
+  shift
+done
+printf fake > "$output"
+"#,
+    );
+    write_executable(
+        &fake_bin.path().join("tar"),
+        r#"#!/bin/sh
+dest=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-C" ]; then
+    shift
+    dest="$1"
+  fi
+  shift
+done
+cat > "$dest/warp" <<'SCRIPT'
+#!/bin/sh
+echo warp 9.9.9
+SCRIPT
+chmod 755 "$dest/warp"
+"#,
+    );
+
+    let output = installer_command(fake_bin.path(), home_dir.path())
+        .env("GIT_WARP_INSTALL_DIR", install_dir.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "{stdout}{stderr}");
+    assert!(stdout.contains("warp 9.9.9"), "{stdout}");
+    assert!(
+        stdout.contains(&format!(
+            "Add {} to PATH so your shell can find 'warp':",
+            install_dir.path().display()
+        )),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains(&format!(
+            "export PATH=\"{}:$PATH\"",
+            install_dir.path().display()
+        )),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("Open a new terminal or run 'warp doctor' after updating PATH."),
+        "{stdout}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- harden `install.sh` failure messages for unsupported OS/arch, failed release downloads, broken archives, invalid methods, and Cargo fallback failures
- print exact PATH export guidance after successful installs when the install directory is not discoverable
- add offline installer surface tests with fake `uname`, `curl`, `tar`, and `cargo` commands

## Verification
- `cargo test --test mod cli_surface_tests -- --nocapture` (26 passed)
- `cargo fmt --check`
- `git diff --check`

Closes #32
