### PR TITLE
Add batch removal to worktree TUI

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -348,6 +348,9 @@ impl Cli {
         match switcher.run()? {
             Some(WorktreeSwitchAction::Switch(target)) => self.handle_switcher_target(target),
             Some(WorktreeSwitchAction::Remove(target)) => self.handle_switcher_remove(target),
+            Some(WorktreeSwitchAction::RemoveMany(batch)) => {
+                self.handle_switcher_batch_remove(batch)
+            }
             None => {
                 println!("No worktree selected");
                 Ok(())
@@ -445,6 +448,87 @@ impl Cli {
         if let Err(err) = git_repo.prune_worktrees() {
             log::warn!("Failed to prune worktrees: {}", err);
         }
+
+        Ok(())
+    }
+
+    fn handle_switcher_batch_remove(&self, batch: crate::tui::WorktreeBatchRemoval) -> Result<()> {
+        use crate::git::GitRepository;
+
+        let git_repo = GitRepository::find().map_err(|_| Self::not_in_git_repo_error())?;
+
+        println!(
+            "Batch removing {} selected worktree{}",
+            batch.targets.len(),
+            if batch.targets.len() == 1 { "" } else { "s" }
+        );
+
+        if !batch.skipped.is_empty() {
+            println!(
+                "Skipped {} worktree{}:",
+                batch.skipped.len(),
+                if batch.skipped.len() == 1 { "" } else { "s" }
+            );
+            for skipped in &batch.skipped {
+                println!(
+                    "  - {} {} ({})",
+                    skipped.branch_label,
+                    skipped.path.display(),
+                    skipped.reason
+                );
+            }
+        }
+
+        if batch.targets.is_empty() {
+            println!(
+                "Batch removal complete: 0 removed, {} skipped, 0 failed",
+                batch.skipped.len()
+            );
+            return Ok(());
+        }
+
+        let mut removed = 0;
+        let mut failed = 0;
+
+        for target in batch.targets {
+            println!(
+                "Removing worktree for branch '{}': {}",
+                target.branch,
+                target.path.display()
+            );
+
+            match git_repo.remove_worktree(&target.path) {
+                Ok(()) => {
+                    removed += 1;
+                    match git_repo.delete_branch(&target.branch, false) {
+                        Ok(()) => {
+                            println!("Removed worktree and branch: {}", target.branch);
+                        }
+                        Err(err) => {
+                            println!(
+                                "Removed worktree but kept branch '{}': {}",
+                                target.branch, err
+                            );
+                        }
+                    }
+                }
+                Err(err) => {
+                    failed += 1;
+                    println!("Failed to remove worktree '{}': {}", target.branch, err);
+                }
+            }
+        }
+
+        if let Err(err) = git_repo.prune_worktrees() {
+            log::warn!("Failed to prune worktrees: {}", err);
+        }
+
+        println!(
+            "Batch removal complete: {} removed, {} skipped, {} failed",
+            removed,
+            batch.skipped.len(),
+            failed
+        );
 
         Ok(())
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -22,6 +22,7 @@ use ratatui::{
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
 };
 use std::{
+    collections::BTreeSet,
     io,
     path::PathBuf,
     time::{Duration, Instant, SystemTime},
@@ -114,9 +115,23 @@ pub struct WorktreeRemovalTarget {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
+pub struct WorktreeRemovalSkip {
+    pub branch_label: String,
+    pub path: PathBuf,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct WorktreeBatchRemoval {
+    pub targets: Vec<WorktreeRemovalTarget>,
+    pub skipped: Vec<WorktreeRemovalSkip>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum WorktreeSwitchAction {
     Switch(WorktreeSwitchTarget),
     Remove(WorktreeRemovalTarget),
+    RemoveMany(WorktreeBatchRemoval),
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -136,6 +151,11 @@ pub struct WorktreeSwitchRow {
     pub badges: Vec<String>,
     pub target: WorktreeSwitchTarget,
     pub removal_blockers: Vec<WorktreeRemovalBlock>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct WorktreeSwitchDisplayRow {
+    pub display_line: String,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -169,6 +189,43 @@ impl WorktreeSwitchModel {
             branch: row.target.branch.clone()?,
             path: row.target.path.clone(),
         })
+    }
+
+    pub fn batch_removal_at(&self, indices: &[usize]) -> Option<WorktreeBatchRemoval> {
+        let unique_indices = indices.iter().copied().collect::<BTreeSet<_>>();
+        if unique_indices.is_empty() {
+            return None;
+        }
+
+        let mut targets = Vec::new();
+        let mut skipped = Vec::new();
+
+        for index in unique_indices {
+            let Some(row) = self.rows.get(index) else {
+                continue;
+            };
+
+            if let Some(target) = self.removal_at(index) {
+                targets.push(target);
+            } else {
+                let reason = if row.removal_blockers.is_empty() {
+                    "no local branch".to_string()
+                } else {
+                    removal_blocker_summary(&row.removal_blockers)
+                };
+                skipped.push(WorktreeRemovalSkip {
+                    branch_label: row.branch_label.clone(),
+                    path: row.target.path.clone(),
+                    reason,
+                });
+            }
+        }
+
+        if targets.is_empty() && skipped.is_empty() {
+            return None;
+        }
+
+        Some(WorktreeBatchRemoval { targets, skipped })
     }
 }
 
@@ -530,6 +587,39 @@ fn removal_blocker_summary(blockers: &[WorktreeRemovalBlock]) -> String {
         .join(", ")
 }
 
+pub fn build_worktree_switch_rows(
+    model: &WorktreeSwitchModel,
+    selected_indices: &[usize],
+) -> Vec<WorktreeSwitchDisplayRow> {
+    let selected_indices = selected_indices.iter().copied().collect::<BTreeSet<_>>();
+
+    model
+        .rows
+        .iter()
+        .enumerate()
+        .map(|(index, row)| {
+            let checked = if selected_indices.contains(&index) {
+                "[x]"
+            } else {
+                "[ ]"
+            };
+            let badges = if row.badges.is_empty() {
+                String::new()
+            } else {
+                format!(" [{}]", row.badges.join(", "))
+            };
+            let display_line = format!(
+                "{checked} {:<30} {:<28} {}",
+                truncate_label(&row.branch_label, 30),
+                truncate_label(&badges, 28),
+                row.path_label
+            );
+
+            WorktreeSwitchDisplayRow { display_line }
+        })
+        .collect()
+}
+
 pub fn build_dashboard_model(
     sessions: &[AgentSessionSummary],
     now: DateTime<Local>,
@@ -805,6 +895,12 @@ pub struct WorktreeSwitchTui {
     model: WorktreeSwitchModel,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+enum PendingWorktreeRemoval {
+    Single(WorktreeRemovalTarget),
+    Batch(WorktreeBatchRemoval),
+}
+
 impl WorktreeSwitchTui {
     pub fn new(model: WorktreeSwitchModel) -> Self {
         Self { model }
@@ -856,15 +952,18 @@ impl WorktreeSwitchTui {
         terminal: &mut RatatuiTerminal<CrosstermBackend<io::Stdout>>,
     ) -> Result<Option<WorktreeSwitchAction>> {
         let mut selected_index = 0;
-        let mut pending_remove: Option<WorktreeRemovalTarget> = None;
+        let mut selected_indices = BTreeSet::new();
+        let mut pending_remove: Option<PendingWorktreeRemoval> = None;
         let mut notice: Option<String> = None;
 
         loop {
+            let selected_indices_list = selected_indices.iter().copied().collect::<Vec<_>>();
             terminal.draw(|f| {
                 draw_worktree_switcher(
                     f,
                     &self.model,
                     selected_index,
+                    &selected_indices_list,
                     pending_remove.as_ref(),
                     notice.as_deref(),
                 )
@@ -878,7 +977,14 @@ impl WorktreeSwitchTui {
                 if let Some(removal) = pending_remove.clone() {
                     match key.code {
                         KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
-                            return Ok(Some(WorktreeSwitchAction::Remove(removal)));
+                            return Ok(Some(match removal {
+                                PendingWorktreeRemoval::Single(target) => {
+                                    WorktreeSwitchAction::Remove(target)
+                                }
+                                PendingWorktreeRemoval::Batch(batch) => {
+                                    WorktreeSwitchAction::RemoveMany(batch)
+                                }
+                            }));
                         }
                         KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
                             pending_remove = None;
@@ -901,6 +1007,28 @@ impl WorktreeSwitchTui {
                             (selected_index + 1).min(self.model.rows.len().saturating_sub(1));
                         notice = None;
                     }
+                    KeyCode::Char(' ') => {
+                        if !selected_indices.insert(selected_index) {
+                            selected_indices.remove(&selected_index);
+                        }
+                        notice = Some(format!(
+                            "{} worktree{} selected",
+                            selected_indices.len(),
+                            if selected_indices.len() == 1 { "" } else { "s" }
+                        ));
+                    }
+                    KeyCode::Char('a') => {
+                        if selected_indices.len() == self.model.rows.len() {
+                            selected_indices.clear();
+                        } else {
+                            selected_indices = (0..self.model.rows.len()).collect();
+                        }
+                        notice = Some(format!(
+                            "{} worktree{} selected",
+                            selected_indices.len(),
+                            if selected_indices.len() == 1 { "" } else { "s" }
+                        ));
+                    }
                     KeyCode::Enter => {
                         return Ok(self
                             .model
@@ -908,12 +1036,36 @@ impl WorktreeSwitchTui {
                             .map(WorktreeSwitchAction::Switch));
                     }
                     KeyCode::Char('d') | KeyCode::Delete => {
-                        if let Some(removal) = self.model.removal_at(selected_index) {
+                        if !selected_indices.is_empty() {
+                            let selected_indices_list =
+                                selected_indices.iter().copied().collect::<Vec<_>>();
+                            if let Some(batch) = self.model.batch_removal_at(&selected_indices_list)
+                            {
+                                if batch.targets.is_empty() {
+                                    let skipped = batch
+                                        .skipped
+                                        .iter()
+                                        .map(|skip| {
+                                            format!("{} ({})", skip.branch_label, skip.reason)
+                                        })
+                                        .collect::<Vec<_>>()
+                                        .join(", ");
+                                    notice = Some(format!(
+                                        "No selected worktrees can be removed: {skipped}"
+                                    ));
+                                } else {
+                                    notice = Some(batch_removal_notice(&batch));
+                                    pending_remove = Some(PendingWorktreeRemoval::Batch(batch));
+                                }
+                            } else {
+                                notice = Some("No worktrees selected".to_string());
+                            }
+                        } else if let Some(removal) = self.model.removal_at(selected_index) {
                             notice = Some(format!(
                                 "Remove '{}' and delete its local branch? y/N",
                                 removal.branch
                             ));
-                            pending_remove = Some(removal);
+                            pending_remove = Some(PendingWorktreeRemoval::Single(removal));
                         } else if let Some(row) = self.model.rows.get(selected_index) {
                             let reason = if row.removal_blockers.is_empty() {
                                 "no local branch".to_string()
@@ -935,7 +1087,8 @@ fn draw_worktree_switcher(
     f: &mut Frame,
     model: &WorktreeSwitchModel,
     selected_index: usize,
-    pending_remove: Option<&WorktreeRemovalTarget>,
+    selected_indices: &[usize],
+    pending_remove: Option<&PendingWorktreeRemoval>,
     notice: Option<&str>,
 ) {
     let chunks = Layout::default()
@@ -949,7 +1102,17 @@ fn draw_worktree_switcher(
         ])
         .split(f.size());
 
-    let header = Paragraph::new(format!("Warp Worktrees ({})", model.rows.len()))
+    let selected_count = selected_indices.len();
+    let header_text = if selected_count == 0 {
+        format!("Warp Worktrees ({})", model.rows.len())
+    } else {
+        format!(
+            "Warp Worktrees ({}; {} selected)",
+            model.rows.len(),
+            selected_count
+        )
+    };
+    let header = Paragraph::new(header_text)
         .style(
             Style::default()
                 .fg(Color::Cyan)
@@ -959,22 +1122,9 @@ fn draw_worktree_switcher(
         .block(Block::default().borders(Borders::ALL));
     f.render_widget(header, chunks[0]);
 
-    let items = model
-        .rows
-        .iter()
-        .map(|row| {
-            let badges = if row.badges.is_empty() {
-                String::new()
-            } else {
-                format!(" [{}]", row.badges.join(", "))
-            };
-            ListItem::new(Line::from(format!(
-                "{:<30} {:<28} {}",
-                truncate_label(&row.branch_label, 30),
-                truncate_label(&badges, 28),
-                row.path_label
-            )))
-        })
+    let items = build_worktree_switch_rows(model, selected_indices)
+        .into_iter()
+        .map(|row| ListItem::new(Line::from(row.display_line)))
         .collect::<Vec<_>>();
     let list = List::new(items)
         .block(Block::default().title("Branches").borders(Borders::ALL))
@@ -996,7 +1146,18 @@ fn draw_worktree_switcher(
             row.badges.join(", ")
         };
         let removal_status = if let Some(removal) = pending_remove {
-            format!("confirm remove {} (y/N)", removal.branch)
+            match removal {
+                PendingWorktreeRemoval::Single(removal) => {
+                    format!("confirm remove {} (y/N)", removal.branch)
+                }
+                PendingWorktreeRemoval::Batch(batch) => {
+                    format!(
+                        "confirm batch remove {} worktree{} (y/N)",
+                        batch.targets.len(),
+                        if batch.targets.len() == 1 { "" } else { "s" }
+                    )
+                }
+            }
         } else if row.removal_blockers.is_empty() && row.target.branch.is_some() {
             "available".to_string()
         } else if row.removal_blockers.is_empty() {
@@ -1011,11 +1172,12 @@ fn draw_worktree_switcher(
             .map(|message| format!("\nNote: {message}"))
             .unwrap_or_default();
         let details = Paragraph::new(format!(
-            "Branch: {}\nPath: {}\nStatus: {}\nRemove: {}{}",
+            "Branch: {}\nPath: {}\nStatus: {}\nRemove: {}\nSelected: {}{}",
             branch,
             row.target.path.display(),
             status,
             removal_status,
+            selected_count,
             notice_line
         ))
         .block(Block::default().title("Details").borders(Borders::ALL))
@@ -1024,11 +1186,43 @@ fn draw_worktree_switcher(
         f.render_widget(details, chunks[2]);
     }
 
-    let help = Paragraph::new("↑↓/jk: Navigate | Enter: Switch | d/Del: Remove | q/Esc: Quit")
+    let help = Paragraph::new(
+        "↑↓/jk: Navigate | Space: Select | a: All | Enter: Switch | d/Del: Remove selected/current | q/Esc: Quit",
+    )
         .style(Style::default().fg(Color::Gray))
         .alignment(Alignment::Center)
         .block(Block::default().borders(Borders::ALL).title("Help"));
     f.render_widget(help, chunks[3]);
+}
+
+fn batch_removal_notice(batch: &WorktreeBatchRemoval) -> String {
+    let mut parts = vec![format!(
+        "Remove {} selected worktree{}",
+        batch.targets.len(),
+        if batch.targets.len() == 1 { "" } else { "s" }
+    )];
+
+    let targets = batch
+        .targets
+        .iter()
+        .map(|target| format!("{} ({})", target.branch, target.path.display()))
+        .collect::<Vec<_>>()
+        .join("; ");
+    if !targets.is_empty() {
+        parts.push(format!("targets: {targets}"));
+    }
+
+    if !batch.skipped.is_empty() {
+        let skipped = batch
+            .skipped
+            .iter()
+            .map(|skip| format!("{} ({})", skip.branch_label, skip.reason))
+            .collect::<Vec<_>>()
+            .join("; ");
+        parts.push(format!("skipped: {skipped}"));
+    }
+
+    format!("{}? y/N", parts.join("; "))
 }
 
 pub fn build_cleanup_rows(statuses: &[BranchStatus], selected: &[bool]) -> Vec<CleanupRow> {

--- a/tests/unit/tui_tests.rs
+++ b/tests/unit/tui_tests.rs
@@ -6,8 +6,8 @@ use git_warp::git::{BranchStatus, WorktreeInfo};
 use git_warp::tui::{
     AgentsDashboard, WorktreeRemovalBlock, WorktreeRuntimeStatus, build_cleanup_rows,
     build_dashboard_model, build_dashboard_model_windowed, build_worktree_switch_model,
-    build_worktree_switch_model_with_protected_branches, next_bulk_selection_state,
-    session_detail_lines,
+    build_worktree_switch_model_with_protected_branches, build_worktree_switch_rows,
+    next_bulk_selection_state, session_detail_lines,
 };
 use std::{
     path::PathBuf,
@@ -582,4 +582,108 @@ fn test_worktree_switch_model_blocks_removal_for_protected_branches() {
         vec![WorktreeRemovalBlock::Protected]
     );
     assert!(model.removal_at(0).is_none());
+}
+
+#[test]
+fn test_worktree_switch_model_builds_batch_removal_plan_with_skips() {
+    let safe_path = PathBuf::from("/repo/.worktrees/safe");
+    let dirty_path = PathBuf::from("/repo/.worktrees/dirty");
+    let primary_path = PathBuf::from("/repo");
+    let worktrees = vec![
+        WorktreeInfo {
+            path: safe_path.clone(),
+            branch: "safe".to_string(),
+            head: "0123456789abcdef".to_string(),
+            is_primary: false,
+            is_current: false,
+            is_detached: false,
+        },
+        WorktreeInfo {
+            path: dirty_path.clone(),
+            branch: "dirty".to_string(),
+            head: "abcdef0123456789".to_string(),
+            is_primary: false,
+            is_current: false,
+            is_detached: false,
+        },
+        WorktreeInfo {
+            path: primary_path.clone(),
+            branch: "main".to_string(),
+            head: "fedcba9876543210".to_string(),
+            is_primary: true,
+            is_current: true,
+            is_detached: false,
+        },
+    ];
+    let statuses = vec![
+        WorktreeRuntimeStatus {
+            path: safe_path.clone(),
+            is_current: false,
+            is_dirty: false,
+            is_occupied: false,
+            last_touched: None,
+        },
+        WorktreeRuntimeStatus {
+            path: dirty_path.clone(),
+            is_current: false,
+            is_dirty: true,
+            is_occupied: false,
+            last_touched: None,
+        },
+        WorktreeRuntimeStatus {
+            path: primary_path.clone(),
+            is_current: true,
+            is_dirty: false,
+            is_occupied: false,
+            last_touched: None,
+        },
+    ];
+
+    let model = build_worktree_switch_model(&worktrees, &statuses);
+    let batch = model
+        .batch_removal_at(&[0, 1, 2, 2, 99])
+        .expect("selected rows should build a batch plan");
+
+    assert_eq!(batch.targets.len(), 1);
+    assert_eq!(batch.targets[0].branch, "safe");
+    assert_eq!(batch.targets[0].path, safe_path);
+    assert_eq!(batch.skipped.len(), 2);
+    assert_eq!(batch.skipped[0].branch_label, "dirty");
+    assert_eq!(batch.skipped[0].path, dirty_path);
+    assert_eq!(batch.skipped[0].reason, "dirty");
+    assert_eq!(batch.skipped[1].branch_label, "main");
+    assert_eq!(batch.skipped[1].path, primary_path);
+    assert_eq!(batch.skipped[1].reason, "primary, protected, current");
+    assert!(model.batch_removal_at(&[]).is_none());
+}
+
+#[test]
+fn test_build_worktree_switch_rows_marks_selected_entries() {
+    let worktrees = vec![
+        WorktreeInfo {
+            path: PathBuf::from("/repo/.worktrees/one"),
+            branch: "one".to_string(),
+            head: "0123456789abcdef".to_string(),
+            is_primary: false,
+            is_current: false,
+            is_detached: false,
+        },
+        WorktreeInfo {
+            path: PathBuf::from("/repo/.worktrees/two"),
+            branch: "two".to_string(),
+            head: "abcdef0123456789".to_string(),
+            is_primary: false,
+            is_current: false,
+            is_detached: false,
+        },
+    ];
+
+    let model = build_worktree_switch_model(&worktrees, &[]);
+    let rows = build_worktree_switch_rows(&model, &[1]);
+
+    assert_eq!(rows.len(), 2);
+    assert!(rows[0].display_line.starts_with("[ ]"));
+    assert!(rows[1].display_line.starts_with("[x]"));
+    assert!(rows[1].display_line.contains("two"));
+    assert!(rows[1].display_line.contains("/repo/.worktrees/two"));
 }


### PR DESCRIPTION
## Summary
- add Space/a multi-select support to the interactive worktree switcher
- plan batch removals with removable targets plus skipped unsafe rows and reasons
- report removed, skipped, and failed worktrees from the batch executor while preserving single-row remove behavior

## Validation
- cargo fmt --check
- cargo test --test mod unit::tui_tests -- --nocapture
- cargo test --test mod integration::cli_surface_tests -- --nocapture
- cargo test

Closes #46