### PR TITLE
Improve warp ls scanability for busy repos

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -159,6 +159,12 @@ enum SwitchStepStatus {
     Warning,
 }
 
+struct LsRow {
+    worktree: crate::git::WorktreeInfo,
+    is_dirty: bool,
+    is_busy: bool,
+}
+
 struct SwitchStep {
     label: &'static str,
     status: SwitchStepStatus,
@@ -947,25 +953,65 @@ impl Cli {
             return Ok(());
         }
 
+        let mut rows: Vec<LsRow> = worktrees
+            .into_iter()
+            .map(|worktree| {
+                let is_dirty = git_repo
+                    .has_uncommitted_changes(&worktree.path)
+                    .unwrap_or(false);
+                let is_busy = !worktree.is_current
+                    && process_manager
+                        .has_processes_in_directory(&worktree.path)
+                        .unwrap_or(false);
+                LsRow {
+                    worktree,
+                    is_dirty,
+                    is_busy,
+                }
+            })
+            .collect();
+
+        rows.sort_by(|a, b| {
+            Self::worktree_sort_priority(&a.worktree, a.is_dirty, a.is_busy)
+                .cmp(&Self::worktree_sort_priority(
+                    &b.worktree,
+                    b.is_dirty,
+                    b.is_busy,
+                ))
+                .then_with(|| a.worktree.branch.cmp(&b.worktree.branch))
+        });
+
         println!("📁 Git Worktrees:");
         println!();
 
-        for (i, worktree) in worktrees.iter().enumerate() {
-            let status_icon = if worktree.is_primary { "🏠" } else { "🌿" };
-            let branch_display = if worktree.is_detached {
-                let short_head: String = worktree.head.chars().take(8).collect();
-                format!("(detached: {})", short_head)
-            } else {
-                worktree.branch.clone()
-            };
-            let is_dirty = git_repo
-                .has_uncommitted_changes(&worktree.path)
-                .unwrap_or(false);
-            let is_busy = !worktree.is_current
-                && process_manager
-                    .has_processes_in_directory(&worktree.path)
-                    .unwrap_or(false);
-            let labels = Self::worktree_status_labels(worktree, is_dirty, is_busy);
+        let current_summary = rows
+            .iter()
+            .find(|r| r.worktree.is_current)
+            .map(|r| Self::ls_branch_display(&r.worktree));
+        let primary_summary = rows
+            .iter()
+            .find(|r| r.worktree.is_primary && !r.worktree.is_current)
+            .map(|r| Self::ls_branch_display(&r.worktree));
+
+        if let Some(branch) = &current_summary {
+            println!("📍 Current: {}", branch);
+        }
+        if let Some(branch) = &primary_summary {
+            println!("🏠 Primary: {}", branch);
+        }
+        if current_summary.is_some() || primary_summary.is_some() {
+            println!();
+        }
+
+        for (i, row) in rows.iter().enumerate() {
+            let LsRow {
+                worktree,
+                is_dirty,
+                is_busy,
+            } = row;
+            let status_icon = Self::worktree_row_icon(worktree, *is_dirty, *is_busy);
+            let branch_display = Self::ls_branch_display(worktree);
+            let labels = Self::worktree_status_labels(worktree, *is_dirty, *is_busy);
             let label_display = Self::format_status_labels(&labels);
 
             println!(
@@ -983,16 +1029,65 @@ impl Cli {
                 println!("     Detached: {}", worktree.is_detached);
                 println!("     Dirty: {}", is_dirty);
                 println!("     Busy: {}", is_busy);
-                if i < worktrees.len() - 1 {
+                if i < rows.len() - 1 {
                     println!();
                 }
             }
         }
 
         println!();
-        println!("📊 Total: {} worktrees", worktrees.len());
+        println!("📊 Total: {} worktrees", rows.len());
 
         Ok(())
+    }
+
+    fn ls_branch_display(worktree: &crate::git::WorktreeInfo) -> String {
+        if worktree.is_detached {
+            let short_head: String = worktree.head.chars().take(8).collect();
+            format!("(detached: {})", short_head)
+        } else {
+            worktree.branch.clone()
+        }
+    }
+
+    fn worktree_row_icon(
+        worktree: &crate::git::WorktreeInfo,
+        is_dirty: bool,
+        is_busy: bool,
+    ) -> &'static str {
+        if worktree.is_current {
+            "👉"
+        } else if worktree.is_primary {
+            "🏠"
+        } else if is_dirty {
+            "⚠️ "
+        } else if is_busy {
+            "⏳"
+        } else if worktree.is_detached {
+            "🔍"
+        } else {
+            "🌿"
+        }
+    }
+
+    fn worktree_sort_priority(
+        worktree: &crate::git::WorktreeInfo,
+        is_dirty: bool,
+        is_busy: bool,
+    ) -> u8 {
+        if worktree.is_current {
+            0
+        } else if worktree.is_primary {
+            1
+        } else if is_dirty {
+            2
+        } else if is_busy {
+            3
+        } else if worktree.is_detached {
+            4
+        } else {
+            5
+        }
     }
 
     fn worktree_status_labels(

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -630,6 +630,35 @@ fn test_ls_shows_primary_current_dirty_and_detached_statuses() {
 }
 
 #[test]
+fn test_ls_orders_current_then_primary_then_dirty_with_summary() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+    let alpha_path = create_worktree(repo_path, "alpha");
+    let dirty_path = create_worktree(repo_path, "zulu-dirty");
+    create_worktree(repo_path, "mike-clean");
+
+    fs::write(dirty_path.join("touch.txt"), "hi\n").unwrap();
+
+    let output = warp_command(&alpha_path).args(["ls"]).output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{stdout}");
+    assert!(stdout.contains("📍 Current: alpha"), "{stdout}");
+    assert!(stdout.contains("🏠 Primary: main"), "{stdout}");
+
+    let current_idx = stdout.find("alpha [current").expect(&stdout);
+    let primary_idx = stdout.find("main [primary").expect(&stdout);
+    let dirty_idx = stdout.find("zulu-dirty [dirty").expect(&stdout);
+    let clean_idx = stdout.find("mike-clean ").expect(&stdout);
+
+    assert!(current_idx < primary_idx, "{stdout}");
+    assert!(primary_idx < dirty_idx, "{stdout}");
+    assert!(dirty_idx < clean_idx, "{stdout}");
+    assert!(stdout.contains("👉  alpha"), "{stdout}");
+    assert!(stdout.contains("⚠️   zulu-dirty"), "{stdout}");
+}
+
+#[test]
 fn test_bare_warp_dry_run_previews_interactive_switcher() {
     let temp_dir = setup_test_repo();
     let repo_path = temp_dir.path();


### PR DESCRIPTION
## Summary
- sort `warp ls` rows so current and primary worktrees come first, followed by dirty, busy, detached, then clean entries
- add a one-line summary header (`📍 Current` / `🏠 Primary`) above the list when applicable
- use distinct row icons for current (👉), primary (🏠), dirty (⚠️), and busy (⏳) worktrees
- keep the existing `[primary current dirty detached busy]` label tokens so script consumers still match

Closes #34

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test mod test_ls_shows_primary_current_dirty_and_detached_statuses -- --nocapture`
- `cargo test --test mod test_ls_orders_current_then_primary_then_dirty_with_summary -- --nocapture`
- `cargo test --test mod tui_tests -- --nocapture`
- `cargo test --test mod git_tests -- --nocapture --test-threads=1`

Note: `test_switch_latest_resolves_branch_from_recent_agent_session` and `test_switch_waiting_resolves_branch_from_waiting_agent_session` continue to fail on `origin/main` and are unrelated to this change (same baseline as PR #48).