### PR TITLE
Filter agents dashboard by runtime, presence, and staleness

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -83,14 +83,118 @@ pub struct DashboardRow {
     pub location_label: String,
     pub agent_label: String,
     pub relative_time: String,
+    pub is_stale: bool,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct DashboardModel {
     pub rows: Vec<DashboardRow>,
     pub total_rows: usize,
+    pub total_unfiltered: usize,
     pub start_index: usize,
     pub empty_state_lines: Vec<String>,
+    pub filter_summary: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+pub enum AgentRuntimeFilter {
+    #[default]
+    All,
+    Claude,
+    Codex,
+}
+
+impl AgentRuntimeFilter {
+    pub fn next(self) -> Self {
+        match self {
+            Self::All => Self::Claude,
+            Self::Claude => Self::Codex,
+            Self::Codex => Self::All,
+        }
+    }
+
+    fn matches(self, runtime: AgentRuntime) -> bool {
+        match self {
+            Self::All => true,
+            Self::Claude => runtime == AgentRuntime::Claude,
+            Self::Codex => runtime == AgentRuntime::Codex,
+        }
+    }
+
+    fn label(self) -> Option<&'static str> {
+        match self {
+            Self::All => None,
+            Self::Claude => Some("Claude"),
+            Self::Codex => Some("Codex"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+pub enum AgentPresenceFilter {
+    #[default]
+    All,
+    Live,
+    Recent,
+}
+
+impl AgentPresenceFilter {
+    pub fn next(self) -> Self {
+        match self {
+            Self::All => Self::Live,
+            Self::Live => Self::Recent,
+            Self::Recent => Self::All,
+        }
+    }
+
+    fn matches(self, session: &AgentSessionSummary, now: DateTime<Local>) -> bool {
+        match self {
+            Self::All => true,
+            Self::Live => session.is_live,
+            Self::Recent => !session.is_live && !is_stale_session(session, now),
+        }
+    }
+
+    fn label(self) -> Option<&'static str> {
+        match self {
+            Self::All => None,
+            Self::Live => Some("live"),
+            Self::Recent => Some("recent"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+pub struct DashboardFilters {
+    pub runtime: AgentRuntimeFilter,
+    pub presence: AgentPresenceFilter,
+}
+
+impl DashboardFilters {
+    pub fn is_active(&self) -> bool {
+        self.runtime != AgentRuntimeFilter::All || self.presence != AgentPresenceFilter::All
+    }
+
+    pub fn summary(&self) -> String {
+        let parts: Vec<&'static str> = [self.runtime.label(), self.presence.label()]
+            .into_iter()
+            .flatten()
+            .collect();
+        if parts.is_empty() {
+            String::new()
+        } else {
+            format!("Filter: {}", parts.join(" · "))
+        }
+    }
+}
+
+const STALE_THRESHOLD_HOURS: i64 = 24;
+
+pub fn is_stale_session(session: &AgentSessionSummary, now: DateTime<Local>) -> bool {
+    if session.is_live {
+        return false;
+    }
+    now.signed_duration_since(session.last_activity) > ChronoDuration::hours(STALE_THRESHOLD_HOURS)
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -235,6 +339,7 @@ pub struct TuiApp {
     last_refresh: Instant,
     discovery: AgentDiscovery,
     sessions: Vec<AgentSessionSummary>,
+    filters: DashboardFilters,
 }
 
 impl TuiApp {
@@ -245,6 +350,7 @@ impl TuiApp {
             last_refresh: Instant::now() - REFRESH_INTERVAL,
             discovery,
             sessions: Vec::new(),
+            filters: DashboardFilters::default(),
         }
     }
 
@@ -311,12 +417,24 @@ impl TuiApp {
                             }
                         }
                         KeyCode::Down | KeyCode::Char('j') => {
-                            if self.selected_index < self.sessions.len().saturating_sub(1) {
+                            if self.selected_index < self.filtered_count().saturating_sub(1) {
                                 self.selected_index += 1;
                             }
                         }
                         KeyCode::Char('r') => {
                             self.refresh_sessions()?;
+                        }
+                        KeyCode::Char('t') => {
+                            self.filters.runtime = self.filters.runtime.next();
+                            self.selected_index = 0;
+                        }
+                        KeyCode::Char('p') => {
+                            self.filters.presence = self.filters.presence.next();
+                            self.selected_index = 0;
+                        }
+                        KeyCode::Char('c') => {
+                            self.filters = DashboardFilters::default();
+                            self.selected_index = 0;
                         }
                         _ => {}
                     }
@@ -333,13 +451,25 @@ impl TuiApp {
 
     fn refresh_sessions(&mut self) -> Result<()> {
         self.sessions = self.discovery.discover(Local::now())?;
-        if self.sessions.is_empty() {
+        let filtered = self.filtered_count();
+        if filtered == 0 {
             self.selected_index = 0;
         } else {
-            self.selected_index = self.selected_index.min(self.sessions.len() - 1);
+            self.selected_index = self.selected_index.min(filtered - 1);
         }
         self.last_refresh = Instant::now();
         Ok(())
+    }
+
+    fn filtered_count(&self) -> usize {
+        let now = Local::now();
+        self.sessions
+            .iter()
+            .filter(|session| {
+                self.filters.runtime.matches(session.runtime)
+                    && self.filters.presence.matches(session, now)
+            })
+            .count()
     }
 
     fn draw_agents_dashboard(&self, f: &mut Frame, now: DateTime<Local>) {
@@ -353,8 +483,24 @@ impl TuiApp {
             ])
             .split(f.size());
 
-        // Header
-        let header = Paragraph::new(format!("Warp Agents ({})", self.sessions.len()))
+        let preview_model = build_dashboard_model_filtered_windowed(
+            &self.sessions,
+            now,
+            self.selected_index,
+            1,
+            self.filters,
+        );
+        let header_text = if self.filters.is_active() {
+            format!(
+                "Warp Agents ({}/{}) — {}",
+                preview_model.total_rows,
+                preview_model.total_unfiltered,
+                preview_model.filter_summary
+            )
+        } else {
+            format!("Warp Agents ({})", preview_model.total_unfiltered)
+        };
+        let header = Paragraph::new(header_text)
             .style(
                 Style::default()
                     .fg(Color::Cyan)
@@ -364,9 +510,10 @@ impl TuiApp {
             .block(Block::default().borders(Borders::ALL));
         f.render_widget(header, chunks[0]);
 
-        if self.sessions.is_empty() {
-            let model = build_dashboard_model(&[], now);
-            let empty_state = Paragraph::new(model.empty_state_lines.join("\n\n"))
+        if preview_model.total_rows == 0 {
+            let empty_model =
+                build_dashboard_model_filtered_windowed(&self.sessions, now, 0, 1, self.filters);
+            let empty_state = Paragraph::new(empty_model.empty_state_lines.join("\n\n"))
                 .block(Block::default().title("No Sessions").borders(Borders::ALL))
                 .alignment(Alignment::Center)
                 .style(Style::default().fg(Color::Gray))
@@ -378,19 +525,22 @@ impl TuiApp {
                 .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
                 .split(chunks[1]);
             let visible_capacity = content_chunks[0].height.saturating_sub(2).max(1) as usize;
-            let model = build_dashboard_model_windowed(
+            let model = build_dashboard_model_filtered_windowed(
                 &self.sessions,
                 now,
                 self.selected_index,
                 visible_capacity,
+                self.filters,
             );
 
             let session_items: Vec<ListItem> = model
                 .rows
                 .iter()
                 .map(|row| {
+                    let stale_marker = if row.is_stale { "~" } else { " " };
                     let text = format!(
-                        "{} {:<6} {:<10} {:<18} {:<18} {}",
+                        "{}{} {:<6} {:<10} {:<18} {:<18} {}",
+                        stale_marker,
                         row.state_symbol,
                         row.runtime_label,
                         truncate_label(row.state_label, 10),
@@ -398,7 +548,13 @@ impl TuiApp {
                         truncate_label(&row.agent_label, 18),
                         row.relative_time
                     );
-                    let style = Style::default().fg(session_state_color(row.session.state));
+                    let style = if row.is_stale {
+                        Style::default()
+                            .fg(Color::DarkGray)
+                            .add_modifier(Modifier::DIM)
+                    } else {
+                        Style::default().fg(session_state_color(row.session.state))
+                    };
                     ListItem::new(Line::from(text)).style(style)
                 })
                 .collect();
@@ -415,17 +571,22 @@ impl TuiApp {
             list_state.select(Some(self.selected_index.saturating_sub(model.start_index)));
             f.render_stateful_widget(sessions_list, content_chunks[0], &mut list_state);
 
-            if let Some(selected_session) = self.sessions.get(self.selected_index) {
-                let details = Paragraph::new(session_detail_lines(selected_session).join("\n"))
-                    .block(Block::default().title("Details").borders(Borders::ALL))
-                    .style(Style::default().fg(Color::White))
-                    .wrap(Wrap { trim: false });
+            if let Some(selected_row) = model
+                .rows
+                .get(self.selected_index.saturating_sub(model.start_index))
+            {
+                let details =
+                    Paragraph::new(session_detail_lines(&selected_row.session).join("\n"))
+                        .block(Block::default().title("Details").borders(Borders::ALL))
+                        .style(Style::default().fg(Color::White))
+                        .wrap(Wrap { trim: false });
                 f.render_widget(details, content_chunks[1]);
             }
         }
 
         // Help
-        let help_text = "↑↓/jk: Navigate | r: Refresh | q/Esc: Quit";
+        let help_text =
+            "↑↓/jk: Navigate | r: Refresh | t: Runtime | p: Presence | c: Clear | q/Esc: Quit";
         let help = Paragraph::new(help_text)
             .style(Style::default().fg(Color::Gray))
             .alignment(Alignment::Center)
@@ -635,13 +796,38 @@ pub fn build_dashboard_model_windowed(
     selected_index: usize,
     visible_capacity: usize,
 ) -> DashboardModel {
-    let total_rows = sessions.len();
+    build_dashboard_model_filtered_windowed(
+        sessions,
+        now,
+        selected_index,
+        visible_capacity,
+        DashboardFilters::default(),
+    )
+}
+
+pub fn build_dashboard_model_filtered_windowed(
+    sessions: &[AgentSessionSummary],
+    now: DateTime<Local>,
+    selected_index: usize,
+    visible_capacity: usize,
+    filters: DashboardFilters,
+) -> DashboardModel {
+    let total_unfiltered = sessions.len();
+    let filtered: Vec<AgentSessionSummary> = sessions
+        .iter()
+        .filter(|session| {
+            filters.runtime.matches(session.runtime) && filters.presence.matches(session, now)
+        })
+        .cloned()
+        .collect();
+
+    let total_rows = filtered.len();
     let visible_capacity = visible_capacity.max(1).min(total_rows.max(1));
     let selected_index = selected_index.min(total_rows.saturating_sub(1));
     let start_index = dashboard_window_start(total_rows, selected_index, visible_capacity);
     let end_index = start_index.saturating_add(visible_capacity).min(total_rows);
 
-    let rows = sessions
+    let rows = filtered
         .get(start_index..end_index)
         .unwrap_or_default()
         .iter()
@@ -653,17 +839,28 @@ pub fn build_dashboard_model_windowed(
             location_label: session_location_label(&session),
             agent_label: session.agent_label.clone(),
             relative_time: relative_time_label(session.last_activity, now),
+            is_stale: is_stale_session(&session, now),
             session,
         })
         .collect::<Vec<_>>();
 
     let empty_state_lines = if rows.is_empty() {
-        vec![
-            "No agent sessions to show for this repository.".to_string(),
-            "Recent Claude/Codex sessions appear here for 7 days.".to_string(),
-            "Hint: run `warp hooks-install --runtime all --level user` to enable live monitoring."
-                .to_string(),
-        ]
+        if filters.is_active() && total_unfiltered > 0 {
+            vec![
+                format!(
+                    "No sessions match the active filter ({}/{} hidden).",
+                    total_unfiltered, total_unfiltered
+                ),
+                "Press `t` to cycle runtime, `p` for presence, or `c` to clear.".to_string(),
+            ]
+        } else {
+            vec![
+                "No agent sessions to show for this repository.".to_string(),
+                "Recent Claude/Codex sessions appear here for 7 days.".to_string(),
+                "Hint: run `warp hooks-install --runtime all --level user` to enable live monitoring."
+                    .to_string(),
+            ]
+        }
     } else {
         Vec::new()
     };
@@ -671,8 +868,10 @@ pub fn build_dashboard_model_windowed(
     DashboardModel {
         rows,
         total_rows,
+        total_unfiltered,
         start_index,
         empty_state_lines,
+        filter_summary: filters.summary(),
     }
 }
 

--- a/tests/unit/tui_tests.rs
+++ b/tests/unit/tui_tests.rs
@@ -4,10 +4,12 @@ use git_warp::agents::{
 };
 use git_warp::git::{BranchStatus, WorktreeInfo};
 use git_warp::tui::{
-    AgentsDashboard, WorktreeRemovalBlock, WorktreeRuntimeStatus, build_cleanup_rows,
-    build_dashboard_model, build_dashboard_model_windowed, build_worktree_switch_model,
-    build_worktree_switch_model_with_protected_branches, build_worktree_switch_rows,
-    cleanup_reason_label_for_mode, next_bulk_selection_state, session_detail_lines,
+    AgentPresenceFilter, AgentRuntimeFilter, AgentsDashboard, DashboardFilters,
+    WorktreeRemovalBlock, WorktreeRuntimeStatus, build_cleanup_rows, build_dashboard_model,
+    build_dashboard_model_filtered_windowed, build_dashboard_model_windowed,
+    build_worktree_switch_model, build_worktree_switch_model_with_protected_branches,
+    build_worktree_switch_rows, cleanup_reason_label_for_mode, is_stale_session,
+    next_bulk_selection_state, session_detail_lines,
 };
 use std::{
     path::PathBuf,
@@ -225,6 +227,244 @@ fn test_build_dashboard_model_windowed_only_formats_visible_rows() {
 fn test_agents_dashboard_accepts_discovery() {
     let discovery = AgentDiscovery::new(vec![PathBuf::from("/repo")]);
     let _dashboard = AgentsDashboard::new(discovery);
+}
+
+fn dashboard_filter_sample(
+    runtime: AgentRuntime,
+    session_id: &str,
+    cwd: &str,
+    is_live: bool,
+    last_activity_hour: u32,
+) -> AgentSessionSummary {
+    let state = if is_live {
+        AgentSessionState::Working
+    } else {
+        AgentSessionState::Recent
+    };
+    let source = if is_live {
+        AgentSessionSource::LiveStatus
+    } else {
+        AgentSessionSource::SessionStore
+    };
+    sample_summary(
+        runtime,
+        session_id,
+        cwd,
+        state,
+        last_activity_hour,
+        is_live,
+        source,
+    )
+}
+
+#[test]
+fn test_is_stale_session_true_when_recent_and_older_than_a_day() {
+    let now = Local.with_ymd_and_hms(2026, 4, 23, 12, 0, 0).unwrap();
+    let mut session = dashboard_filter_sample(
+        AgentRuntime::Codex,
+        "stale",
+        "/repo/.worktrees/stale",
+        false,
+        11,
+    );
+    session.last_activity = now - chrono::Duration::hours(48);
+
+    assert!(is_stale_session(&session, now));
+}
+
+#[test]
+fn test_is_stale_session_false_when_live_even_if_old() {
+    let now = Local.with_ymd_and_hms(2026, 4, 23, 12, 0, 0).unwrap();
+    let mut session = dashboard_filter_sample(
+        AgentRuntime::Claude,
+        "live-old",
+        "/repo/.worktrees/live-old",
+        true,
+        11,
+    );
+    session.last_activity = now - chrono::Duration::hours(72);
+
+    assert!(!is_stale_session(&session, now));
+}
+
+#[test]
+fn test_is_stale_session_false_when_recent_but_fresh() {
+    let now = Local.with_ymd_and_hms(2026, 4, 23, 12, 0, 0).unwrap();
+    let mut session = dashboard_filter_sample(
+        AgentRuntime::Codex,
+        "fresh",
+        "/repo/.worktrees/fresh",
+        false,
+        11,
+    );
+    session.last_activity = now - chrono::Duration::hours(2);
+
+    assert!(!is_stale_session(&session, now));
+}
+
+#[test]
+fn test_build_dashboard_model_marks_stale_rows() {
+    let now = Local.with_ymd_and_hms(2026, 4, 23, 12, 0, 0).unwrap();
+    let mut stale = dashboard_filter_sample(
+        AgentRuntime::Codex,
+        "stale",
+        "/repo/.worktrees/stale",
+        false,
+        11,
+    );
+    stale.last_activity = now - chrono::Duration::hours(48);
+    let fresh = dashboard_filter_sample(
+        AgentRuntime::Codex,
+        "fresh",
+        "/repo/.worktrees/fresh",
+        false,
+        11,
+    );
+
+    let model = build_dashboard_model(&[stale, fresh], now);
+
+    let stale_row = model
+        .rows
+        .iter()
+        .find(|row| row.session.session_id.as_deref() == Some("stale"))
+        .expect("stale row");
+    let fresh_row = model
+        .rows
+        .iter()
+        .find(|row| row.session.session_id.as_deref() == Some("fresh"))
+        .expect("fresh row");
+    assert!(stale_row.is_stale);
+    assert!(!fresh_row.is_stale);
+}
+
+#[test]
+fn test_build_dashboard_model_filtered_filters_runtime_codex() {
+    let now = Local.with_ymd_and_hms(2026, 4, 23, 12, 0, 0).unwrap();
+    let sessions = vec![
+        dashboard_filter_sample(
+            AgentRuntime::Claude,
+            "claude-1",
+            "/repo/.worktrees/claude-1",
+            true,
+            11,
+        ),
+        dashboard_filter_sample(
+            AgentRuntime::Codex,
+            "codex-1",
+            "/repo/.worktrees/codex-1",
+            true,
+            10,
+        ),
+    ];
+
+    let filters = DashboardFilters {
+        runtime: AgentRuntimeFilter::Codex,
+        presence: AgentPresenceFilter::All,
+    };
+    let model = build_dashboard_model_filtered_windowed(&sessions, now, 0, 10, filters);
+
+    assert_eq!(model.total_unfiltered, 2);
+    assert_eq!(model.total_rows, 1);
+    assert_eq!(model.rows[0].session.session_id.as_deref(), Some("codex-1"));
+}
+
+#[test]
+fn test_build_dashboard_model_filtered_filters_presence_live() {
+    let now = Local.with_ymd_and_hms(2026, 4, 23, 12, 0, 0).unwrap();
+    let sessions = vec![
+        dashboard_filter_sample(
+            AgentRuntime::Codex,
+            "live-one",
+            "/repo/.worktrees/live-one",
+            true,
+            11,
+        ),
+        dashboard_filter_sample(
+            AgentRuntime::Codex,
+            "recent-one",
+            "/repo/.worktrees/recent-one",
+            false,
+            10,
+        ),
+    ];
+
+    let filters = DashboardFilters {
+        runtime: AgentRuntimeFilter::All,
+        presence: AgentPresenceFilter::Live,
+    };
+    let model = build_dashboard_model_filtered_windowed(&sessions, now, 0, 10, filters);
+
+    assert_eq!(model.rows.len(), 1);
+    assert_eq!(
+        model.rows[0].session.session_id.as_deref(),
+        Some("live-one")
+    );
+}
+
+#[test]
+fn test_build_dashboard_model_filter_summary_text_describes_active_filters() {
+    let now = Local.with_ymd_and_hms(2026, 4, 23, 12, 0, 0).unwrap();
+    let sessions = vec![dashboard_filter_sample(
+        AgentRuntime::Codex,
+        "codex-1",
+        "/repo/.worktrees/codex-1",
+        true,
+        11,
+    )];
+
+    let filters = DashboardFilters {
+        runtime: AgentRuntimeFilter::Codex,
+        presence: AgentPresenceFilter::Live,
+    };
+    let model = build_dashboard_model_filtered_windowed(&sessions, now, 0, 10, filters);
+
+    assert_eq!(model.filter_summary, "Filter: Codex · live");
+}
+
+#[test]
+fn test_build_dashboard_model_filter_summary_empty_when_no_filters_active() {
+    let now = Local.with_ymd_and_hms(2026, 4, 23, 12, 0, 0).unwrap();
+    let sessions = vec![dashboard_filter_sample(
+        AgentRuntime::Codex,
+        "codex-1",
+        "/repo/.worktrees/codex-1",
+        true,
+        11,
+    )];
+
+    let model =
+        build_dashboard_model_filtered_windowed(&sessions, now, 0, 10, DashboardFilters::default());
+
+    assert!(model.filter_summary.is_empty());
+}
+
+#[test]
+fn test_build_dashboard_model_filtered_empty_state_explains_filter() {
+    let now = Local.with_ymd_and_hms(2026, 4, 23, 12, 0, 0).unwrap();
+    let sessions = vec![dashboard_filter_sample(
+        AgentRuntime::Claude,
+        "claude-1",
+        "/repo/.worktrees/claude-1",
+        true,
+        11,
+    )];
+
+    let filters = DashboardFilters {
+        runtime: AgentRuntimeFilter::Codex,
+        presence: AgentPresenceFilter::All,
+    };
+    let model = build_dashboard_model_filtered_windowed(&sessions, now, 0, 10, filters);
+
+    assert!(model.rows.is_empty());
+    assert_eq!(model.total_unfiltered, 1);
+    assert!(
+        model
+            .empty_state_lines
+            .iter()
+            .any(|line| line.contains("filter")),
+        "expected empty state to mention the active filter, got {:?}",
+        model.empty_state_lines
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add runtime / presence cycle filters and a clear key (`t`, `p`, `c`) to `warp agents`, plus a header showing filtered/total counts and the active filter summary.
- Mark recent sessions with no activity in the last 24h as **stale** (`is_stale_session`); render stale rows dimmed with a `~` marker so they don't look live.
- Cover the new behavior with unit tests for staleness boundaries, runtime/presence filtering, header summary, and the filter-aware empty state.

Closes #38

## Verification
- `cargo fmt --check`
- `cargo build`
- `cargo test --test mod -- --test-threads=1 'unit::tui_tests' 'unit::agents_tests'` (42 passed)
- `cargo test --lib` (30 passed)
- Full `cargo test --test mod` reproduces only the pre-existing baseline failures `integration::cli_surface_tests::test_switch_latest_resolves_branch_from_recent_agent_session`, `integration::cli_surface_tests::test_switch_waiting_resolves_branch_from_waiting_agent_session`, and `unit::process_tests::test_signal_handling`. Confirmed against `origin/main` (commit 3087c84) where the same three tests fail in isolation; same baseline cited by PRs #51 and #52.

New tests:
- `unit::tui_tests::test_is_stale_session_true_when_recent_and_older_than_a_day`
- `unit::tui_tests::test_is_stale_session_false_when_live_even_if_old`
- `unit::tui_tests::test_is_stale_session_false_when_recent_but_fresh`
- `unit::tui_tests::test_build_dashboard_model_marks_stale_rows`
- `unit::tui_tests::test_build_dashboard_model_filtered_filters_runtime_codex`
- `unit::tui_tests::test_build_dashboard_model_filtered_filters_presence_live`
- `unit::tui_tests::test_build_dashboard_model_filter_summary_text_describes_active_filters`
- `unit::tui_tests::test_build_dashboard_model_filter_summary_empty_when_no_filters_active`
- `unit::tui_tests::test_build_dashboard_model_filtered_empty_state_explains_filter`