### PR TITLE
Prepare v0.3.0 docs and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,81 @@
 
 ## Unreleased
 
+## v0.3.0 - 2026-05-06
+
+Second public Git-Warp release. Adds per-worktree cleanup eligibility output,
+runtime/scope hook diagnostics, ordered `warp ls`, batch removal in the bare-
+`warp` switcher, branch-source classification in `warp switch`, an
+`uninstall.sh` script, and `warp release-check` for maintainers.
+
+Release notes: [docs/releases/v0.3.0.md](docs/releases/v0.3.0.md)
+
 ### Added
 
-- `warp release-check` validates release metadata and runs the maintainer
-  release verification flow before tagging.
+- `warp release-check` validates release metadata (`Cargo.toml`, `CHANGELOG.md`,
+  `docs/releases/vX.Y.Z.md`, `docs/install.md`, `install.sh`) and runs the
+  maintainer release verification flow before tagging.
 - Prebuilt release binary workflow for macOS and Linux targets.
-- Root `install.sh` now installs prebuilt release binaries by default, with
-  Cargo available only as an explicit fallback.
+- Root `install.sh` installs prebuilt release binaries by default, with Cargo
+  available only as an explicit fallback.
+- `uninstall.sh` removes the default install, lists other detected `warp`
+  binaries without touching them, and supports `--dry-run`.
+- `warp doctor` Install check lists detected `warp` binaries with versions and
+  warns when more than one is on `PATH`.
 - Dedicated install documentation with one-command setup, PATH guidance, custom
-  install locations, pinned versions, and supported binary targets.
+  install locations, pinned versions, supported binary targets, and
+  upgrade/uninstall flows.
+- `warp ls` orders rows by current → primary → dirty → busy → detached → clean,
+  adds a one-line summary header, and uses distinct row icons while keeping the
+  existing label tokens for script consumers.
+- `warp cleanup` (and `--dry-run cleanup`) prints the resolved base branch,
+  per-worktree skip reasons (primary, base, protected, detached, no branch),
+  mode-excluded entries, candidate tags (`merged` / `identical` / `no remote` /
+  `all-mode`), and a `process-busy` flag from a pre-confirm process preview.
+- `warp switch` and the bare interactive switcher classify the target as
+  existing worktree, local branch, remote branch, or new branch and surface a
+  labeled status line; remote-only targets create a local tracking branch from
+  the remote ref instead of branching from `HEAD`.
+- Bare-`warp` switcher rows show a `local-only` badge for branches with no
+  matching ref on any remote (skipped when the repo has no remotes).
+- Bare-`warp` switcher supports multi-select (`Space` / `a`) and batch removal,
+  with structured reporting of removed, skipped, and failed worktrees.
+- `warp hooks-status` and `warp doctor` diagnose each runtime and scope
+  independently and report `Complete`, `Partial`, `Missing`, and `Conflicting`
+  states with the absolute settings path and the exact
+  `warp hooks-install --level <scope> --runtime <runtime>` repair command.
+- `warp cleanup --force` can remove dirty worktrees when the user explicitly
+  bypasses safety checks.
+
+### Changed
+
+- `warp agents` dashboard history is faster and uses less memory on long
+  sessions.
+- `install.sh` reports existing `warp` binaries before install, warns when a
+  different `warp` shadows the freshly installed one on `PATH`, and prints
+  precise next steps on download or extraction failures.
+
+### Fixed
+
+- `warp switch` reuses an existing branch's worktree instead of failing with a
+  duplicate-branch error.
+- Worktree path root resolution now picks the right repository root when
+  Git-Warp is invoked from nested directories.
+
+### Documentation
+
+- README, install docs, user guide, and documentation index updated for the
+  shipped command surface.
+- Release notes available as a standalone Markdown file at
+  `docs/releases/v0.3.0.md` for GitHub release publishing.
+
+### Verification
+
+- `cargo fmt --check`
+- `cargo test`
+- `cargo build --release --bin warp`
+- `./target/release/warp --version`
+- `./target/release/warp doctor`
 
 ## v0.2.0 - 2026-04-26
 

