### PR TITLE
Add shell integration self-checks to warp doctor

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -152,6 +152,16 @@ pub enum Commands {
     },
 }
 
+enum DoctorShell {
+    Known {
+        name: &'static str,
+        rc_path: PathBuf,
+    },
+    Unknown {
+        value: Option<String>,
+    },
+}
+
 struct DoctorInstallEntry {
     path: PathBuf,
     active: bool,
@@ -1607,6 +1617,7 @@ impl Cli {
         }
 
         Self::report_doctor_install(&mut next_steps);
+        Self::report_doctor_shell_integration(&mut next_steps);
 
         if repo.is_some() && config_manager.config_exists() && hooks_installed {
             next_steps.push("Run `warp switch <branch>` to create or open a worktree.".to_string());
@@ -1696,6 +1707,162 @@ impl Cli {
         } else {
             Self::doctor_ok("Install", detail);
         }
+    }
+
+    fn report_doctor_shell_integration(next_steps: &mut Vec<String>) {
+        let active = Self::resolve_warp_on_path();
+        let default_dir = Self::doctor_default_install_dir();
+        let path_dirs = Self::path_dirs();
+        let install_on_path = default_dir
+            .as_ref()
+            .map(|dir| path_dirs.iter().any(|d| Self::same_path(d, dir)))
+            .unwrap_or(false);
+
+        match (&active, &default_dir) {
+            (Some(path), _) => {
+                Self::doctor_ok("Shell PATH", format!("active warp at {}", path.display()))
+            }
+            (None, Some(dir)) => {
+                Self::doctor_warn(
+                    "Shell PATH",
+                    format!("no warp on PATH (expected {}/warp)", dir.display()),
+                );
+                next_steps.push(format!(
+                    "Add `{}` to PATH (e.g. `export PATH=\"{}:$PATH\"`).",
+                    dir.display(),
+                    dir.display()
+                ));
+            }
+            (None, None) => {
+                Self::doctor_warn("Shell PATH", "no warp on PATH and HOME is not set");
+            }
+        }
+
+        if let Some(dir) = &default_dir {
+            if !install_on_path {
+                Self::doctor_warn(
+                    "Default install path",
+                    format!("{} is not in PATH", dir.display()),
+                );
+                next_steps.push(format!(
+                    "Add `{}` to PATH (e.g. `export PATH=\"{}:$PATH\"`) so installed warp is found.",
+                    dir.display(),
+                    dir.display()
+                ));
+            } else if let Some(active_path) = &active {
+                let installed = dir.join("warp");
+                if installed.is_file() && !Self::same_path(active_path, &installed) {
+                    Self::doctor_warn(
+                        "Default install path",
+                        format!(
+                            "{} is on PATH but a different warp resolves first at {}",
+                            dir.display(),
+                            active_path.display()
+                        ),
+                    );
+                    next_steps.push(format!(
+                        "Reorder PATH to put `{}` before `{}`.",
+                        dir.display(),
+                        active_path
+                            .parent()
+                            .map(|p| p.display().to_string())
+                            .unwrap_or_else(|| active_path.display().to_string())
+                    ));
+                }
+            }
+        }
+
+        let shell = Self::detect_shell();
+        match &shell {
+            DoctorShell::Known { name, rc_path } => {
+                let rc_label = rc_path.display().to_string();
+                let configured = Self::shell_rc_has_warp_integration(rc_path);
+                if configured {
+                    Self::doctor_ok(
+                        "Shell integration",
+                        format!("warp_cd helper detected in {rc_label}"),
+                    );
+                } else {
+                    Self::doctor_warn(
+                        "Shell integration",
+                        format!("warp_cd helper not found in {rc_label}"),
+                    );
+                    next_steps.push(format!(
+                        "Run `warp shell-config {name}` and append the output to {rc_label} to enable `warp_cd` and completions."
+                    ));
+                }
+            }
+            DoctorShell::Unknown { value } => {
+                let detail = match value {
+                    Some(v) => format!("unsupported shell `{v}`; supported: bash, zsh, fish"),
+                    None => "SHELL is not set".to_string(),
+                };
+                Self::doctor_warn("Shell integration", detail);
+                next_steps.push(
+                    "Set SHELL to bash, zsh, or fish, then run `warp shell-config` for setup snippets.".to_string(),
+                );
+            }
+        }
+    }
+
+    fn doctor_default_install_dir() -> Option<PathBuf> {
+        if let Some(value) = std::env::var_os("GIT_WARP_DEFAULT_INSTALL_DIR") {
+            let path = PathBuf::from(value);
+            if !path.as_os_str().is_empty() {
+                return Some(path);
+            }
+        }
+        dirs::home_dir().map(|h| h.join(".local").join("bin"))
+    }
+
+    fn path_dirs() -> Vec<PathBuf> {
+        std::env::var_os("PATH")
+            .map(|value| std::env::split_paths(&value).collect())
+            .unwrap_or_default()
+    }
+
+    fn same_path(a: &Path, b: &Path) -> bool {
+        let canon_a = std::fs::canonicalize(a).unwrap_or_else(|_| a.to_path_buf());
+        let canon_b = std::fs::canonicalize(b).unwrap_or_else(|_| b.to_path_buf());
+        canon_a == canon_b
+    }
+
+    fn detect_shell() -> DoctorShell {
+        let raw = std::env::var("SHELL").ok().filter(|v| !v.trim().is_empty());
+        let basename = raw.as_deref().and_then(|value| {
+            value
+                .rsplit('/')
+                .next()
+                .map(str::to_string)
+                .filter(|v| !v.is_empty())
+        });
+
+        let home = match dirs::home_dir() {
+            Some(h) => h,
+            None => return DoctorShell::Unknown { value: raw },
+        };
+
+        match basename.as_deref() {
+            Some("bash") => DoctorShell::Known {
+                name: "bash",
+                rc_path: home.join(".bashrc"),
+            },
+            Some("zsh") => DoctorShell::Known {
+                name: "zsh",
+                rc_path: home.join(".zshrc"),
+            },
+            Some("fish") => DoctorShell::Known {
+                name: "fish",
+                rc_path: home.join(".config").join("fish").join("config.fish"),
+            },
+            _ => DoctorShell::Unknown { value: raw },
+        }
+    }
+
+    fn shell_rc_has_warp_integration(rc_path: &Path) -> bool {
+        std::fs::read_to_string(rc_path)
+            .map(|content| content.contains("warp_cd") || content.contains("warp __complete"))
+            .unwrap_or(false)
     }
 
     fn doctor_install_candidates() -> Vec<DoctorInstallEntry> {

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -1248,3 +1248,201 @@ fn test_doctor_install_check_passes_with_single_active_binary() {
         "{stdout}"
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn test_doctor_shell_check_warns_when_install_dir_not_in_path() {
+    let temp_dir = tempdir().unwrap();
+    let home_dir = tempdir().unwrap();
+    let other_dir = tempdir().unwrap();
+
+    let install_dir = home_dir.path().join(".local").join("bin");
+    let output = warp_command(temp_dir.path())
+        .env("HOME", home_dir.path())
+        .env("XDG_CONFIG_HOME", home_dir.path().join(".config"))
+        .env("PATH", other_dir.path())
+        .env("GIT_WARP_DOCTOR_PROBE_DIRS", other_dir.path())
+        .arg("doctor")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "{stdout}{stderr}");
+    assert!(stdout.contains("Default install path"), "{stdout}");
+    assert!(
+        stdout.contains(&format!("{} is not in PATH", install_dir.display())),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains(&format!("export PATH=\"{}:$PATH\"", install_dir.display())),
+        "{stdout}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_doctor_shell_check_passes_when_install_dir_in_path() {
+    let temp_dir = tempdir().unwrap();
+    let home_dir = tempdir().unwrap();
+    let install_dir = home_dir.path().join(".local").join("bin");
+    fs::create_dir_all(&install_dir).unwrap();
+    write_fake_warp_binary(&install_dir.join("warp"), "warp 0.4.0");
+
+    let output = warp_command(temp_dir.path())
+        .env("HOME", home_dir.path())
+        .env("XDG_CONFIG_HOME", home_dir.path().join(".config"))
+        .env("PATH", &install_dir)
+        .env("GIT_WARP_DOCTOR_PROBE_DIRS", &install_dir)
+        .arg("doctor")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "{stdout}{stderr}");
+    assert!(stdout.contains("Shell PATH"), "{stdout}");
+    assert!(
+        stdout.contains(&format!("active warp at {}/warp", install_dir.display())),
+        "{stdout}"
+    );
+    assert!(!stdout.contains("is not in PATH"), "{stdout}");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_doctor_shell_check_warns_when_path_shadows_install_dir() {
+    let temp_dir = tempdir().unwrap();
+    let home_dir = tempdir().unwrap();
+    let install_dir = home_dir.path().join(".local").join("bin");
+    fs::create_dir_all(&install_dir).unwrap();
+    write_fake_warp_binary(&install_dir.join("warp"), "warp 0.4.0");
+
+    let other_dir = tempdir().unwrap();
+    write_fake_warp_binary(&other_dir.path().join("warp"), "warp 0.1.0");
+
+    let path_value = format!("{}:{}", other_dir.path().display(), install_dir.display());
+    let output = warp_command(temp_dir.path())
+        .env("HOME", home_dir.path())
+        .env("XDG_CONFIG_HOME", home_dir.path().join(".config"))
+        .env("PATH", &path_value)
+        .env("GIT_WARP_DOCTOR_PROBE_DIRS", &path_value)
+        .arg("doctor")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "{stdout}{stderr}");
+    assert!(stdout.contains("Default install path"), "{stdout}");
+    assert!(
+        stdout.contains("a different warp resolves first at"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains(&format!(
+            "Reorder PATH to put `{}` before `{}`",
+            install_dir.display(),
+            other_dir.path().display()
+        )),
+        "{stdout}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_doctor_shell_check_warns_when_shell_rc_lacks_warp_cd() {
+    let temp_dir = tempdir().unwrap();
+    let home_dir = tempdir().unwrap();
+    let probe = tempdir().unwrap();
+    write_fake_warp_binary(&probe.path().join("warp"), "warp 0.4.0");
+
+    let output = warp_command(temp_dir.path())
+        .env("HOME", home_dir.path())
+        .env("XDG_CONFIG_HOME", home_dir.path().join(".config"))
+        .env("PATH", probe.path())
+        .env("GIT_WARP_DOCTOR_PROBE_DIRS", probe.path())
+        .env("SHELL", "/bin/zsh")
+        .arg("doctor")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "{stdout}{stderr}");
+    assert!(stdout.contains("Shell integration"), "{stdout}");
+    let zshrc = home_dir.path().join(".zshrc");
+    assert!(
+        stdout.contains(&format!("warp_cd helper not found in {}", zshrc.display())),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains(&format!(
+            "Run `warp shell-config zsh` and append the output to {}",
+            zshrc.display()
+        )),
+        "{stdout}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_doctor_shell_check_passes_when_shell_rc_has_warp_cd() {
+    let temp_dir = tempdir().unwrap();
+    let home_dir = tempdir().unwrap();
+    let probe = tempdir().unwrap();
+    write_fake_warp_binary(&probe.path().join("warp"), "warp 0.4.0");
+    let zshrc = home_dir.path().join(".zshrc");
+    fs::write(
+        &zshrc,
+        "# user config\nwarp_cd() { eval \"$(warp --terminal echo \"$@\")\"; }\n",
+    )
+    .unwrap();
+
+    let output = warp_command(temp_dir.path())
+        .env("HOME", home_dir.path())
+        .env("XDG_CONFIG_HOME", home_dir.path().join(".config"))
+        .env("PATH", probe.path())
+        .env("GIT_WARP_DOCTOR_PROBE_DIRS", probe.path())
+        .env("SHELL", "/bin/zsh")
+        .arg("doctor")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "{stdout}{stderr}");
+    assert!(
+        stdout.contains(&format!("warp_cd helper detected in {}", zshrc.display())),
+        "{stdout}"
+    );
+    assert!(!stdout.contains("warp_cd helper not found"), "{stdout}");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_doctor_shell_check_handles_unknown_shell() {
+    let temp_dir = tempdir().unwrap();
+    let home_dir = tempdir().unwrap();
+    let probe = tempdir().unwrap();
+    write_fake_warp_binary(&probe.path().join("warp"), "warp 0.4.0");
+
+    let output = warp_command(temp_dir.path())
+        .env("HOME", home_dir.path())
+        .env("XDG_CONFIG_HOME", home_dir.path().join(".config"))
+        .env("PATH", probe.path())
+        .env("GIT_WARP_DOCTOR_PROBE_DIRS", probe.path())
+        .env("SHELL", "/usr/bin/tcsh")
+        .arg("doctor")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "{stdout}{stderr}");
+    assert!(
+        stdout.contains("unsupported shell `/usr/bin/tcsh`"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("supported: bash, zsh, fish"), "{stdout}");
+}


### PR DESCRIPTION
## Summary
- report the active `warp` on PATH and warn when the default install directory (`$HOME/.local/bin`) is missing from PATH or shadowed by an earlier `warp`
- detect the user shell from `$SHELL` and check its rc file (`.bashrc` / `.zshrc` / `config.fish`) for the `warp_cd` helper, with actionable `warp shell-config <shell>` guidance when missing — no automatic file edits
- cover the new checks with `cli_surface_tests` for in-PATH, out-of-PATH, PATH-shadow, rc-configured, rc-missing, and unsupported-shell cases

Closes #37

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo build`
- `cargo test --test mod 'integration::cli_surface_tests::test_doctor' -- --test-threads=1` (10 passed)
- `cargo test --test mod 'unit::tui_tests' -- --test-threads=1` (19 passed)
- `cargo test --test mod 'unit::git_tests' -- --test-threads=1` (18 passed)
- `cargo test --test mod 'integration::switch_post_create_tests' -- --test-threads=1` (2 passed)

The pre-existing baseline failures `test_switch_latest_resolves_branch_from_recent_agent_session` / `test_switch_waiting_resolves_branch_from_waiting_agent_session` and `unit::process_tests::test_signal_handling` reproduce on `origin/main` and are unrelated to this change (same baseline as PR #50 / #51).

New tests:
- `integration::cli_surface_tests::test_doctor_shell_check_warns_when_install_dir_not_in_path`
- `integration::cli_surface_tests::test_doctor_shell_check_passes_when_install_dir_in_path`
- `integration::cli_surface_tests::test_doctor_shell_check_warns_when_path_shadows_install_dir`
- `integration::cli_surface_tests::test_doctor_shell_check_warns_when_shell_rc_lacks_warp_cd`
- `integration::cli_surface_tests::test_doctor_shell_check_passes_when_shell_rc_has_warp_cd`
- `integration::cli_surface_tests::test_doctor_shell_check_handles_unknown_shell`