### PR TITLE
[codex] fix worktree path root resolution

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -520,11 +520,23 @@ impl GitRepository {
 
         let base_path = match worktrees_path {
             Some(path) if path.is_absolute() => path.to_path_buf(),
-            Some(path) => self.repo_path.join(path),
-            None => self.repo_path.join("../worktrees"),
+            Some(path) => self.primary_worktree_root().join(path),
+            None => self.primary_worktree_root().join("../worktrees"),
         };
 
         base_path.join(sanitized_branch)
+    }
+
+    fn primary_worktree_root(&self) -> PathBuf {
+        self.list_worktrees()
+            .ok()
+            .and_then(|worktrees| {
+                worktrees
+                    .into_iter()
+                    .find(|worktree| worktree.is_primary)
+                    .map(|worktree| worktree.path)
+            })
+            .unwrap_or_else(|| self.repo_path.clone())
     }
 
     /// Get the main branch name (main or master)

--- a/tests/unit/git_tests.rs
+++ b/tests/unit/git_tests.rs
@@ -565,3 +565,29 @@ fn test_worktree_path_generation_with_relative_base() {
 
     assert!(worktree_path.ends_with(".worktrees/feature-with-custom-base"));
 }
+
+#[test]
+fn test_relative_worktrees_path_generation_uses_primary_root_from_linked_worktree() {
+    let _cwd = crate::support::CurrentDirGuard::new();
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path().canonicalize().unwrap();
+    let linked_path = repo_path.join(".worktrees").join("feature-current");
+
+    std::env::set_current_dir(&repo_path).unwrap();
+    let main_repo = GitRepository::find().unwrap();
+    main_repo
+        .create_worktree_and_branch("feature-current", &linked_path, None)
+        .unwrap();
+
+    std::env::set_current_dir(&linked_path).unwrap();
+    let linked_repo = GitRepository::find().unwrap();
+    let worktree_path = linked_repo.get_worktree_path_with_base(
+        "feature/from-linked",
+        Some(std::path::Path::new(".worktrees")),
+    );
+
+    assert_eq!(
+        worktree_path,
+        repo_path.join(".worktrees").join("feature-from-linked")
+    );
+}


### PR DESCRIPTION
## Summary
- Resolve relative configured worktree paths from the primary worktree root instead of the current linked worktree.
- Leave already-anchored configured path values unchanged.
- Add regression coverage for path generation from inside a linked worktree.

## Root Cause
When `warp switch` ran from an existing linked worktree, `GitRepository` used that linked worktree as `repo_path`. A relative `worktrees_path = ".worktrees"` was then joined onto the linked worktree path, creating nested paths like `.worktrees/<current>/.worktrees/<new>`.

## Validation
- `cargo fmt --check`
- `cargo test test_relative_worktrees_path_generation_uses_primary_root_from_linked_worktree -- --nocapture`
- `cargo test worktree_path_generation -- --nocapture`
- `git diff --check`
- From an existing `webui-nodeum` linked worktree, `warp --dry-run switch codex-path-check-nested` resolves to `.worktrees/codex-path-check-nested` under the primary repo root, not `.worktrees/<current>/.worktrees/codex-path-check-nested`