--- a/README.md
+++ b/README.md
@@ -11,16 +11,24 @@ available.
 ## What It Does Today
 
 - Creates or switches to branch worktrees with `warp switch <branch>` or the
-  short form `warp <branch>`.
+  short form `warp <branch>`, classifying the target as existing worktree,
+  local branch, remote branch, or new branch.
 - Opens the selected worktree in a terminal tab/window, starts a shell in the
   current terminal, or prints the target path/command.
-- Lists worktrees with primary/current/dirty/detached/busy state.
+- Lists worktrees with primary/current/dirty/detached/busy state, ordered for
+  fast scanning in busy repositories.
+- Bare `warp` opens an interactive switcher with multi-select and batch removal.
 - Cleans up eligible worktrees with dry-run, interactive selection, process
-  checks, protected branches, and optional process termination.
-- Checks local setup with `warp doctor`.
-- Installs, removes, and reports Claude/Codex hooks for live session tracking.
+  checks, protected branches, optional process termination, and per-worktree
+  eligibility reasons.
+- Checks local setup with `warp doctor`, including detection of multiple `warp`
+  binaries on `PATH`.
+- Installs, removes, and reports Claude/Codex hooks with per-runtime and
+  per-scope `Complete` / `Partial` / `Missing` / `Conflicting` diagnostics and
+  the exact repair command.
 - Shows a TUI dashboard for live hook data and recent local agent sessions.
 - Generates shell completion snippets for Bash, Zsh, and Fish.
+- Validates release metadata before tagging with `warp release-check`.
 
 ## Install
 
@@ -225,7 +233,8 @@ cargo run -- --dry-run cleanup --mode merged
 - [Technical Overview](docs/technical-overview.md)
 - [Documentation Index](docs/README.md)
 - [Changelog](CHANGELOG.md)
-- [Release Notes](docs/releases/v0.2.0.md)
+- [Release Notes (v0.3.0)](docs/releases/v0.3.0.md)
+- [Release Notes (v0.2.0)](docs/releases/v0.2.0.md)
 - [Original autowt reference](docs/autowt.txt)
 - [Original coworktree reference](docs/coworktree.txt)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,8 +14,10 @@ material, and original reference documents for Git-Warp.
 - [Technical Overview](technical-overview.md): architecture, modules, and
   implementation notes.
 - [Changelog](../CHANGELOG.md): release notes and verification commands.
-- [Release Notes](releases/v0.2.0.md): pasteable notes for the `v0.2.0`
-  GitHub release.
+- [Release Notes (v0.3.0)](releases/v0.3.0.md): pasteable notes for the
+  `v0.3.0` GitHub release.
+- [Release Notes (v0.2.0)](releases/v0.2.0.md): pasteable notes for the
+  `v0.2.0` GitHub release.
 - [Root README](../README.md): short project overview and verified quick start.
 
 ## Reference Documents

--- a/docs/install.md
+++ b/docs/install.md
@@ -53,7 +53,7 @@ The installer defaults to the latest documented release. Pin a version with
 `GIT_WARP_VERSION`:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.sh | GIT_WARP_VERSION=v0.2.0 sh
