### PR TITLE
ci: add fmt/clippy/test workflow for PRs and main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  fmt:
+    name: cargo fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  clippy:
+    name: cargo clippy (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --locked --lib --bins --tests
+
+  test:
+    name: cargo test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --locked


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yml` so every PR and every push to `main` runs cargo fmt, clippy, and tests. Closes #56.

- Triggers: `pull_request` (any branch) and `push` to `main`.
- Jobs: `fmt` on a single `ubuntu-latest` runner; `clippy` and `test` on a `[ubuntu-latest, macos-14]` matrix with `fail-fast: false`. The macOS-14 cell covers the `#[cfg(target_os = "macos")]` paths in `src/cow.rs`, `src/terminal.rs`, and a few files under `tests/unit/`. The Linux cell covers the `#[cfg(target_os = "linux")]` reflink branches in `src/cow.rs`.
- Cache via `Swatinem/rust-cache@v2`. Concurrency cancels superseded PR runs but leaves `main` runs alone.
- Top-level permissions pinned to `contents: read`.

### Why clippy is not strict yet

The issue suggested `cargo clippy --all-targets --locked -- -D warnings`. That exact form currently fails on `main` for two pre-existing reasons, both out of scope for #56:

- `benches/performance_benchmarks.rs` has 4 hard compile errors against the current `git_warp` API (`remove_worktree`, `WorktreeInfo`, and `PathRewriter::new` signatures have all moved on). `--all-targets` pulls benches in.
- `cargo clippy --locked` reports 89 lints in `src/`. `-D warnings` would turn them into errors.

So this PR ships `cargo clippy --locked --lib --bins --tests`. Warnings still surface in CI logs, but they don't fail the build. A follow-up should fix the benches, clear the existing lints, and then tighten this step back to `--all-targets -- -D warnings`.

## Verification

Ran in the worktree on macOS:

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — workflow parses.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy --locked --lib --bins --tests` — passes (warnings only).
- `cargo test --locked` — 226 passed, 1 pre-existing flake (`unit::process_tests::test_signal_handling`, a SIGTERM-vs-bash-trap race; unrelated to this PR).
- `git diff --check` — clean.