### PR TITLE
Distinguish branch sources in warp switch and bare TUI

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -247,18 +247,57 @@ impl Cli {
         )
     }
 
-    fn create_worktree_with_recovery(
+    fn create_worktree_for_source_with_recovery(
         git_repo: &crate::git::GitRepository,
         branch: &str,
         worktree_path: &Path,
+        source: &crate::git::BranchSource,
     ) -> Result<()> {
         git_repo
-            .create_worktree_and_branch(branch, worktree_path, None)
+            .create_worktree_for_source(branch, worktree_path, source)
             .map_err(|error| {
                 anyhow::anyhow!(
                     "{error}. Use a different branch name or run `warp ls` to inspect existing worktrees."
                 )
             })
+    }
+
+    fn source_announcement(branch: &str, source: &crate::git::BranchSource) -> String {
+        match source {
+            crate::git::BranchSource::ExistingWorktree { path } => format!(
+                "🔁 Reusing existing worktree for branch '{}' at {}",
+                branch,
+                path.display()
+            ),
+            crate::git::BranchSource::LocalBranch => {
+                format!("🌱 Creating worktree for local branch '{}'", branch)
+            }
+            crate::git::BranchSource::RemoteBranch { remote_ref } => format!(
+                "🌐 Creating worktree from remote branch '{}' (new local '{}' tracking it)",
+                remote_ref, branch
+            ),
+            crate::git::BranchSource::NewBranch => {
+                format!("✨ Creating new branch '{}' from HEAD", branch)
+            }
+        }
+    }
+
+    fn dry_run_source_label(branch: &str, source: &crate::git::BranchSource) -> String {
+        match source {
+            crate::git::BranchSource::ExistingWorktree { path } => {
+                format!("Source: existing worktree at {}", path.display())
+            }
+            crate::git::BranchSource::LocalBranch => {
+                format!("Source: local branch '{}'", branch)
+            }
+            crate::git::BranchSource::RemoteBranch { remote_ref } => format!(
+                "Source: remote branch '{}' (would create local '{}' tracking it)",
+                remote_ref, branch
+            ),
+            crate::git::BranchSource::NewBranch => {
+                format!("Source: new branch '{}' from HEAD", branch)
+            }
+        }
     }
 
     pub fn run(&self) -> Result<()> {
@@ -333,8 +372,7 @@ impl Cli {
         use crate::git::GitRepository;
         use crate::process::ProcessManager;
         use crate::tui::{
-            WorktreeSwitchAction, WorktreeSwitchTui,
-            build_worktree_switch_model_with_protected_branches,
+            WorktreeSwitchAction, WorktreeSwitchTui, build_worktree_switch_model_with_metadata,
         };
 
         info!("Starting default worktree switcher");
@@ -345,10 +383,12 @@ impl Cli {
         let worktrees = git_repo.list_worktrees()?;
         let statuses =
             Self::collect_worktree_runtime_statuses(&git_repo, &worktrees, ProcessManager::new());
-        let model = build_worktree_switch_model_with_protected_branches(
+        let local_only_branches = Self::collect_local_only_branches(&git_repo, &worktrees);
+        let model = build_worktree_switch_model_with_metadata(
             &worktrees,
             &statuses,
             &protected_branches,
+            &local_only_branches,
         );
 
         if self.dry_run {
@@ -368,6 +408,23 @@ impl Cli {
                 Ok(())
             }
         }
+    }
+
+    fn collect_local_only_branches(
+        git_repo: &crate::git::GitRepository,
+        worktrees: &[crate::git::WorktreeInfo],
+    ) -> Vec<String> {
+        if !git_repo.has_remotes().unwrap_or(false) {
+            return Vec::new();
+        }
+        worktrees
+            .iter()
+            .filter(|wt| !wt.branch.trim().is_empty() && !wt.is_detached)
+            .filter_map(|wt| match git_repo.remote_branch_exists(&wt.branch) {
+                Ok(false) => Some(wt.branch.clone()),
+                _ => None,
+            })
+            .collect()
     }
 
     fn collect_worktree_runtime_statuses(
@@ -545,17 +602,6 @@ impl Cli {
         Ok(())
     }
 
-    fn existing_worktree_path_for_branch(
-        git_repo: &crate::git::GitRepository,
-        branch: &str,
-    ) -> Result<Option<PathBuf>> {
-        Ok(git_repo
-            .list_worktrees()?
-            .into_iter()
-            .find(|worktree| worktree.branch == branch)
-            .map(|worktree| worktree.path))
-    }
-
     fn handle_existing_worktree_jump(&self, worktree_path: &Path) -> Result<()> {
         use crate::config::ConfigManager;
         use crate::terminal::TerminalMode;
@@ -606,13 +652,18 @@ impl Cli {
         let config_manager = ConfigManager::new()?;
         let config = config_manager.get();
 
+        let worktrees_for_classification = git_repo.list_worktrees()?;
+        let branch_source =
+            git_repo.classify_branch_source(&branch, &worktrees_for_classification)?;
+
         // Determine worktree path
         let worktree_path = if let Some(path) = path {
             PathBuf::from(path)
-        } else if let Some(existing_path) =
-            Self::existing_worktree_path_for_branch(&git_repo, &branch)?
+        } else if let crate::git::BranchSource::ExistingWorktree {
+            path: existing_path,
+        } = &branch_source
         {
-            existing_path
+            existing_path.clone()
         } else {
             git_repo.get_worktree_path_with_base(&branch, config.worktrees_path.as_deref())
         };
@@ -623,6 +674,7 @@ impl Cli {
                 branch,
                 worktree_path.display()
             );
+            println!("{}", Self::dry_run_source_label(&branch, &branch_source));
             if worktree_path.exists() {
                 println!("Would reuse existing worktree");
             } else if !no_cow && cow::is_cow_supported(&worktree_path).unwrap_or(false) {
@@ -642,7 +694,7 @@ impl Cli {
             println!("📁 Worktree already exists at: {}", worktree_path.display());
             report.skipped("Worktree creation", "already existed");
         } else {
-            println!("🚀 Creating worktree for branch '{}'", branch);
+            println!("{}", Self::source_announcement(&branch, &branch_source));
 
             // Choose creation method based on CoW support and user preference
             let use_cow =
@@ -652,7 +704,12 @@ impl Cli {
                 println!("⚡ Using Copy-on-Write for instant creation...");
 
                 // Create worktree using traditional method first
-                Self::create_worktree_with_recovery(&git_repo, &branch, &worktree_path)?;
+                Self::create_worktree_for_source_with_recovery(
+                    &git_repo,
+                    &branch,
+                    &worktree_path,
+                    &branch_source,
+                )?;
 
                 // If we have existing worktrees, try CoW enhancement
                 let worktrees = git_repo.list_worktrees()?;
@@ -666,7 +723,12 @@ impl Cli {
                     if let Err(e) = cow::clone_directory(&main_worktree.path, &worktree_path) {
                         log::warn!("CoW failed, falling back to traditional method: {}", e);
                         // Recreate using traditional method
-                        Self::create_worktree_with_recovery(&git_repo, &branch, &worktree_path)?;
+                        Self::create_worktree_for_source_with_recovery(
+                            &git_repo,
+                            &branch,
+                            &worktree_path,
+                            &branch_source,
+                        )?;
                     } else {
                         // Rewrite paths in the CoW copy
                         let rewriter = PathRewriter::new(&main_worktree.path, &worktree_path);
@@ -690,7 +752,12 @@ impl Cli {
                 }
             } else {
                 println!("📦 Using traditional Git worktree creation...");
-                Self::create_worktree_with_recovery(&git_repo, &branch, &worktree_path)?;
+                Self::create_worktree_for_source_with_recovery(
+                    &git_repo,
+                    &branch,
+                    &worktree_path,
+                    &branch_source,
+                )?;
             }
 
             if worktree_path.exists() {

--- a/src/git.rs
+++ b/src/git.rs
@@ -58,6 +58,19 @@ pub struct CleanupAnalysis {
     pub base_branch: String,
 }
 
+/// Where the branch for `warp switch <branch>` comes from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BranchSource {
+    /// Branch is already checked out in another worktree, which will be reused.
+    ExistingWorktree { path: PathBuf },
+    /// Local branch exists, no worktree yet.
+    LocalBranch,
+    /// Branch only exists on the remote; a local tracking branch will be created.
+    RemoteBranch { remote_ref: String },
+    /// Neither local nor remote branch exists; a brand new branch will be created from HEAD.
+    NewBranch,
+}
+
 pub struct GitRepository {
     repo: Repository,
     repo_path: PathBuf,
@@ -205,6 +218,163 @@ impl GitRepository {
         Ok(worktrees)
     }
 
+    /// Classify how a branch should be materialized for `warp switch`.
+    pub fn classify_branch_source(
+        &self,
+        branch_name: &str,
+        worktrees: &[WorktreeInfo],
+    ) -> Result<BranchSource> {
+        if let Some(existing) = worktrees.iter().find(|wt| wt.branch == branch_name) {
+            return Ok(BranchSource::ExistingWorktree {
+                path: existing.path.clone(),
+            });
+        }
+        if self.branch_exists(branch_name)? {
+            return Ok(BranchSource::LocalBranch);
+        }
+        if let Some(remote_ref) = self.find_remote_branch_ref(branch_name)? {
+            return Ok(BranchSource::RemoteBranch { remote_ref });
+        }
+        Ok(BranchSource::NewBranch)
+    }
+
+    /// Locate the first remote that carries `branch_name`, returning the short ref
+    /// (e.g. `origin/feature`). `origin` is preferred when present.
+    pub fn find_remote_branch_ref(&self, branch_name: &str) -> Result<Option<String>> {
+        use std::process::Command;
+
+        let output = Command::new("git")
+            .args(["for-each-ref", "--format=%(refname:short)", "refs/remotes"])
+            .current_dir(&self.repo_path)
+            .output()
+            .map_err(|e| anyhow::anyhow!("Failed to list remote branches: {}", e))?;
+
+        if !output.status.success() {
+            let error = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow::anyhow!("Failed to list remote branches: {}", error).into());
+        }
+
+        let mut origin_match: Option<String> = None;
+        let mut other_match: Option<String> = None;
+        for line in String::from_utf8_lossy(&output.stdout).lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.ends_with("/HEAD") {
+                continue;
+            }
+            let Some((remote, branch)) = trimmed.split_once('/') else {
+                continue;
+            };
+            if branch != branch_name {
+                continue;
+            }
+            if remote == "origin" {
+                origin_match = Some(trimmed.to_string());
+                break;
+            }
+            if other_match.is_none() {
+                other_match = Some(trimmed.to_string());
+            }
+        }
+
+        Ok(origin_match.or(other_match))
+    }
+
+    /// Return true if a remote tracks a branch with this name on any remote.
+    pub fn remote_branch_exists(&self, branch_name: &str) -> Result<bool> {
+        Ok(self.find_remote_branch_ref(branch_name)?.is_some())
+    }
+
+    /// Return true if at least one remote is configured for this repository.
+    pub fn has_remotes(&self) -> Result<bool> {
+        use std::process::Command;
+
+        let output = Command::new("git")
+            .args(["remote"])
+            .current_dir(&self.repo_path)
+            .output()
+            .map_err(|e| anyhow::anyhow!("Failed to list remotes: {}", e))?;
+
+        if !output.status.success() {
+            return Ok(false);
+        }
+
+        Ok(String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .any(|line| !line.trim().is_empty()))
+    }
+
+    /// Create a new worktree and branch using a precomputed `BranchSource` classification.
+    pub fn create_worktree_for_source<P: AsRef<Path>>(
+        &self,
+        branch_name: &str,
+        worktree_path: P,
+        source: &BranchSource,
+    ) -> Result<()> {
+        use std::process::Command;
+
+        let worktree_path = worktree_path.as_ref();
+
+        match source {
+            BranchSource::ExistingWorktree { .. } => Err(anyhow::anyhow!(
+                "Cannot create worktree for branch '{branch_name}': it is already checked out in another worktree"
+            )
+            .into()),
+            BranchSource::LocalBranch => {
+                let output = Command::new("git")
+                    .args(["worktree", "add"])
+                    .arg(worktree_path)
+                    .arg(branch_name)
+                    .current_dir(&self.repo_path)
+                    .output()
+                    .map_err(|e| anyhow::anyhow!("Failed to create worktree: {}", e))?;
+
+                if !output.status.success() {
+                    let error = String::from_utf8_lossy(&output.stderr);
+                    return Err(anyhow::anyhow!("Failed to create worktree: {}", error).into());
+                }
+                Ok(())
+            }
+            BranchSource::RemoteBranch { remote_ref } => {
+                let output = Command::new("git")
+                    .args(["worktree", "add", "-b", branch_name])
+                    .arg(worktree_path)
+                    .arg(remote_ref)
+                    .current_dir(&self.repo_path)
+                    .output()
+                    .map_err(|e| {
+                        anyhow::anyhow!("Failed to create worktree from remote branch: {}", e)
+                    })?;
+
+                if !output.status.success() {
+                    let error = String::from_utf8_lossy(&output.stderr);
+                    return Err(anyhow::anyhow!(
+                        "Failed to create worktree from remote branch '{remote_ref}': {}",
+                        error
+                    )
+                    .into());
+                }
+                Ok(())
+            }
+            BranchSource::NewBranch => {
+                let output = Command::new("git")
+                    .args(["worktree", "add", "-b", branch_name])
+                    .arg(worktree_path)
+                    .arg("HEAD")
+                    .current_dir(&self.repo_path)
+                    .output()
+                    .map_err(|e| anyhow::anyhow!("Failed to create worktree and branch: {}", e))?;
+
+                if !output.status.success() {
+                    let error = String::from_utf8_lossy(&output.stderr);
+                    return Err(
+                        anyhow::anyhow!("Failed to create worktree and branch: {}", error).into(),
+                    );
+                }
+                Ok(())
+            }
+        }
+    }
+
     /// Create a new worktree and branch
     pub fn create_worktree_and_branch<P: AsRef<Path>>(
         &self,
@@ -232,6 +402,26 @@ impl GitRepository {
             if !output.status.success() {
                 let error = String::from_utf8_lossy(&output.stderr);
                 return Err(anyhow::anyhow!("Failed to create worktree: {}", error).into());
+            }
+        } else if let Some(remote_ref) = self.find_remote_branch_ref(branch_name)? {
+            // Track remote branch as new local branch
+            let mut cmd = Command::new("git");
+            cmd.args(["worktree", "add", "-b", branch_name])
+                .arg(worktree_path)
+                .arg(&remote_ref)
+                .current_dir(&self.repo_path);
+
+            let output = cmd.output().map_err(|e| {
+                anyhow::anyhow!("Failed to create worktree from remote branch: {}", e)
+            })?;
+
+            if !output.status.success() {
+                let error = String::from_utf8_lossy(&output.stderr);
+                return Err(anyhow::anyhow!(
+                    "Failed to create worktree from remote branch '{remote_ref}': {}",
+                    error
+                )
+                .into());
             }
         } else {
             // Create new branch and worktree

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -450,6 +450,15 @@ pub fn build_worktree_switch_model_with_protected_branches(
     statuses: &[WorktreeRuntimeStatus],
     protected_branches: &[String],
 ) -> WorktreeSwitchModel {
+    build_worktree_switch_model_with_metadata(worktrees, statuses, protected_branches, &[])
+}
+
+pub fn build_worktree_switch_model_with_metadata(
+    worktrees: &[WorktreeInfo],
+    statuses: &[WorktreeRuntimeStatus],
+    protected_branches: &[String],
+    local_only_branches: &[String],
+) -> WorktreeSwitchModel {
     let mut rows = worktrees
         .iter()
         .enumerate()
@@ -457,6 +466,11 @@ pub fn build_worktree_switch_model_with_protected_branches(
             let status = statuses.iter().find(|status| status.path == worktree.path);
             let is_detached = worktree.branch.trim().is_empty() || worktree.is_detached;
             let is_protected = is_protected_branch(&worktree.branch, protected_branches);
+            let is_local_only = !is_detached
+                && !worktree.branch.is_empty()
+                && local_only_branches
+                    .iter()
+                    .any(|name| name == &worktree.branch);
             let removal_blockers = worktree_removal_blockers(worktree, status, protected_branches);
             let mut badges = Vec::new();
 
@@ -468,6 +482,9 @@ pub fn build_worktree_switch_model_with_protected_branches(
             }
             if is_detached {
                 badges.push("detached".to_string());
+            }
+            if is_local_only {
+                badges.push("local-only".to_string());
             }
             if status.is_some_and(|status| status.is_current) {
                 badges.push("current".to_string());
@@ -506,7 +523,8 @@ pub fn build_worktree_switch_model_with_protected_branches(
     let empty_state_lines = if rows.is_empty() {
         vec![
             "No Git worktrees found for this repository.".to_string(),
-            "Run `warp switch <branch>` to create one.".to_string(),
+            "Run `warp switch <branch>` to create one (local or remote branches both work)."
+                .to_string(),
         ]
     } else {
         Vec::new()

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -1248,3 +1248,162 @@ fn test_doctor_install_check_passes_with_single_active_binary() {
         "{stdout}"
     );
 }
+
+fn setup_repo_with_origin() -> (tempfile::TempDir, tempfile::TempDir) {
+    let upstream = tempdir().unwrap();
+    Command::new("git")
+        .args(["init", "--bare", "-b", "main"])
+        .current_dir(upstream.path())
+        .output()
+        .unwrap();
+
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+    Command::new("git")
+        .args(["remote", "add", "origin"])
+        .arg(upstream.path())
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["push", "-u", "origin", "main"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    (temp_dir, upstream)
+}
+
+#[test]
+fn test_switch_dry_run_labels_new_branch_source() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+
+    let output = warp_command(repo_path)
+        .args(["--dry-run", "switch", "fresh-feature"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{stdout}");
+    assert!(
+        stdout.contains("Source: new branch 'fresh-feature' from HEAD"),
+        "{stdout}"
+    );
+}
+
+#[test]
+fn test_switch_dry_run_labels_local_branch_source() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+
+    Command::new("git")
+        .args(["branch", "feature-local"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    let output = warp_command(repo_path)
+        .args(["--dry-run", "switch", "feature-local"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{stdout}");
+    assert!(
+        stdout.contains("Source: local branch 'feature-local'"),
+        "{stdout}"
+    );
+}
+
+#[test]
+fn test_switch_dry_run_labels_existing_worktree_source() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+    let worktree_path = create_worktree(repo_path, "feature-existing");
+
+    let output = warp_command(repo_path)
+        .args(["--dry-run", "switch", "feature-existing"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{stdout}");
+    let canonical = worktree_path.canonicalize().unwrap();
+    assert!(
+        stdout.contains(&format!(
+            "Source: existing worktree at {}",
+            canonical.display()
+        )) || stdout.contains(&format!(
+            "Source: existing worktree at {}",
+            worktree_path.display()
+        )),
+        "{stdout}"
+    );
+}
+
+#[test]
+fn test_switch_dry_run_labels_remote_branch_source() {
+    let (temp_dir, _upstream) = setup_repo_with_origin();
+    let repo_path = temp_dir.path();
+
+    Command::new("git")
+        .args(["branch", "feature-remote"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["push", "origin", "feature-remote"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["branch", "-D", "feature-remote"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["fetch", "origin"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    let output = warp_command(repo_path)
+        .args(["--dry-run", "switch", "feature-remote"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{stdout}");
+    assert!(
+        stdout.contains("Source: remote branch 'origin/feature-remote'"),
+        "{stdout}"
+    );
+}
+
+#[test]
+fn test_bare_warp_dry_run_marks_local_only_branch_in_switcher() {
+    let (temp_dir, _upstream) = setup_repo_with_origin();
+    let repo_path = temp_dir.path();
+    create_worktree(repo_path, "tracked-feature");
+    Command::new("git")
+        .args(["push", "origin", "tracked-feature"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    create_worktree(repo_path, "local-feature");
+
+    let output = warp_command(repo_path).arg("--dry-run").output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{stdout}");
+    let local_line = stdout
+        .lines()
+        .find(|line| line.contains("local-feature"))
+        .expect(&stdout);
+    assert!(local_line.contains("local-only"), "{local_line}");
+    let tracked_line = stdout
+        .lines()
+        .find(|line| line.contains("tracked-feature"))
+        .expect(&stdout);
+    assert!(!tracked_line.contains("local-only"), "{tracked_line}");
+}

--- a/tests/unit/git_tests.rs
+++ b/tests/unit/git_tests.rs
@@ -1,5 +1,5 @@
 use git_warp::config::GitConfig;
-use git_warp::git::{CleanupSkipReason, GitRepository};
+use git_warp::git::{BranchSource, CleanupSkipReason, GitRepository};
 use std::fs;
 use std::process::Command;
 use tempfile::tempdir;
@@ -656,4 +656,186 @@ fn test_relative_worktrees_path_generation_uses_primary_root_from_linked_worktre
         worktree_path,
         repo_path.join(".worktrees").join("feature-from-linked")
     );
+}
+
+fn setup_repo_with_origin() -> (tempfile::TempDir, tempfile::TempDir) {
+    let upstream = tempdir().unwrap();
+    Command::new("git")
+        .args(["init", "--bare", "--initial-branch", "main"])
+        .current_dir(upstream.path())
+        .output()
+        .unwrap();
+
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+    Command::new("git")
+        .args(["remote", "add", "origin"])
+        .arg(upstream.path())
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["push", "-u", "origin", "main"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    (temp_dir, upstream)
+}
+
+#[test]
+fn test_classify_branch_source_existing_worktree() {
+    let _cwd = crate::support::CurrentDirGuard::new();
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+    std::env::set_current_dir(repo_path).unwrap();
+
+    let git_repo = GitRepository::find().unwrap();
+    let worktree_path = repo_path.join(".worktrees").join("feature-existing");
+    git_repo
+        .create_worktree_and_branch("feature-existing", &worktree_path, None)
+        .unwrap();
+
+    let worktrees = git_repo.list_worktrees().unwrap();
+    let source = git_repo
+        .classify_branch_source("feature-existing", &worktrees)
+        .unwrap();
+
+    match source {
+        BranchSource::ExistingWorktree { path } => {
+            assert_eq!(
+                path.canonicalize().unwrap(),
+                worktree_path.canonicalize().unwrap()
+            );
+        }
+        other => panic!("expected ExistingWorktree, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_classify_branch_source_local_branch() {
+    let _cwd = crate::support::CurrentDirGuard::new();
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+    std::env::set_current_dir(repo_path).unwrap();
+
+    Command::new("git")
+        .args(["branch", "feature-local"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    let git_repo = GitRepository::find().unwrap();
+    let worktrees = git_repo.list_worktrees().unwrap();
+    let source = git_repo
+        .classify_branch_source("feature-local", &worktrees)
+        .unwrap();
+
+    assert_eq!(source, BranchSource::LocalBranch);
+}
+
+#[test]
+fn test_classify_branch_source_remote_branch() {
+    let _cwd = crate::support::CurrentDirGuard::new();
+    let (temp_dir, _upstream) = setup_repo_with_origin();
+    let repo_path = temp_dir.path();
+    std::env::set_current_dir(repo_path).unwrap();
+
+    Command::new("git")
+        .args(["branch", "feature-remote"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["push", "origin", "feature-remote"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["branch", "-D", "feature-remote"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["fetch", "origin"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    let git_repo = GitRepository::find().unwrap();
+    let worktrees = git_repo.list_worktrees().unwrap();
+    let source = git_repo
+        .classify_branch_source("feature-remote", &worktrees)
+        .unwrap();
+
+    assert_eq!(
+        source,
+        BranchSource::RemoteBranch {
+            remote_ref: "origin/feature-remote".to_string()
+        }
+    );
+}
+
+#[test]
+fn test_classify_branch_source_new_branch() {
+    let _cwd = crate::support::CurrentDirGuard::new();
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+    std::env::set_current_dir(repo_path).unwrap();
+
+    let git_repo = GitRepository::find().unwrap();
+    let worktrees = git_repo.list_worktrees().unwrap();
+    let source = git_repo
+        .classify_branch_source("brand-new", &worktrees)
+        .unwrap();
+
+    assert_eq!(source, BranchSource::NewBranch);
+}
+
+#[test]
+fn test_create_worktree_for_remote_branch_creates_local_tracking() {
+    let _cwd = crate::support::CurrentDirGuard::new();
+    let (temp_dir, _upstream) = setup_repo_with_origin();
+    let repo_path = temp_dir.path();
+    std::env::set_current_dir(repo_path).unwrap();
+
+    Command::new("git")
+        .args(["branch", "feature-track"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["push", "origin", "feature-track"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["branch", "-D", "feature-track"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["fetch", "origin"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    let git_repo = GitRepository::find().unwrap();
+    let worktree_path = repo_path.join(".worktrees").join("feature-track");
+    let source = BranchSource::RemoteBranch {
+        remote_ref: "origin/feature-track".to_string(),
+    };
+    git_repo
+        .create_worktree_for_source("feature-track", &worktree_path, &source)
+        .unwrap();
+
+    assert!(worktree_path.exists());
+    let head_branch = Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .current_dir(&worktree_path)
+        .output()
+        .unwrap();
+    let head_branch = String::from_utf8_lossy(&head_branch.stdout)
+        .trim()
+        .to_string();
+    assert_eq!(head_branch, "feature-track");
 }

--- a/tests/unit/tui_tests.rs
+++ b/tests/unit/tui_tests.rs
@@ -6,8 +6,9 @@ use git_warp::git::{BranchStatus, WorktreeInfo};
 use git_warp::tui::{
     AgentsDashboard, WorktreeRemovalBlock, WorktreeRuntimeStatus, build_cleanup_rows,
     build_dashboard_model, build_dashboard_model_windowed, build_worktree_switch_model,
-    build_worktree_switch_model_with_protected_branches, build_worktree_switch_rows,
-    cleanup_reason_label_for_mode, next_bulk_selection_state, session_detail_lines,
+    build_worktree_switch_model_with_metadata, build_worktree_switch_model_with_protected_branches,
+    build_worktree_switch_rows, cleanup_reason_label_for_mode, next_bulk_selection_state,
+    session_detail_lines,
 };
 use std::{
     path::PathBuf,
@@ -274,6 +275,52 @@ fn test_build_worktree_switch_model_marks_state_and_detached_rows() {
     );
     assert_eq!(model.rows[1].branch_label, "(detached HEAD: abcdef01)");
     assert_eq!(model.rows[1].badges, vec!["detached", "occupied"]);
+}
+
+#[test]
+fn test_build_worktree_switch_model_marks_local_only_branches() {
+    let worktrees = vec![
+        WorktreeInfo {
+            path: PathBuf::from("/repo/.worktrees/tracked"),
+            branch: "tracked".to_string(),
+            head: "0123456789abcdef".to_string(),
+            is_primary: false,
+            is_current: false,
+            is_detached: false,
+        },
+        WorktreeInfo {
+            path: PathBuf::from("/repo/.worktrees/local-only"),
+            branch: "local-only".to_string(),
+            head: "abcdef0123456789".to_string(),
+            is_primary: false,
+            is_current: false,
+            is_detached: false,
+        },
+    ];
+    let statuses = vec![];
+    let local_only_branches = vec!["local-only".to_string()];
+
+    let model =
+        build_worktree_switch_model_with_metadata(&worktrees, &statuses, &[], &local_only_branches);
+
+    let tracked_row = model
+        .rows
+        .iter()
+        .find(|row| row.branch_label == "tracked")
+        .expect("tracked row");
+    assert!(!tracked_row.badges.iter().any(|badge| badge == "local-only"));
+
+    let local_only_row = model
+        .rows
+        .iter()
+        .find(|row| row.branch_label == "local-only")
+        .expect("local-only row");
+    assert!(
+        local_only_row
+            .badges
+            .iter()
+            .any(|badge| badge == "local-only")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- classify the target of `warp switch` as existing worktree, local branch, remote branch, or new branch and surface a labeled status line in both run and dry-run output (e.g. `🌐 Creating worktree from remote branch 'origin/foo' (new local 'foo' tracking it)`)
- when the branch only exists on a remote, create the local tracking branch from that remote ref instead of silently branching from HEAD
- add a `local-only` badge to bare-warp switcher rows for branches that have no matching ref on any configured remote (skipped when the repo has no remotes, so single-developer setups stay quiet)
- add unit + CLI surface coverage for local-only, remote-only, existing-worktree, and new-branch cases

Closes #36

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test mod unit -- --nocapture --test-threads=1` (103 passed)
- `cargo test --test mod integration::cli_surface_tests -- --nocapture --test-threads=1` (38 passed; 2 pre-existing failures `test_switch_latest_resolves_branch_from_recent_agent_session` / `test_switch_waiting_resolves_branch_from_waiting_agent_session` reproduce on `origin/main`, same baseline as PR #50 / #49 / #48)
- `cargo test --test mod integration::switch_post_create_tests integration::terminal_switch_tests` (12 passed)

New tests:
- `unit::git_tests::test_classify_branch_source_existing_worktree`
- `unit::git_tests::test_classify_branch_source_local_branch`
- `unit::git_tests::test_classify_branch_source_remote_branch`
- `unit::git_tests::test_classify_branch_source_new_branch`
- `unit::git_tests::test_create_worktree_for_remote_branch_creates_local_tracking`
- `unit::tui_tests::test_build_worktree_switch_model_marks_local_only_branches`
- `integration::cli_surface_tests::test_switch_dry_run_labels_new_branch_source`
- `integration::cli_surface_tests::test_switch_dry_run_labels_local_branch_source`
- `integration::cli_surface_tests::test_switch_dry_run_labels_existing_worktree_source`
- `integration::cli_surface_tests::test_switch_dry_run_labels_remote_branch_source`
- `integration::cli_surface_tests::test_bare_warp_dry_run_marks_local_only_branch_in_switcher`