### PR TITLE
Explain cleanup eligibility per worktree

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1041,54 +1041,95 @@ impl Cli {
 
         info!("Cleaning up worktrees with mode: {}", mode);
 
+        if !matches!(mode, "all" | "merged" | "remoteless" | "interactive") {
+            println!("❌ Unknown cleanup mode: {}", mode);
+            return Ok(());
+        }
+
         let git_repo = GitRepository::find().map_err(|_| Self::not_in_git_repo_error())?;
         let config_manager = ConfigManager::new()?;
         let git_config = config_manager.get().git.clone();
         let mut process_manager = ProcessManager::new();
 
         if self.dry_run {
-            println!("Would cleanup worktrees with mode: {}", mode);
-            return Ok(());
-        }
-
-        // Fetch latest changes for accurate analysis
-        println!("🔄 Fetching latest changes...");
-        if !git_repo.fetch_branches()? {
-            println!("⚠️  Fetch failed, analysis may be outdated");
+            println!("🔎 Dry run: previewing cleanup with mode: {}", mode);
+        } else {
+            // Fetch latest changes for accurate analysis
+            println!("🔄 Fetching latest changes...");
+            if !git_repo.fetch_branches()? {
+                println!("⚠️  Fetch failed, analysis may be outdated");
+            }
         }
 
         let worktrees = git_repo.list_worktrees()?;
-        let branch_statuses =
-            git_repo.analyze_branches_for_cleanup_with_config(&worktrees, &git_config)?;
+        let analysis =
+            git_repo.analyze_worktrees_for_cleanup_with_config(&worktrees, &git_config)?;
 
-        if branch_statuses.is_empty() {
+        println!("🧭 Cleanup base branch: {}", analysis.base_branch);
+
+        if !analysis.skipped.is_empty() {
+            println!("🛡️  Skipped (not eligible for cleanup):");
+            for skip in &analysis.skipped {
+                println!(
+                    "  • {} at {} [{}]",
+                    skip.branch_label,
+                    skip.path.display(),
+                    skip.reason.label()
+                );
+            }
+            println!();
+        }
+
+        if analysis.candidates.is_empty() {
             println!("✨ No worktrees to clean up");
             return Ok(());
         }
 
         let mut candidates = Vec::new();
         let mut blocked = Vec::new();
+        let mut mode_excluded = Vec::new();
 
-        // Filter based on mode
-        for status in branch_statuses {
-            let should_include = match mode {
-                "all" => true,
+        for status in analysis.candidates {
+            let matches_mode = match mode {
+                "all" | "interactive" => true,
                 "merged" => status.is_merged,
                 "remoteless" => !status.has_remote,
-                "interactive" => true, // Will be filtered in interactive mode
-                _ => {
-                    println!("❌ Unknown cleanup mode: {}", mode);
-                    return Ok(());
-                }
+                _ => unreachable!(),
             };
 
-            if should_include {
-                if status.has_uncommitted_changes && !force {
-                    blocked.push(status);
-                } else {
-                    candidates.push(status);
-                }
+            if !matches_mode {
+                mode_excluded.push(status);
+                continue;
             }
+
+            if status.has_uncommitted_changes && !force {
+                blocked.push(status);
+            } else {
+                candidates.push(status);
+            }
+        }
+
+        if !mode_excluded.is_empty() {
+            println!("➖ Excluded by mode `{}`:", mode);
+            for status in &mode_excluded {
+                println!(
+                    "  • {} at {} [{}; {}; {}]",
+                    status.branch,
+                    status.path.display(),
+                    crate::tui::cleanup_reason_label_for_mode(status, mode),
+                    if status.has_remote {
+                        "remote"
+                    } else {
+                        "no remote"
+                    },
+                    if status.has_uncommitted_changes {
+                        "dirty"
+                    } else {
+                        "clean"
+                    }
+                );
+            }
+            println!();
         }
 
         if !blocked.is_empty() {
@@ -1111,6 +1152,7 @@ impl Cli {
 
         // Show what would be cleaned up
         println!("🧹 Cleanup candidates:");
+        let mut process_busy = Vec::new();
         for candidate in &candidates {
             let remote = if candidate.has_remote {
                 "remote"
@@ -1122,14 +1164,34 @@ impl Cli {
             } else {
                 "clean"
             };
+            let busy = match process_manager.has_processes_in_directory(&candidate.path) {
+                Ok(true) => {
+                    process_busy.push(candidate.branch.clone());
+                    "; process-busy"
+                }
+                Ok(false) => "",
+                Err(_) => "",
+            };
             println!(
-                "  • {} at {} [{}; {}; {}]",
+                "  • {} at {} [{}; {}; {}{}]",
                 candidate.branch,
                 candidate.path.display(),
-                crate::tui::cleanup_reason_label(candidate),
+                crate::tui::cleanup_reason_label_for_mode(candidate, mode),
                 remote,
-                dirty
+                dirty,
+                busy,
             );
+        }
+        if !process_busy.is_empty() && !force && !kill {
+            println!(
+                "💡 {} candidate(s) have running processes. Use --kill to terminate or --force to ignore.",
+                process_busy.len()
+            );
+        }
+
+        if self.dry_run {
+            println!("\n🔎 Dry run complete: no worktrees were removed.");
+            return Ok(());
         }
 
         if interactive {

--- a/src/git.rs
+++ b/src/git.rs
@@ -23,6 +23,41 @@ pub struct BranchStatus {
     pub has_uncommitted_changes: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CleanupSkipReason {
+    PrimaryWorktree,
+    BaseBranch,
+    ProtectedBranch,
+    DetachedHead,
+    EmptyBranch,
+}
+
+impl CleanupSkipReason {
+    pub fn label(&self) -> &'static str {
+        match self {
+            CleanupSkipReason::PrimaryWorktree => "primary worktree",
+            CleanupSkipReason::BaseBranch => "base branch",
+            CleanupSkipReason::ProtectedBranch => "protected branch",
+            CleanupSkipReason::DetachedHead => "detached HEAD",
+            CleanupSkipReason::EmptyBranch => "no branch checked out",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CleanupSkip {
+    pub branch_label: String,
+    pub path: PathBuf,
+    pub reason: CleanupSkipReason,
+}
+
+#[derive(Debug, Clone)]
+pub struct CleanupAnalysis {
+    pub candidates: Vec<BranchStatus>,
+    pub skipped: Vec<CleanupSkip>,
+    pub base_branch: String,
+}
+
 pub struct GitRepository {
     repo: Repository,
     repo_path: PathBuf,
@@ -32,6 +67,29 @@ fn is_protected_branch(branch: &str, protected_branches: &[String]) -> bool {
     protected_branches
         .iter()
         .any(|protected_branch| protected_branch.trim() == branch)
+}
+
+fn cleanup_skip_reason(
+    worktree: &WorktreeInfo,
+    cleanup_base_branch: &str,
+    protected_branches: &[String],
+) -> Option<CleanupSkipReason> {
+    if worktree.is_primary {
+        return Some(CleanupSkipReason::PrimaryWorktree);
+    }
+    if worktree.is_detached {
+        return Some(CleanupSkipReason::DetachedHead);
+    }
+    if worktree.branch.is_empty() {
+        return Some(CleanupSkipReason::EmptyBranch);
+    }
+    if worktree.branch == cleanup_base_branch {
+        return Some(CleanupSkipReason::BaseBranch);
+    }
+    if is_protected_branch(&worktree.branch, protected_branches) {
+        return Some(CleanupSkipReason::ProtectedBranch);
+    }
+    None
 }
 
 impl GitRepository {
@@ -281,11 +339,13 @@ impl GitRepository {
         worktrees: &[WorktreeInfo],
         protected_branches: &[String],
     ) -> Result<Vec<BranchStatus>> {
-        self.analyze_branches_for_cleanup_with_options(
-            worktrees,
-            protected_branches,
-            &GitConfig::default().default_branch,
-        )
+        Ok(self
+            .analyze_worktrees_for_cleanup_with_options(
+                worktrees,
+                protected_branches,
+                &GitConfig::default().default_branch,
+            )?
+            .candidates)
     }
 
     /// Analyze branches for cleanup using full git configuration
@@ -294,7 +354,19 @@ impl GitRepository {
         worktrees: &[WorktreeInfo],
         config: &GitConfig,
     ) -> Result<Vec<BranchStatus>> {
-        self.analyze_branches_for_cleanup_with_options(
+        Ok(self
+            .analyze_worktrees_for_cleanup_with_config(worktrees, config)?
+            .candidates)
+    }
+
+    /// Analyze worktrees for cleanup, returning both eligible candidates and
+    /// skipped worktrees with the reason each was filtered out.
+    pub fn analyze_worktrees_for_cleanup_with_config(
+        &self,
+        worktrees: &[WorktreeInfo],
+        config: &GitConfig,
+    ) -> Result<CleanupAnalysis> {
+        self.analyze_worktrees_for_cleanup_with_options(
             worktrees,
             &config.protected_branches,
             &config.default_branch,
@@ -327,23 +399,39 @@ impl GitRepository {
         self.get_main_branch()
     }
 
-    fn analyze_branches_for_cleanup_with_options(
+    fn analyze_worktrees_for_cleanup_with_options(
         &self,
         worktrees: &[WorktreeInfo],
         protected_branches: &[String],
         configured_default_branch: &str,
-    ) -> Result<Vec<BranchStatus>> {
+    ) -> Result<CleanupAnalysis> {
         use std::process::Command;
 
-        let mut branch_statuses = Vec::new();
+        let mut candidates = Vec::new();
+        let mut skipped = Vec::new();
         let cleanup_base_branch = self.cleanup_base_branch(worktrees, configured_default_branch)?;
 
         for worktree in worktrees {
-            if worktree.is_primary
-                || worktree.branch.is_empty()
-                || worktree.branch == cleanup_base_branch
-                || is_protected_branch(&worktree.branch, protected_branches)
+            if let Some(reason) =
+                cleanup_skip_reason(worktree, &cleanup_base_branch, protected_branches)
             {
+                let branch_label = if worktree.branch.is_empty() {
+                    if worktree.is_detached {
+                        format!(
+                            "(detached {})",
+                            worktree.head.chars().take(7).collect::<String>()
+                        )
+                    } else {
+                        "(no branch)".to_string()
+                    }
+                } else {
+                    worktree.branch.clone()
+                };
+                skipped.push(CleanupSkip {
+                    branch_label,
+                    path: worktree.path.clone(),
+                    reason,
+                });
                 continue;
             }
 
@@ -389,7 +477,7 @@ impl GitRepository {
                 output.map(|o| !o.stdout.is_empty()).unwrap_or(false)
             };
 
-            branch_statuses.push(BranchStatus {
+            candidates.push(BranchStatus {
                 branch: branch.clone(),
                 path: path.clone(),
                 has_remote,
@@ -399,7 +487,11 @@ impl GitRepository {
             });
         }
 
-        Ok(branch_statuses)
+        Ok(CleanupAnalysis {
+            candidates,
+            skipped,
+            base_branch: cleanup_base_branch,
+        })
     }
 
     fn remote_default_branch(&self) -> Result<Option<String>> {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1284,6 +1284,18 @@ pub fn cleanup_reason_label(status: &BranchStatus) -> &'static str {
     }
 }
 
+/// Same as [`cleanup_reason_label`] but disambiguates the generic `candidate`
+/// fallback when a branch is included only because the caller passed
+/// `--mode all` or `--mode interactive`.
+pub fn cleanup_reason_label_for_mode(status: &BranchStatus, mode: &str) -> &'static str {
+    let base = cleanup_reason_label(status);
+    if base == "candidate" && matches!(mode, "all" | "interactive") {
+        "all-mode"
+    } else {
+        base
+    }
+}
+
 pub struct CleanupTui {
     candidates: Option<Vec<BranchStatus>>,
 }

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -690,6 +690,73 @@ fn test_cleanup_uses_primary_branch_as_base_and_prints_candidate_reasons() {
 }
 
 #[test]
+fn test_cleanup_dry_run_explains_candidates_and_skipped_reasons() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+    create_worktree(repo_path, "feature/eligible");
+
+    // A protected branch worktree (`develop` is protected by default).
+    Command::new("git")
+        .args(["branch", "develop"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    let develop_path = repo_path.join(".worktrees").join("develop");
+    fs::create_dir_all(develop_path.parent().unwrap()).unwrap();
+    Command::new("git")
+        .args(["worktree", "add"])
+        .arg(&develop_path)
+        .arg("develop")
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    let output = warp_command(repo_path)
+        .args(["--dry-run", "cleanup", "--mode", "all"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{stdout}");
+    assert!(
+        stdout.contains("Dry run: previewing cleanup with mode: all"),
+        "dry-run header missing: {stdout}"
+    );
+    assert!(
+        stdout.contains("Cleanup base branch: main"),
+        "base branch should be reported: {stdout}"
+    );
+    assert!(
+        stdout.contains("Skipped (not eligible for cleanup):"),
+        "skipped section header missing: {stdout}"
+    );
+    assert!(
+        stdout.contains("[primary worktree]"),
+        "primary worktree should be skipped with reason: {stdout}"
+    );
+    assert!(
+        stdout.contains("develop") && stdout.contains("[protected branch]"),
+        "develop should be skipped as protected: {stdout}"
+    );
+    assert!(
+        stdout.contains("feature/eligible"),
+        "feature/eligible should appear as candidate: {stdout}"
+    );
+    let candidate_line = stdout
+        .lines()
+        .find(|line| line.contains("feature/eligible") && line.contains("•"))
+        .expect("candidate row missing");
+    assert!(
+        candidate_line.contains("[") && candidate_line.contains("; clean"),
+        "candidate row should include reason and clean/dirty tags: {candidate_line}"
+    );
+    assert!(
+        stdout.contains("Dry run complete: no worktrees were removed."),
+        "dry-run footer missing: {stdout}"
+    );
+}
+
+#[test]
 fn test_config_edit_creates_config_and_launches_editor() {
     let temp_dir = setup_test_repo();
     let repo_path = temp_dir.path();

--- a/tests/unit/git_tests.rs
+++ b/tests/unit/git_tests.rs
@@ -1,4 +1,5 @@
-use git_warp::git::GitRepository;
+use git_warp::config::GitConfig;
+use git_warp::git::{CleanupSkipReason, GitRepository};
 use std::fs;
 use std::process::Command;
 use tempfile::tempdir;
@@ -202,6 +203,71 @@ fn test_cleanup_analysis_excludes_custom_protected_branches() {
         branch_statuses
             .iter()
             .any(|status| status.branch == "feature")
+    );
+}
+
+#[test]
+fn test_cleanup_analysis_reports_skipped_with_reasons() {
+    let _cwd = crate::support::CurrentDirGuard::new();
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+    std::env::set_current_dir(repo_path).unwrap();
+
+    let git_repo = GitRepository::find().unwrap();
+
+    // Protected branch worktree (default protected list contains "develop").
+    Command::new("git")
+        .args(&["branch", "develop"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    let develop_path = repo_path.join("worktrees").join("develop");
+    git_repo
+        .create_worktree_and_branch("develop", &develop_path, Some("develop"))
+        .unwrap();
+
+    // Eligible feature branch.
+    let feature_path = repo_path.join("worktrees").join("feature");
+    git_repo
+        .create_worktree_and_branch("feature", &feature_path, None)
+        .unwrap();
+
+    let worktrees = git_repo.list_worktrees().unwrap();
+    let analysis = git_repo
+        .analyze_worktrees_for_cleanup_with_config(&worktrees, &GitConfig::default())
+        .unwrap();
+
+    assert_eq!(analysis.base_branch, "main");
+
+    let primary_skip = analysis
+        .skipped
+        .iter()
+        .find(|skip| skip.reason == CleanupSkipReason::PrimaryWorktree)
+        .expect("primary worktree should be reported as skipped");
+    assert_eq!(primary_skip.branch_label, "main");
+
+    assert!(
+        analysis
+            .skipped
+            .iter()
+            .any(|skip| skip.reason == CleanupSkipReason::ProtectedBranch
+                && skip.branch_label == "develop"),
+        "develop should be reported as protected: {:?}",
+        analysis.skipped
+    );
+
+    assert!(
+        analysis
+            .candidates
+            .iter()
+            .any(|status| status.branch == "feature"),
+        "feature branch should remain a candidate"
+    );
+    assert!(
+        analysis
+            .candidates
+            .iter()
+            .all(|status| status.branch != "main" && status.branch != "develop")
     );
 }
 

--- a/tests/unit/tui_tests.rs
+++ b/tests/unit/tui_tests.rs
@@ -7,7 +7,7 @@ use git_warp::tui::{
     AgentsDashboard, WorktreeRemovalBlock, WorktreeRuntimeStatus, build_cleanup_rows,
     build_dashboard_model, build_dashboard_model_windowed, build_worktree_switch_model,
     build_worktree_switch_model_with_protected_branches, build_worktree_switch_rows,
-    next_bulk_selection_state, session_detail_lines,
+    cleanup_reason_label_for_mode, next_bulk_selection_state, session_detail_lines,
 };
 use std::{
     path::PathBuf,
@@ -411,6 +411,36 @@ fn test_build_cleanup_rows_explains_remoteless_candidates() {
     assert_eq!(rows[0].remote_label, "no remote");
     assert_eq!(rows[0].dirty_label, "clean");
     assert!(rows[0].display_line.contains("no remote"));
+}
+
+#[test]
+fn test_cleanup_reason_label_for_mode_disambiguates_all_mode_fallback() {
+    let plain_candidate = BranchStatus {
+        branch: "feature/active".to_string(),
+        path: PathBuf::from("/repo/.worktrees/active"),
+        has_remote: true,
+        is_merged: false,
+        is_identical: false,
+        has_uncommitted_changes: false,
+    };
+    assert_eq!(
+        cleanup_reason_label_for_mode(&plain_candidate, "all"),
+        "all-mode"
+    );
+    assert_eq!(
+        cleanup_reason_label_for_mode(&plain_candidate, "interactive"),
+        "all-mode"
+    );
+    assert_eq!(
+        cleanup_reason_label_for_mode(&plain_candidate, "merged"),
+        "candidate"
+    );
+
+    let merged = BranchStatus {
+        is_merged: true,
+        ..plain_candidate.clone()
+    };
+    assert_eq!(cleanup_reason_label_for_mode(&merged, "all"), "merged");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- return a `CleanupAnalysis` from a new `analyze_worktrees_for_cleanup_with_config` that splits eligible candidates from worktrees skipped because they are the primary, base branch, protected, detached, or have no branch checked out
- in `warp cleanup`, print the resolved base branch, the skipped worktrees with structured reasons, the mode-excluded entries, and tag each candidate with `merged` / `identical` / `no remote` / `all-mode`, plus a `process-busy` flag from a pre-confirm process preview
- replace the old `Would cleanup worktrees with mode: <mode>` stub so `warp --dry-run cleanup` runs the same analysis and prints the same reasons without fetching or removing anything

Closes #35

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo build`
- `cargo test --test mod unit::git_tests -- --nocapture --test-threads=1` (18 passed)
- `cargo test --test mod unit::tui_tests -- --nocapture` (19 passed)
- `cargo test --test mod integration::cli_surface_tests -- --nocapture --test-threads=1` (25 passed; 2 pre-existing failures `test_switch_latest_resolves_branch_from_recent_agent_session` / `test_switch_waiting_resolves_branch_from_waiting_agent_session` reproduce on `origin/main` and are unrelated to this change, same baseline as PR #48 / #49)

New tests:
- `unit::git_tests::test_cleanup_analysis_reports_skipped_with_reasons`
- `unit::tui_tests::test_cleanup_reason_label_for_mode_disambiguates_all_mode_fallback`
- `integration::cli_surface_tests::test_cleanup_dry_run_explains_candidates_and_skipped_reasons`