### PR TITLE
Improve hook health diagnostics

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -159,6 +159,19 @@ struct DoctorInstallEntry {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DoctorHookSeverity {
+    Healthy,
+    Partial,
+    Missing,
+}
+
+struct DoctorHooksSummary {
+    severity: DoctorHookSeverity,
+    detail: String,
+    next_steps: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SwitchStepStatus {
     Done,
     Skipped,
@@ -1595,16 +1608,25 @@ impl Cli {
             );
         }
 
-        let hooks_installed = Self::doctor_hooks_installed();
-        if hooks_installed {
-            Self::doctor_ok("Agent hooks", "git-warp hooks found for Claude or Codex");
-        } else {
-            Self::doctor_warn("Agent hooks", "no user or project git-warp hooks found");
-            next_steps.push(
-                "Run `warp hooks-install --level user --runtime all` to enable live agent monitoring."
-                    .to_string(),
-            );
+        let hooks_summary = Self::doctor_hooks_summary();
+        match hooks_summary.severity {
+            DoctorHookSeverity::Healthy => {
+                Self::doctor_ok("Agent hooks", hooks_summary.detail);
+            }
+            DoctorHookSeverity::Partial => {
+                Self::doctor_warn("Agent hooks", hooks_summary.detail);
+                for step in &hooks_summary.next_steps {
+                    next_steps.push(step.clone());
+                }
+            }
+            DoctorHookSeverity::Missing => {
+                Self::doctor_warn("Agent hooks", hooks_summary.detail);
+                for step in &hooks_summary.next_steps {
+                    next_steps.push(step.clone());
+                }
+            }
         }
+        let hooks_installed = matches!(hooks_summary.severity, DoctorHookSeverity::Healthy);
 
         Self::report_doctor_install(&mut next_steps);
 
@@ -1789,24 +1811,95 @@ impl Cli {
         Some(line)
     }
 
-    fn doctor_hooks_installed() -> bool {
-        let mut paths = Vec::new();
+    fn doctor_hooks_summary() -> DoctorHooksSummary {
+        use crate::hooks::{HookState, HooksManager};
 
-        if let Some(home) = dirs::home_dir() {
-            paths.push(home.join(".claude").join("settings.json"));
-            paths.push(home.join(".codex").join("hooks.json"));
+        let diagnoses = match HooksManager::diagnose("all") {
+            Ok(d) => d,
+            Err(_) => {
+                return DoctorHooksSummary {
+                    severity: DoctorHookSeverity::Missing,
+                    detail: "unable to inspect hook configuration".to_string(),
+                    next_steps: vec![
+                        "Run `warp hooks-status --runtime all` to investigate.".to_string(),
+                    ],
+                };
+            }
+        };
+
+        let mut healthy: Vec<String> = Vec::new();
+        let mut partial: Vec<String> = Vec::new();
+        let mut conflicting: Vec<String> = Vec::new();
+        let mut next_steps: Vec<String> = Vec::new();
+
+        for d in &diagnoses {
+            let scope_label = match d.scope {
+                crate::hooks::HookScope::User => "user",
+                crate::hooks::HookScope::Project => "project",
+            };
+            let runtime_label = match d.runtime {
+                crate::hooks::HookRuntime::Claude => "claude",
+                crate::hooks::HookRuntime::Codex => "codex",
+            };
+            let combined = format!("{scope_label} {runtime_label}");
+
+            match d.state {
+                HookState::Complete => healthy.push(combined),
+                HookState::Partial => {
+                    partial.push(combined);
+                    next_steps.push(format!(
+                        "Run `{}` to repair partial {} {} hooks.",
+                        d.install_command(),
+                        scope_label,
+                        runtime_label
+                    ));
+                }
+                HookState::Conflicting => {
+                    conflicting.push(combined);
+                    next_steps.push(format!(
+                        "Run `{}` to deduplicate {} {} hooks.",
+                        d.install_command(),
+                        scope_label,
+                        runtime_label
+                    ));
+                }
+                HookState::Missing | HookState::NotConfigured => {}
+            }
         }
 
-        if let Ok(current_dir) = std::env::current_dir() {
-            paths.push(current_dir.join(".claude").join("settings.json"));
-            paths.push(current_dir.join(".codex").join("hooks.json"));
+        if healthy.is_empty() && partial.is_empty() && conflicting.is_empty() {
+            return DoctorHooksSummary {
+                severity: DoctorHookSeverity::Missing,
+                detail: "no user or project git-warp hooks found".to_string(),
+                next_steps: vec![
+                    "Run `warp hooks-install --level user --runtime all` to enable live agent monitoring.".to_string(),
+                ],
+            };
         }
 
-        paths.into_iter().any(|path| {
-            std::fs::read_to_string(path)
-                .map(|content| content.contains("\"git_warp_hook_id\""))
-                .unwrap_or(false)
-        })
+        if !partial.is_empty() || !conflicting.is_empty() {
+            let mut detail_parts = Vec::new();
+            if !healthy.is_empty() {
+                detail_parts.push(format!("complete: {}", healthy.join(", ")));
+            }
+            if !partial.is_empty() {
+                detail_parts.push(format!("partial: {}", partial.join(", ")));
+            }
+            if !conflicting.is_empty() {
+                detail_parts.push(format!("conflicting: {}", conflicting.join(", ")));
+            }
+            return DoctorHooksSummary {
+                severity: DoctorHookSeverity::Partial,
+                detail: detail_parts.join("; "),
+                next_steps,
+            };
+        }
+
+        DoctorHooksSummary {
+            severity: DoctorHookSeverity::Healthy,
+            detail: format!("complete: {}", healthy.join(", ")),
+            next_steps,
+        }
     }
 
     fn handle_agents(&self) -> Result<()> {

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,12 +1,20 @@
 use crate::error::Result;
 use serde_json::{Map, Value, json};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 const GIT_WARP_HOOK_PREFIX: &str = "agent_status_";
 
+const EXPECTED_EVENTS: &[&str] = &[
+    "UserPromptSubmit",
+    "Stop",
+    "PreToolUse",
+    "PostToolUse",
+    "SubagentStop",
+];
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum HookRuntime {
+pub enum HookRuntime {
     Claude,
     Codex,
 }
@@ -25,6 +33,13 @@ impl HookRuntime {
         match self {
             Self::Claude => "Claude Code",
             Self::Codex => "Codex",
+        }
+    }
+
+    fn install_arg(&self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
         }
     }
 
@@ -56,6 +71,63 @@ impl HookRuntime {
 
     fn wraps_hooks_at_root(&self) -> bool {
         matches!(self, Self::Claude)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HookScope {
+    User,
+    Project,
+}
+
+impl HookScope {
+    fn label(&self) -> &'static str {
+        match self {
+            Self::User => "User",
+            Self::Project => "Project",
+        }
+    }
+
+    fn install_arg(&self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Project => "project",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HookState {
+    NotConfigured,
+    Missing,
+    Partial,
+    Conflicting,
+    Complete,
+}
+
+#[derive(Clone, Debug)]
+pub struct HookDiagnosis {
+    pub runtime: HookRuntime,
+    pub scope: HookScope,
+    pub path: PathBuf,
+    pub state: HookState,
+    pub present_events: Vec<String>,
+    pub missing_events: Vec<String>,
+    pub conflicting_events: Vec<String>,
+    pub parse_error: Option<String>,
+}
+
+impl HookDiagnosis {
+    pub fn install_command(&self) -> String {
+        format!(
+            "warp hooks-install --level {} --runtime {}",
+            self.scope.install_arg(),
+            self.runtime.install_arg()
+        )
+    }
+
+    pub fn is_healthy(&self) -> bool {
+        matches!(self.state, HookState::Complete)
     }
 }
 
@@ -128,45 +200,220 @@ impl HooksManager {
 
         println!("🔧 Git-Warp Agent Integration Status");
         println!("====================================");
+        println!("Expected events: {}", EXPECTED_EVENTS.join(", "));
+
+        let mut repair_steps: Vec<String> = Vec::new();
+        let mut any_complete = false;
 
         for (index, runtime) in runtimes.iter().enumerate() {
             if index > 0 {
                 println!();
             }
 
-            println!("{}:", runtime.display_name());
+            println!("\n{}:", runtime.display_name());
 
-            match runtime.user_settings_path() {
-                Ok(path) => {
-                    if path.exists() {
-                        println!("✅ User config: {}", path.display());
-                        Self::show_hooks_for_path(&path, *runtime)?;
-                    } else {
-                        println!("❌ User config: Not found");
-                    }
+            for scope in [HookScope::User, HookScope::Project] {
+                let diagnosis = Self::diagnose_scope(*runtime, scope);
+                Self::print_diagnosis(&diagnosis);
+                if diagnosis.is_healthy() {
+                    any_complete = true;
+                } else {
+                    repair_steps.push(diagnosis.install_command());
                 }
-                Err(_) => println!("❌ User config: Unable to locate"),
-            }
-
-            match runtime.project_settings_path() {
-                Ok(path) => {
-                    if path.exists() {
-                        println!("✅ Project config: {}", path.display());
-                        Self::show_hooks_for_path(&path, *runtime)?;
-                    } else {
-                        println!("❌ Project config: Not found");
-                    }
-                }
-                Err(_) => println!("❌ Project config: Unable to locate"),
             }
         }
 
-        println!("\n📖 Integration Guide:");
-        println!("   warp hooks-install --level user --runtime codex");
-        println!("   warp hooks-install --level project --runtime claude");
-        println!("   warp hooks-install --level user --runtime all");
+        println!("\n📖 Repair guidance:");
+        if repair_steps.is_empty() {
+            println!("   All checked scopes look healthy. No action needed.");
+        } else {
+            for step in &repair_steps {
+                println!("   {step}");
+            }
+            if !any_complete {
+                println!(
+                    "   warp hooks-install --level user --runtime all  # bootstrap both runtimes at user level"
+                );
+            }
+        }
 
         Ok(())
+    }
+
+    pub fn diagnose(runtime: &str) -> Result<Vec<HookDiagnosis>> {
+        let runtimes = HookRuntime::parse_many(runtime)?;
+        let mut out = Vec::with_capacity(runtimes.len() * 2);
+        for runtime in runtimes {
+            for scope in [HookScope::User, HookScope::Project] {
+                out.push(Self::diagnose_scope(runtime, scope));
+            }
+        }
+        Ok(out)
+    }
+
+    fn diagnose_scope(runtime: HookRuntime, scope: HookScope) -> HookDiagnosis {
+        let path = match scope {
+            HookScope::User => runtime.user_settings_path(),
+            HookScope::Project => runtime.project_settings_path(),
+        };
+
+        let path = match path {
+            Ok(p) => p,
+            Err(error) => {
+                return HookDiagnosis {
+                    runtime,
+                    scope,
+                    path: PathBuf::new(),
+                    state: HookState::NotConfigured,
+                    present_events: Vec::new(),
+                    missing_events: EXPECTED_EVENTS.iter().map(|s| s.to_string()).collect(),
+                    conflicting_events: Vec::new(),
+                    parse_error: Some(error.to_string()),
+                };
+            }
+        };
+
+        Self::diagnose_path(&path, runtime, scope)
+    }
+
+    pub fn diagnose_path(path: &Path, runtime: HookRuntime, scope: HookScope) -> HookDiagnosis {
+        let mut diagnosis = HookDiagnosis {
+            runtime,
+            scope,
+            path: path.to_path_buf(),
+            state: HookState::NotConfigured,
+            present_events: Vec::new(),
+            missing_events: EXPECTED_EVENTS.iter().map(|s| s.to_string()).collect(),
+            conflicting_events: Vec::new(),
+            parse_error: None,
+        };
+
+        if !path.exists() {
+            return diagnosis;
+        }
+
+        let content = match fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(error) => {
+                diagnosis.parse_error = Some(format!("read error: {error}"));
+                return diagnosis;
+            }
+        };
+
+        let settings: Value = match serde_json::from_str(&content) {
+            Ok(v) => v,
+            Err(error) => {
+                diagnosis.parse_error = Some(format!("invalid JSON: {error}"));
+                return diagnosis;
+            }
+        };
+
+        let hooks = match Self::hooks_object(&settings, runtime) {
+            Ok(h) => h,
+            Err(_) => {
+                return diagnosis;
+            }
+        };
+
+        let mut present: Vec<String> = Vec::new();
+        let mut conflicting: Vec<String> = Vec::new();
+        for event in EXPECTED_EVENTS {
+            let entries = hooks.get(*event).and_then(Value::as_array);
+            let warp_entries = entries
+                .map(|arr| arr.iter().filter(|h| Self::is_git_warp_hook(h)).count())
+                .unwrap_or(0);
+
+            if warp_entries == 0 {
+                continue;
+            }
+
+            present.push((*event).to_string());
+            if warp_entries > 1 {
+                conflicting.push((*event).to_string());
+            }
+        }
+
+        let missing: Vec<String> = EXPECTED_EVENTS
+            .iter()
+            .filter(|e| !present.contains(&(**e).to_string()))
+            .map(|e| (*e).to_string())
+            .collect();
+
+        diagnosis.state = if present.is_empty() {
+            HookState::Missing
+        } else if !conflicting.is_empty() {
+            HookState::Conflicting
+        } else if missing.is_empty() {
+            HookState::Complete
+        } else {
+            HookState::Partial
+        };
+
+        diagnosis.present_events = present;
+        diagnosis.missing_events = missing;
+        diagnosis.conflicting_events = conflicting;
+        diagnosis
+    }
+
+    fn print_diagnosis(d: &HookDiagnosis) {
+        let scope_label = d.scope.label();
+        let path_label = if d.path.as_os_str().is_empty() {
+            "<unresolved>".to_string()
+        } else {
+            d.path.display().to_string()
+        };
+
+        match d.state {
+            HookState::Complete => {
+                println!(
+                    "  ✅ {scope_label} ({path}): all {n} hooks installed",
+                    path = path_label,
+                    n = EXPECTED_EVENTS.len()
+                );
+            }
+            HookState::Partial => {
+                println!(
+                    "  ⚠️  {scope_label} ({path}): partial — {p}/{t} hooks installed; missing: {missing}",
+                    path = path_label,
+                    p = d.present_events.len(),
+                    t = EXPECTED_EVENTS.len(),
+                    missing = d.missing_events.join(", ")
+                );
+                println!("     Repair: {}", d.install_command());
+            }
+            HookState::Conflicting => {
+                println!(
+                    "  ⚠️  {scope_label} ({path}): conflicting duplicate git-warp entries on: {events}",
+                    path = path_label,
+                    events = d.conflicting_events.join(", ")
+                );
+                println!(
+                    "     Repair: {}  # rewrites a single canonical entry per event",
+                    d.install_command()
+                );
+            }
+            HookState::Missing => {
+                println!(
+                    "  ❌ {scope_label} ({path}): file present but no git-warp hooks installed",
+                    path = path_label
+                );
+                println!("     Repair: {}", d.install_command());
+            }
+            HookState::NotConfigured => {
+                if let Some(err) = &d.parse_error {
+                    println!(
+                        "  ❌ {scope_label} ({path}): unreadable — {err}",
+                        path = path_label
+                    );
+                } else {
+                    println!(
+                        "  ❌ {scope_label} ({path}): not configured",
+                        path = path_label
+                    );
+                }
+                println!("     Repair: {}", d.install_command());
+            }
+        }
     }
 
     fn get_hooks_config(runtime: HookRuntime) -> Value {
@@ -268,51 +515,6 @@ impl HooksManager {
             runtime.display_name(),
             settings_path.display()
         );
-        Ok(())
-    }
-
-    fn show_hooks_for_path(path: &PathBuf, runtime: HookRuntime) -> Result<()> {
-        if !path.exists() {
-            println!("  No settings file found");
-            return Ok(());
-        }
-
-        let content = fs::read_to_string(path)?;
-        let settings: Value = serde_json::from_str(&content)?;
-        let hooks = match Self::hooks_object(&settings, runtime) {
-            Ok(hooks) => hooks,
-            Err(_) => {
-                println!("  No git-warp hooks installed");
-                return Ok(());
-            }
-        };
-
-        let mut found_hooks = false;
-        for (hook_type, hook_array) in hooks {
-            if let Some(array) = hook_array.as_array() {
-                let git_warp_hooks: Vec<_> = array
-                    .iter()
-                    .filter(|hook| Self::is_git_warp_hook(hook))
-                    .collect();
-
-                if !git_warp_hooks.is_empty() {
-                    if !found_hooks {
-                        println!("  ✓ Hooks installed:");
-                        found_hooks = true;
-                    }
-                    println!(
-                        "    {}: {} git-warp hook(s)",
-                        hook_type,
-                        git_warp_hooks.len()
-                    );
-                }
-            }
-        }
-
-        if !found_hooks {
-            println!("  No git-warp hooks installed");
-        }
-
         Ok(())
     }
 
@@ -428,6 +630,172 @@ mod tests {
                 .unwrap()
                 .iter()
                 .any(|entry| HooksManager::is_git_warp_hook(entry))
+        );
+    }
+
+    #[test]
+    fn test_diagnose_missing_when_file_absent() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("settings.json");
+
+        let d = HooksManager::diagnose_path(&path, HookRuntime::Claude, HookScope::User);
+
+        assert!(matches!(d.state, HookState::NotConfigured));
+        assert_eq!(d.present_events.len(), 0);
+        assert_eq!(d.missing_events.len(), EXPECTED_EVENTS.len());
+        assert_eq!(
+            d.install_command(),
+            "warp hooks-install --level user --runtime claude"
+        );
+    }
+
+    #[test]
+    fn test_diagnose_partial_when_some_events_present() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let settings_path = temp_dir.path().join("settings.json");
+
+        // Pre-existing settings with only Stop wired up.
+        fs::write(
+            &settings_path,
+            serde_json::to_string_pretty(&json!({
+                "hooks": {
+                    "Stop": [{
+                        "git_warp_hook_id": "agent_status_stop",
+                        "hooks": [{ "type": "command", "command": "x" }]
+                    }]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let d =
+            HooksManager::diagnose_path(&settings_path, HookRuntime::Claude, HookScope::Project);
+
+        assert!(matches!(d.state, HookState::Partial));
+        assert_eq!(d.present_events, vec!["Stop"]);
+        assert!(d.missing_events.contains(&"PreToolUse".to_string()));
+        assert!(d.missing_events.contains(&"UserPromptSubmit".to_string()));
+        assert_eq!(
+            d.install_command(),
+            "warp hooks-install --level project --runtime claude"
+        );
+    }
+
+    #[test]
+    fn test_diagnose_complete_after_install_claude() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let settings_path = temp_dir.path().join("settings.json");
+
+        HooksManager::merge_hooks_into_settings(settings_path.clone(), HookRuntime::Claude)
+            .unwrap();
+
+        let d = HooksManager::diagnose_path(&settings_path, HookRuntime::Claude, HookScope::User);
+
+        assert!(
+            matches!(d.state, HookState::Complete),
+            "expected Complete, got {:?}",
+            d.state
+        );
+        assert_eq!(d.present_events.len(), EXPECTED_EVENTS.len());
+        assert!(d.missing_events.is_empty());
+        assert!(d.is_healthy());
+    }
+
+    #[test]
+    fn test_diagnose_complete_after_install_codex() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let hooks_path = temp_dir.path().join("hooks.json");
+
+        HooksManager::merge_hooks_into_settings(hooks_path.clone(), HookRuntime::Codex).unwrap();
+
+        let d = HooksManager::diagnose_path(&hooks_path, HookRuntime::Codex, HookScope::Project);
+
+        assert!(matches!(d.state, HookState::Complete));
+        assert!(d.missing_events.is_empty());
+    }
+
+    #[test]
+    fn test_diagnose_missing_when_file_has_no_warp_hooks() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let settings_path = temp_dir.path().join("settings.json");
+
+        fs::write(
+            &settings_path,
+            serde_json::to_string_pretty(&json!({
+                "hooks": {
+                    "Stop": [{ "type": "command", "command": "unrelated" }]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let d = HooksManager::diagnose_path(&settings_path, HookRuntime::Claude, HookScope::User);
+
+        assert!(matches!(d.state, HookState::Missing));
+        assert!(d.present_events.is_empty());
+        assert_eq!(d.missing_events.len(), EXPECTED_EVENTS.len());
+    }
+
+    #[test]
+    fn test_diagnose_conflicting_when_duplicate_warp_entries() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let settings_path = temp_dir.path().join("settings.json");
+
+        fs::write(
+            &settings_path,
+            serde_json::to_string_pretty(&json!({
+                "hooks": {
+                    "Stop": [
+                        {
+                            "git_warp_hook_id": "agent_status_stop",
+                            "hooks": [{ "type": "command", "command": "a" }]
+                        },
+                        {
+                            "git_warp_hook_id": "agent_status_stop_old",
+                            "hooks": [{ "type": "command", "command": "b" }]
+                        }
+                    ]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let d = HooksManager::diagnose_path(&settings_path, HookRuntime::Claude, HookScope::User);
+
+        assert!(matches!(d.state, HookState::Conflicting));
+        assert_eq!(d.conflicting_events, vec!["Stop"]);
+    }
+
+    #[test]
+    fn test_diagnose_invalid_json_reports_parse_error() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let settings_path = temp_dir.path().join("settings.json");
+        fs::write(&settings_path, "{not json").unwrap();
+
+        let d = HooksManager::diagnose_path(&settings_path, HookRuntime::Codex, HookScope::Project);
+
+        assert!(matches!(d.state, HookState::NotConfigured));
+        assert!(d.parse_error.is_some());
+    }
+
+    #[test]
+    fn test_install_command_uses_scope_and_runtime_args() {
+        let d = HookDiagnosis {
+            runtime: HookRuntime::Codex,
+            scope: HookScope::User,
+            path: PathBuf::from("/tmp/x"),
+            state: HookState::Missing,
+            present_events: Vec::new(),
+            missing_events: Vec::new(),
+            conflicting_events: Vec::new(),
+            parse_error: None,
+        };
+        assert_eq!(
+            d.install_command(),
+            "warp hooks-install --level user --runtime codex"
         );
     }
 


### PR DESCRIPTION
## Summary
- `hooks-status` now diagnoses each runtime/scope independently and prints distinct messages for `Complete`, `Partial`, `Missing`, `Conflicting`, and `NotConfigured` states. Partial output names the exact events that are missing; conflicting flags duplicate `git_warp_hook_id` entries.
- Each scope's diagnosis includes its absolute settings path with a `User`/`Project` label and emits the exact repair command (`warp hooks-install --level <scope> --runtime <runtime>`).
- `warp doctor` reuses the new diagnostics: it surfaces partial/conflicting states with a warning, lists the affected scopes, and threads runtime-specific repair steps into the checklist.
- Added unit tests for missing, partial, complete (Claude + Codex), conflicting, missing-warp-hooks, invalid-JSON, and install-command formatting.

Closes #39

## Verification
- `cargo fmt --check`
- `cargo build`
- `cargo test --lib hooks::` — 12 passed
- `cargo test --lib` — 38 passed
- `cargo test --test mod -- --test-threads=1 'integration::cli_surface_tests::test_doctor'` — 4 passed
- Full `cargo test --test mod -- --test-threads=1` reproduces only the pre-existing baseline failures `integration::cli_surface_tests::test_switch_latest_resolves_branch_from_recent_agent_session` and `integration::cli_surface_tests::test_switch_waiting_resolves_branch_from_waiting_agent_session`. Both also fail on `origin/main` (3087c84) without these changes; same baseline noted in PR #53.
- Smoke-tested the binary against three temp `HOME`s to confirm `Complete`, `Partial`, and `Missing` outputs render the correct repair commands.