+curl -fsSL https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.sh | GIT_WARP_VERSION=v0.3.0 sh
 ```
 
 ## Supported Prebuilt Binaries

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,0 +1,134 @@
+# Git-Warp v0.3.0
+
+Second public Git-Warp release.
+
+This release adds per-worktree cleanup eligibility output, runtime/scope hook
+diagnostics, ordered `warp ls` rows for busy repos, multi-select batch removal
+in the bare-`warp` switcher, branch-source classification in `warp switch`, an
+`uninstall.sh` script, and a `warp release-check` command for maintainers.
+
+## Highlights
+
+- Per-worktree cleanup eligibility: `warp cleanup` and `warp --dry-run cleanup`
+  print the resolved base branch, per-worktree skip reasons, mode-excluded
+  entries, and candidate tags (`merged` / `identical` / `no remote` /
+  `all-mode`), plus a `process-busy` preview before confirmation.
+- Branch-source-aware switching: `warp switch` classifies the target as
+  existing worktree, local branch, remote branch, or new branch and surfaces a
+  labeled status line. Remote-only targets create a local tracking branch from
+  the remote ref instead of branching from `HEAD`.
+- Bare-`warp` switcher: rows show a `local-only` badge for branches with no
+  matching ref on any remote, multi-select (`Space` / `a`) is supported, and
+  batch removal reports removed, skipped, and failed worktrees.
+- Faster, more scannable `warp ls`: rows ordered current → primary → dirty →
+  busy → detached → clean, with a one-line summary header and distinct row
+  icons. Existing label tokens are preserved for script consumers.
+- Hook health diagnostics: `warp hooks-status` and `warp doctor` diagnose each
+  runtime and scope independently, distinguish `Complete`, `Partial`, `Missing`,
+  and `Conflicting` states, and emit the exact
+  `warp hooks-install --level <scope> --runtime <runtime>` repair command.
+- Install lifecycle: prebuilt release binaries for macOS and Linux, an
+  `uninstall.sh` script with `--dry-run`, a `warp doctor` Install check that
+  warns when multiple `warp` binaries are on `PATH`, and clearer installer
+  failure messaging.
+- Release validation: `warp release-check` verifies release metadata
+  (`Cargo.toml`, `CHANGELOG.md`, `docs/releases/vX.Y.Z.md`, `docs/install.md`,
+  `install.sh`) and runs the maintainer verification flow before tagging.
+
+## Install Or Upgrade
+
+One command, no Rust/Cargo required:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.sh | sh
+```
+
+Then verify the install:
+
+```bash
+warp --version
+warp doctor
+```
+
+The installer downloads the matching release archive for macOS/Linux and
+Intel/Apple Silicon and installs to `~/.local/bin` by default.
+
+Upgrading from v0.2.0 is the same command — re-running the installer overwrites
+the existing binary at the install directory. The installer prints any other
+`warp` binaries it finds and warns when `warp` on `PATH` resolves to a
+different binary than the one just installed. Run `warp doctor` to confirm only
+one `warp` is active.
+
+Cargo fallback:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.sh | GIT_WARP_INSTALL_METHOD=cargo sh
+```
+
+Source checkout:
+
+```bash
+git clone https://github.com/denysbutenko/git-warp
+cd git-warp
+git checkout v0.3.0
+cargo install --path .
+warp --version
+warp doctor
+```
+
+Expected version output:
+
+```text
+warp 0.3.0
+```
+
+## Uninstall
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/denysbutenko/git-warp/main/uninstall.sh | sh
+```
+
+The uninstaller removes `~/.local/bin/warp` (or `$GIT_WARP_INSTALL_DIR/warp`),
+lists any other detected `warp` installs without touching them, and warns if
+`warp` is still on `PATH`. Use `--dry-run` to preview without changing anything.
+For Cargo installs, also run `cargo uninstall git-warp`.
+
+## Useful Commands
+
+```bash
+warp switch feature/my-change
+warp ls
+warp --dry-run cleanup --mode merged
+warp cleanup --interactive
+warp cleanup --mode merged --force
+warp hooks-install --level user --runtime all
+warp hooks-status
+warp agents
+warp release-check --metadata-only --version v0.3.0
+```
+
+## Verification
+
+Release prep was checked with:
+
+```bash
+cargo fmt --check
+cargo test
+cargo build --release --bin warp
+./target/release/warp --version
+./target/release/warp doctor
+```
+
+`warp release-check --version v0.3.0` runs the same flow plus metadata checks
+against `Cargo.toml`, `CHANGELOG.md`, `docs/releases/v0.3.0.md`,
+`docs/install.md`, and `install.sh`.
+
+## Notes
+
+- Copy-on-Write acceleration is best on macOS/APFS. Other filesystems fall back
+  to normal Git worktree creation.
+- The installer script defaults to `v0.3.0`. Set `GIT_WARP_VERSION` before
+  running it to install a different tag, or `GIT_WARP_INSTALL_DIR` to install
+  somewhere other than `~/.local/bin`.
+- Git-Warp is still a `0.x` tool. Use `warp doctor`, `--dry-run`, and focused
+  command help when setting it up on a new repo.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -84,7 +84,11 @@ warp doctor
 ```
 
 `warp doctor` checks repository detection, config path, worktree base path, CoW
-support, terminal mode, and hook setup.
+support, terminal mode, install layout (lists detected `warp` binaries and
+warns when more than one is on `PATH`), and hook setup. Hook output names each
+runtime/scope and reports `Complete`, `Partial`, `Missing`, or `Conflicting`
+with the exact `warp hooks-install --level <scope> --runtime <runtime>` repair
+command.
 
 ## Quick Start
 
@@ -124,6 +128,13 @@ warp switch --latest
 warp switch --waiting
 ```
 
