### PR TITLE
Add upgrade and uninstall paths for installed binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ warp doctor
 The installer downloads a prebuilt binary for macOS/Linux and installs `warp` to
 `~/.local/bin`. If your shell cannot find `warp`, add that directory to `PATH`.
 
-More install options: [Install Git-Warp](docs/install.md).
+More install options, including upgrade and uninstall flows: [Install Git-Warp](docs/install.md).
 
 Cargo is still available as a fallback:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -65,6 +65,44 @@ Release binaries are published for:
 - Linux arm64: `aarch64-unknown-linux-gnu`
 - Linux x64: `x86_64-unknown-linux-gnu`
 
+## Upgrade
+
+Re-running the installer overwrites the binary at the same install directory:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.sh | sh
+```
+
+The installer prints any other `warp` binaries it sees (Cargo, Homebrew prefixes,
+custom directories). After the upgrade it warns when `warp` on `PATH` resolves
+to a different binary than the one just installed, and prints the fix:
+
+- Reorder `PATH` so the install directory comes first, or
+- Remove the older binary at the path the warning prints.
+
+Run `warp doctor` to confirm only one `warp` binary is active. The Install check
+lists every `warp` it finds in `PATH` and known install directories, marks the
+active one, and warns when more than one exists.
+
+## Uninstall
+
+Remove the default install with the bundled uninstaller:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/denysbutenko/git-warp/main/uninstall.sh | sh
+```
+
+The uninstaller removes `~/.local/bin/warp` (or `$GIT_WARP_INSTALL_DIR/warp`),
+lists any other detected `warp` installs without touching them, and warns if
+`warp` is still on `PATH` after the removal. Use `--dry-run` to preview the
+removal without changing anything.
+
+If you installed Git-Warp with Cargo, also run:
+
+```bash
+cargo uninstall git-warp
+```
+
 ## Cargo Fallback
 
 Use Cargo only if you want to build during installation:

--- a/install.sh
+++ b/install.sh
@@ -54,6 +54,55 @@ need_cmd() {
   command -v "$1" >/dev/null 2>&1 || fail "$1 is required for Git-Warp installation"
 }
 
+candidate_install_dirs() {
+  printf '%s\n' \
+    "${install_dir}" \
+    "${HOME}/.local/bin" \
+    "${HOME}/.cargo/bin" \
+    "/usr/local/bin" \
+    "/opt/homebrew/bin"
+}
+
+list_existing_warp_binaries() {
+  printed=""
+  candidate_install_dirs | awk 'NF && !seen[$0]++' | while IFS= read -r dir; do
+    binary="${dir}/warp"
+    [ -x "$binary" ] || continue
+    case ":$printed:" in
+      *":$binary:"*) continue ;;
+    esac
+    printed="${printed}:${binary}"
+    version_line="$("$binary" --version 2>/dev/null | head -n1)"
+    if [ -n "$version_line" ]; then
+      printf '  - %s (%s)\n' "$binary" "$version_line"
+    else
+      printf '  - %s\n' "$binary"
+    fi
+  done
+}
+
+report_existing_installs() {
+  existing="$(list_existing_warp_binaries)"
+  if [ -n "$existing" ]; then
+    echo "Existing Git-Warp installs detected:"
+    printf '%s\n' "$existing"
+    echo "The installer will replace ${install_dir}/warp; other locations are left as-is."
+    echo "Run 'curl -fsSL ${repo_url}/raw/main/uninstall.sh | sh' to remove the default install,"
+    echo "or 'cargo uninstall git-warp' to remove a Cargo install."
+    echo
+  fi
+}
+
+report_active_warp_shadowing() {
+  active="$(command -v warp 2>/dev/null || true)"
+  installed="${install_dir}/warp"
+  [ -n "$active" ] || return 0
+  [ "$active" = "$installed" ] && return 0
+  echo
+  echo "Note: 'warp' on PATH resolves to ${active}, not the binary just installed at ${installed}."
+  echo "Reorder PATH to put ${install_dir} first, or remove the older binary at ${active}."
+}
+
 download() {
   url="$1"
   output="$2"
@@ -137,6 +186,8 @@ install_from_cargo() {
   }
 }
 
