### PR TITLE
[codex] reuse existing branch worktree

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -449,6 +449,17 @@ impl Cli {
         Ok(())
     }
 
+    fn existing_worktree_path_for_branch(
+        git_repo: &crate::git::GitRepository,
+        branch: &str,
+    ) -> Result<Option<PathBuf>> {
+        Ok(git_repo
+            .list_worktrees()?
+            .into_iter()
+            .find(|worktree| worktree.branch == branch)
+            .map(|worktree| worktree.path))
+    }
+
     fn handle_existing_worktree_jump(&self, worktree_path: &Path) -> Result<()> {
         use crate::config::ConfigManager;
         use crate::terminal::TerminalMode;
@@ -502,6 +513,10 @@ impl Cli {
         // Determine worktree path
         let worktree_path = if let Some(path) = path {
             PathBuf::from(path)
+        } else if let Some(existing_path) =
+            Self::existing_worktree_path_for_branch(&git_repo, &branch)?
+        {
+            existing_path
         } else {
             git_repo.get_worktree_path_with_base(&branch, config.worktrees_path.as_deref())
         };
@@ -512,7 +527,9 @@ impl Cli {
                 branch,
                 worktree_path.display()
             );
-            if !no_cow && cow::is_cow_supported(&worktree_path).unwrap_or(false) {
+            if worktree_path.exists() {
+                println!("Would reuse existing worktree");
+            } else if !no_cow && cow::is_cow_supported(&worktree_path).unwrap_or(false) {
                 println!("Would use Copy-on-Write for fast worktree creation");
             } else {
                 println!("Would use traditional Git worktree creation");

--- a/tests/integration/terminal_switch_tests.rs
+++ b/tests/integration/terminal_switch_tests.rs
@@ -268,6 +268,57 @@ fn test_warp_switch_branch_already_in_use_prints_recovery_guidance() {
 }
 
 #[test]
+fn test_dynamic_branch_reuses_existing_worktree_for_branch() {
+    let repo_dir = setup_git_repo();
+    let repo_path = repo_dir.path();
+    let home_dir = tempdir().unwrap();
+    let worktree_path = repo_path
+        .join("external-worktrees")
+        .join("feature-existing");
+
+    write_config_with_terminal_options(home_dir.path(), "auto", "echo", true, &[]);
+
+    let create_output = Command::new("git")
+        .args(["worktree", "add", "-b", "feature/existing"])
+        .arg(&worktree_path)
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    assert!(
+        create_output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&create_output.stderr)
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_warp"))
+        .args(["--terminal", "echo", "feature/existing"])
+        .current_dir(repo_path)
+        .env("HOME", home_dir.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let expected_path = worktree_path.canonicalize().unwrap();
+
+    assert!(output.status.success(), "stdout={stdout}\nstderr={stderr}");
+    assert!(
+        stdout.contains(&format!(
+            "📁 Worktree already exists at: {}",
+            expected_path.display()
+        )),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("↪️  Worktree creation: already existed"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("✅ Branch checkout: feature/existing"),
+        "{stdout}"
+    );
+}
+
+#[test]
 fn test_warp_switch_reports_existing_worktree_branch_mismatch_as_incomplete() {
     let repo_dir = setup_git_repo();
     let repo_path = repo_dir.path();


### PR DESCRIPTION
## Summary
- Reuse an existing worktree when `warp <branch>` is called for a branch that Git already has checked out elsewhere.
- Keep explicit `--path` behavior unchanged and improve dry-run output for the reuse case.
- Add a regression test for a branch whose worktree lives outside the default computed path.

## Root cause
`warp <branch>` computed the default target path first and only checked whether that path existed. If the same branch was already checked out at another path, Git rejected the later `worktree add`, while the TUI worked because it starts from `git worktree list` and already knows the existing path.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test terminal_switch_tests -- --nocapture`
- `cargo test cli_surface_tests -- --nocapture`
- Manual smoke before branch publish: `warp --terminal echo logo-loader` reused `/Users/deryzh/.codex/worktrees/afe0/webui-nodeum`