+`warp switch` classifies the target as existing worktree, local branch, remote
+branch, or new branch and prints a labeled status line. When a branch only
+exists on a remote, Git-Warp creates a local tracking branch from that remote
+ref instead of branching from `HEAD`. Running bare `warp` opens an interactive
+switcher with a `local-only` badge for branches with no matching remote ref;
+`Space` and `a` toggle multi-select for batch worktree removal.
+
 Terminal handoff modes:
 
 ```bash
@@ -142,7 +153,11 @@ warp ls --debug
 ```
 
 The list output marks useful state such as primary, current, dirty, detached,
-and busy worktrees. `--debug` includes additional details for diagnostics.
+and busy worktrees. Rows are ordered current → primary → dirty → busy →
+detached → clean, with a one-line summary header and distinct row icons so
+busy repos stay scannable. The `[primary current dirty detached busy]` label
+tokens are preserved for script consumers. `--debug` includes additional
+details for diagnostics.
 
 ## Cleanup
 
@@ -171,6 +186,18 @@ warp cleanup --mode merged --no-kill
 ```
 
 Use `--dry-run` first when you are unsure what a cleanup mode will select.
+
+Both `warp cleanup` and `warp --dry-run cleanup` print:
+
+- the resolved base branch,
+- worktrees skipped from cleanup (primary, base branch, protected, detached, no
+  branch checked out) with structured reasons,
+- mode-excluded entries,
+- candidate tags (`merged` / `identical` / `no remote` / `all-mode`),
+- a `process-busy` flag from a pre-confirm process preview.
+
+`--force` can also remove dirty worktrees when you intentionally bypass safety
+checks.
 
 ## Agent Session Dashboard
 


### PR DESCRIPTION
## Summary

- Add `docs/releases/v0.3.0.md` (pasteable GitHub release notes) following the `v0.2.0.md` layout, dated 2026-05-06.
- Graduate the `Unreleased` block in `CHANGELOG.md` to a `v0.3.0 - 2026-05-06` section covering every user-facing change since `v0.2.0` (cleanup eligibility output, ordered `warp ls`, branch-source classification in `warp switch`, multi-select batch removal in the bare-`warp` switcher, runtime/scope hook diagnostics, install/upgrade/uninstall flow, force-remove dirty worktrees, `warp release-check`).
- Align `README.md`, `docs/README.md`, and `docs/user-guide.md` (`warp doctor` Install check, ordered/scannable `warp ls`, branch-source classification + multi-select batch removal, cleanup skip reasons + candidate tags) with the shipped command surface and link the new release notes.
- Bump the `GIT_WARP_VERSION` example in `docs/install.md` to `v0.3.0` so it matches the `warp release-check` metadata expectation.

Closes #40

## Verification

- `git diff --check` — clean
- Cross-checked release-note bullets against PR bodies for #41, #43, #44, #45, #47, #48, #49, #50, #51, #54 and the `1fc4717` force-remove-dirty fix.
- Docs-only change; no Rust source touched, so `cargo` builds/tests were not re-run for this PR.