+report_existing_installs
+
 case "$method" in
   binary) install_from_binary ;;
   cargo) install_from_cargo ;;
@@ -161,5 +212,7 @@ case ":${PATH}:" in
     echo "Open a new terminal or run 'warp doctor' after updating PATH."
     ;;
 esac
+
+report_active_warp_shadowing
 
 echo "Run 'warp doctor' to check your setup."

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -152,6 +152,12 @@ pub enum Commands {
     },
 }
 
+struct DoctorInstallEntry {
+    path: PathBuf,
+    active: bool,
+    version: Option<String>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SwitchStepStatus {
     Done,
@@ -1443,6 +1449,8 @@ impl Cli {
             );
         }
 
+        Self::report_doctor_install(&mut next_steps);
+
         if repo.is_some() && config_manager.config_exists() && hooks_installed {
             next_steps.push("Run `warp switch <branch>` to create or open a worktree.".to_string());
         }
@@ -1480,6 +1488,148 @@ impl Cli {
             }
         }
         candidate
+    }
+
+    fn report_doctor_install(next_steps: &mut Vec<String>) {
+        let installs = Self::doctor_install_candidates();
+        if installs.is_empty() {
+            Self::doctor_warn(
+                "Install",
+                "no warp binary found in PATH or known install dirs",
+            );
+            next_steps.push(
+                "Reinstall with `curl -fsSL https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.sh | sh`."
+                    .to_string(),
+            );
+            return;
+        }
+
+        let active_index = installs.iter().position(|entry| entry.active);
+        let detail = installs
+            .iter()
+            .enumerate()
+            .map(|(i, entry)| {
+                let marker = if Some(i) == active_index {
+                    " (active)"
+                } else {
+                    ""
+                };
+                let version = entry
+                    .version
+                    .as_deref()
+                    .map(|v| format!(" [{v}]"))
+                    .unwrap_or_default();
+                format!("{}{}{}", entry.path.display(), marker, version)
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let unique_paths: std::collections::BTreeSet<_> =
+            installs.iter().map(|entry| entry.path.clone()).collect();
+
+        if unique_paths.len() > 1 {
+            Self::doctor_warn(
+                "Install",
+                format!("multiple warp binaries detected: {detail}"),
+            );
+            next_steps.push(
+                "Resolve install conflicts: keep one warp binary on PATH, or run the matching uninstaller (`uninstall.sh` or `cargo uninstall git-warp`)."
+                    .to_string(),
+            );
+        } else {
+            Self::doctor_ok("Install", detail);
+        }
+    }
+
+    fn doctor_install_candidates() -> Vec<DoctorInstallEntry> {
+        let mut paths = Vec::new();
+
+        if let Some(active) = Self::resolve_warp_on_path() {
+            paths.push((active, true));
+        }
+
+        for dir in Self::doctor_install_probe_dirs() {
+            let candidate = dir.join("warp");
+            if candidate.is_file() {
+                paths.push((candidate, false));
+            }
+        }
+
+        let mut seen = std::collections::HashSet::new();
+        let mut entries = Vec::new();
+        for (path, active) in paths {
+            let canonical = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+            if !seen.insert(canonical.clone()) {
+                if active {
+                    if let Some(existing) = entries
+                        .iter_mut()
+                        .find(|e: &&mut DoctorInstallEntry| e.path == path)
+                    {
+                        existing.active = true;
+                    }
+                }
+                continue;
+            }
+            entries.push(DoctorInstallEntry {
+                version: Self::probe_warp_version(&path),
+                path,
+                active,
+            });
+        }
+        entries
+    }
+
+    fn doctor_install_probe_dirs() -> Vec<PathBuf> {
+        if let Some(override_value) = std::env::var_os("GIT_WARP_DOCTOR_PROBE_DIRS") {
+            return std::env::split_paths(&override_value).collect();
+        }
+        let mut dirs = Vec::new();
+        if let Some(home) = dirs::home_dir() {
+            dirs.push(home.join(".local").join("bin"));
+            dirs.push(home.join(".cargo").join("bin"));
+        }
+        dirs.push(PathBuf::from("/usr/local/bin"));
+        dirs.push(PathBuf::from("/opt/homebrew/bin"));
+        dirs
+    }
+
+    fn resolve_warp_on_path() -> Option<PathBuf> {
+        let path = std::env::var_os("PATH")?;
+        for dir in std::env::split_paths(&path) {
+            let candidate = dir.join("warp");
+            if candidate.is_file() && Self::is_executable(&candidate) {
+                return Some(candidate);
+            }
+        }
+        None
+    }
+
+    #[cfg(unix)]
+    fn is_executable(path: &Path) -> bool {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::metadata(path)
+            .map(|m| m.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+    }
+
+    #[cfg(not(unix))]
+    fn is_executable(path: &Path) -> bool {
+        path.is_file()
+    }
+
+    fn probe_warp_version(path: &Path) -> Option<String> {
+        let output = Command::new(path)
+            .arg("--version")
+            .output()
+            .ok()
+            .filter(|o| o.status.success())?;
+        let line = String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .next()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())?
+            .to_string();
+        Some(line)
     }
 
     fn doctor_hooks_installed() -> bool {

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -800,3 +800,355 @@ fn test_shell_config_fish_outputs_branch_completion_for_root_and_switch() {
     assert!(stdout.contains("__fish_seen_subcommand_from switch"));
     assert!(stdout.contains("warp __complete branches (commandline -ct)"));
 }
+
+#[cfg(unix)]
+fn uninstall_script_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("uninstall.sh")
+}
+
+#[cfg(unix)]
+fn write_fake_warp_binary(path: &Path, version_label: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    write_executable(path, &format!("#!/bin/sh\necho \"{version_label}\"\n"));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_installer_lists_existing_installs_before_replacing() {
+    let fake_bin = tempdir().unwrap();
+    let home_dir = tempdir().unwrap();
+    let install_dir = tempdir().unwrap();
+
+    write_fake_warp_binary(&install_dir.path().join("warp"), "warp 0.1.0");
+    write_fake_warp_binary(
+        &home_dir.path().join(".cargo").join("bin").join("warp"),
+        "warp 0.1.0-cargo",
+    );
+
+    write_executable(
+        &fake_bin.path().join("uname"),
+        r#"#!/bin/sh
+if [ "$1" = "-s" ]; then
+  echo Linux
+else
+  echo x86_64
+fi
+"#,
+    );
+    write_executable(
+        &fake_bin.path().join("curl"),
+        r#"#!/bin/sh
+output=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    output="$1"
+  fi
+  shift
+done
+printf fake > "$output"
+"#,
+    );
+    write_executable(
+        &fake_bin.path().join("tar"),
+        r#"#!/bin/sh
+dest=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-C" ]; then
+    shift
+    dest="$1"
+  fi
+  shift
+done
+cat > "$dest/warp" <<'SCRIPT'
+#!/bin/sh
+echo "warp 9.9.9"
+SCRIPT
+chmod 755 "$dest/warp"
+"#,
+    );
+
+    let output = installer_command(fake_bin.path(), home_dir.path())
+        .env("GIT_WARP_INSTALL_DIR", install_dir.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "{stdout}{stderr}");
+    assert!(
+        stdout.contains("Existing Git-Warp installs detected:"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains(&format!("{}/warp", install_dir.path().display())),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains(&format!("{}/.cargo/bin/warp", home_dir.path().display())),
+        "{stdout}"
+    );
+    assert!(stdout.contains("uninstall.sh"), "{stdout}");
+    assert!(stdout.contains("cargo uninstall git-warp"), "{stdout}");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_installer_warns_when_active_warp_shadows_new_install() {
+    let fake_bin = tempdir().unwrap();
+    let home_dir = tempdir().unwrap();
+    let install_dir = tempdir().unwrap();
+    let shadow_dir = tempdir().unwrap();
+
+    write_fake_warp_binary(&shadow_dir.path().join("warp"), "warp 0.0.1-old");
+
+    write_executable(
+        &fake_bin.path().join("uname"),
+        r#"#!/bin/sh
+if [ "$1" = "-s" ]; then
+  echo Linux
+else
+  echo x86_64
+fi
+"#,
+    );
+    write_executable(
+        &fake_bin.path().join("curl"),
+        r#"#!/bin/sh
+output=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    output="$1"
+  fi
+  shift
+done
+printf fake > "$output"
+"#,
+    );
+    write_executable(
+        &fake_bin.path().join("tar"),
+        r#"#!/bin/sh
+dest=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-C" ]; then
+    shift
+    dest="$1"
+  fi
+  shift
+done
+cat > "$dest/warp" <<'SCRIPT'
+#!/bin/sh
+echo "warp 9.9.9"
+SCRIPT
+chmod 755 "$dest/warp"
+"#,
+    );
+
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    let output = Command::new("/bin/sh")
+        .arg(install_script_path())
+        .env("HOME", home_dir.path())
+        .env(
+            "PATH",
+            format!(
+                "{}:{}:{original_path}",
+                shadow_dir.path().display(),
+                fake_bin.path().display()
+            ),
+        )
+        .env("GIT_WARP_VERSION", "v9.9.9")
+        .env("GIT_WARP_INSTALL_DIR", install_dir.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "{stdout}{stderr}");
+    assert!(
+        stdout.contains(&format!(
+            "Note: 'warp' on PATH resolves to {}/warp",
+            shadow_dir.path().display()
+        )),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains(&format!("{}/warp", install_dir.path().display())),
+        "{stdout}"
+    );
+    assert!(stdout.contains("Reorder PATH"), "{stdout}");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_uninstaller_removes_default_install_and_lists_others() {
+    let home_dir = tempdir().unwrap();
+    let install_dir = tempdir().unwrap();
+    let cargo_bin = home_dir.path().join(".cargo").join("bin");
+
+    write_fake_warp_binary(&install_dir.path().join("warp"), "warp 9.9.9");
+    write_fake_warp_binary(&cargo_bin.join("warp"), "warp 9.9.9-cargo");
+
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    let output = Command::new("/bin/sh")
+        .arg(uninstall_script_path())
+        .env("HOME", home_dir.path())
+        .env("PATH", format!("{}:{original_path}", cargo_bin.display()))
+        .env("GIT_WARP_INSTALL_DIR", install_dir.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "{stdout}{stderr}");
+    assert!(
+        stdout.contains(&format!("Removed {}/warp", install_dir.path().display())),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("Other Git-Warp installs detected"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains(&format!("{}/warp", cargo_bin.display())),
+        "{stdout}"
+    );
+    assert!(stdout.contains("cargo uninstall git-warp"), "{stdout}");
+    assert!(
+        stdout.contains(&format!(
+            "'warp' is still on PATH at {}/warp",
+            cargo_bin.display()
+        )),
+        "{stdout}"
+    );
+    assert!(!install_dir.path().join("warp").exists());
+    assert!(cargo_bin.join("warp").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn test_uninstaller_dry_run_keeps_default_install() {
+    let home_dir = tempdir().unwrap();
+    let install_dir = tempdir().unwrap();
+    let target = install_dir.path().join("warp");
+
+    write_fake_warp_binary(&target, "warp 9.9.9");
+
+    let output = Command::new("/bin/sh")
+        .arg(uninstall_script_path())
+        .arg("--dry-run")
+        .env("HOME", home_dir.path())
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("GIT_WARP_INSTALL_DIR", install_dir.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "{stdout}{stderr}");
+    assert!(
+        stdout.contains(&format!("Would remove {}", target.display())),
+        "{stdout}"
+    );
+    assert!(target.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn test_uninstaller_reports_when_no_default_install_exists() {
+    let home_dir = tempdir().unwrap();
+    let install_dir = tempdir().unwrap();
+
+    let output = Command::new("/bin/sh")
+        .arg(uninstall_script_path())
+        .env("HOME", home_dir.path())
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("GIT_WARP_INSTALL_DIR", install_dir.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "{stdout}{stderr}");
+    assert!(
+        stdout.contains(&format!(
+            "No Git-Warp binary found at {}/warp",
+            install_dir.path().display()
+        )),
+        "{stdout}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_doctor_install_check_warns_on_multiple_warp_binaries() {
+    let temp_dir = tempdir().unwrap();
+    let home_dir = tempdir().unwrap();
+    let probe_a = tempdir().unwrap();
+    let probe_b = tempdir().unwrap();
+
+    write_fake_warp_binary(&probe_a.path().join("warp"), "warp 0.1.0");
+    write_fake_warp_binary(&probe_b.path().join("warp"), "warp 0.2.0");
+
+    let output = warp_command(temp_dir.path())
+        .env("HOME", home_dir.path())
+        .env("XDG_CONFIG_HOME", home_dir.path().join(".config"))
+        .env("PATH", probe_a.path())
+        .env(
+            "GIT_WARP_DOCTOR_PROBE_DIRS",
+            format!("{}:{}", probe_a.path().display(), probe_b.path().display()),
+        )
+        .arg("doctor")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "{stdout}{stderr}");
+    assert!(stdout.contains("Install:"), "{stdout}");
+    assert!(
+        stdout.contains("multiple warp binaries detected"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains(&format!("{}/warp (active)", probe_a.path().display())),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains(&format!("{}/warp", probe_b.path().display())),
+        "{stdout}"
+    );
+    assert!(stdout.contains("Resolve install conflicts"), "{stdout}");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_doctor_install_check_passes_with_single_active_binary() {
+    let temp_dir = tempdir().unwrap();
+    let home_dir = tempdir().unwrap();
+    let probe = tempdir().unwrap();
+
+    write_fake_warp_binary(&probe.path().join("warp"), "warp 0.3.0");
+
+    let output = warp_command(temp_dir.path())
+        .env("HOME", home_dir.path())
+        .env("XDG_CONFIG_HOME", home_dir.path().join(".config"))
+        .env("PATH", probe.path())
+        .env("GIT_WARP_DOCTOR_PROBE_DIRS", probe.path())
+        .arg("doctor")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "{stdout}{stderr}");
+    assert!(stdout.contains("Install:"), "{stdout}");
+    assert!(
+        stdout.contains(&format!("{}/warp (active)", probe.path().display())),
+        "{stdout}"
+    );
+    assert!(
+        !stdout.contains("multiple warp binaries detected"),
+        "{stdout}"
+    );
+}

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env sh
+set -eu
+
+repo_url="${GIT_WARP_REPO_URL:-https://github.com/denysbutenko/git-warp}"
+
+if [ -n "${GIT_WARP_INSTALL_DIR:-}" ]; then
+  install_dir="$GIT_WARP_INSTALL_DIR"
+elif [ -n "${GIT_WARP_INSTALL_ROOT:-}" ]; then
+  install_dir="${GIT_WARP_INSTALL_ROOT}/bin"
+else
+  install_dir="${HOME}/.local/bin"
+fi
+
+dry_run=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run|-n) dry_run=1 ;;
+    -h|--help)
+      cat <<EOF
+Usage: uninstall.sh [--dry-run]
+
+Removes the Git-Warp binary at \${GIT_WARP_INSTALL_DIR:-\$HOME/.local/bin}/warp.
+Other detected installs (Cargo, Homebrew prefixes) are listed but not touched.
+
+Environment:
+  GIT_WARP_INSTALL_DIR   Override the install directory (default: \$HOME/.local/bin)
+  GIT_WARP_INSTALL_ROOT  Use \$GIT_WARP_INSTALL_ROOT/bin as the install directory
+EOF
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+target="${install_dir}/warp"
+
+candidate_install_dirs() {
+  printf '%s\n' \
+    "${install_dir}" \
+    "${HOME}/.local/bin" \
+    "${HOME}/.cargo/bin" \
+    "/usr/local/bin" \
+    "/opt/homebrew/bin"
+}
+
+list_other_installs() {
+  printed=""
+  candidate_install_dirs | awk 'NF && !seen[$0]++' | while IFS= read -r dir; do
+    binary="${dir}/warp"
+    [ "$binary" = "$target" ] && continue
+    [ -x "$binary" ] || continue
+    case ":$printed:" in
+      *":$binary:"*) continue ;;
+    esac
+    printed="${printed}:${binary}"
+    version_line="$("$binary" --version 2>/dev/null | head -n1)"
+    if [ -n "$version_line" ]; then
+      printf '  - %s (%s)\n' "$binary" "$version_line"
+    else
+      printf '  - %s\n' "$binary"
+    fi
+  done
+}
+
+if [ ! -e "$target" ]; then
+  echo "No Git-Warp binary found at ${target}; nothing to remove."
+else
+  if [ "$dry_run" -eq 1 ]; then
+    echo "Would remove ${target}"
+  else
+    rm -f "$target" || {
+      echo "error: failed to remove ${target}" >&2
+      exit 1
+    }
+    echo "Removed ${target}"
+  fi
+fi
+
+others="$(list_other_installs)"
+if [ -n "$others" ]; then
+  echo
+  echo "Other Git-Warp installs detected (not removed):"
+  printf '%s\n' "$others"
+  echo "Remove them manually, or with the matching tool:"
+  echo "  Cargo install:    cargo uninstall git-warp"
+  echo "  Other directory:  rm <path>"
+fi
+
+active="$(command -v warp 2>/dev/null || true)"
+if [ -n "$active" ]; then
+  echo
+  echo "'warp' is still on PATH at ${active}."
+  echo "Remove it or adjust PATH if you intended a complete uninstall."
+fi


### PR DESCRIPTION
## Summary
- list existing `warp` binaries during install and warn when the active `warp` on PATH still resolves to a different install after upgrade
- add `uninstall.sh` to remove the default install, list other detected installs without touching them, and flag remaining `warp` on PATH
- extend `warp doctor` with an Install check that lists detected `warp` binaries with versions and warns when more than one exists
- document upgrade and uninstall flows in `docs/install.md` and link from the README

Closes #33

## Verification
- `cargo fmt --check`
- `cargo test --test mod cli_surface_tests -- --nocapture` (31 passed; 2 pre-existing unrelated failures in `test_switch_latest_resolves_branch_from_recent_agent_session` / `test_switch_waiting_resolves_branch_from_waiting_agent_session` reproduce on `origin/main`)
- `git diff --check`

New tests added:
- `test_installer_lists_existing_installs_before_replacing`
- `test_installer_warns_when_active_warp_shadows_new_install`
- `test_uninstaller_removes_default_install_and_lists_others`
- `test_uninstaller_dry_run_keeps_default_install`
- `test_uninstaller_reports_when_no_default_install_exists`
- `test_doctor_install_check_warns_on_multiple_warp_binaries`
- `test_doctor_install_check_passes_with_single_active_binary`