### PR TITLE
fix(rewrite): require path boundary and cap file size

### DIFF
--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -4,6 +4,11 @@ use rayon::prelude::*;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+/// Cap for files considered for path rewriting. Larger gitignored
+/// artifacts (build output, caches, large `.env`) are skipped without
+/// being read into memory.
+const MAX_REWRITE_FILE_BYTES: u64 = 2 * 1024 * 1024;
+
 pub struct PathRewriter {
     src_path: PathBuf,
     dest_path: PathBuf,
@@ -51,6 +56,20 @@ impl PathRewriter {
 
     /// Rewrite paths in a single file
     fn rewrite_file(&self, file_path: &Path, src_str: &str, dest_str: &str) -> Result<()> {
+        // Skip files larger than the rewrite cap before loading them.
+        match fs::metadata(file_path) {
+            Ok(meta) if meta.len() > MAX_REWRITE_FILE_BYTES => {
+                log::debug!(
+                    "Skipping path rewrite for {} ({} bytes exceeds cap)",
+                    file_path.display(),
+                    meta.len()
+                );
+                return Ok(());
+            }
+            Ok(_) => {}
+            Err(_) => return Ok(()),
+        }
+
         // Read file content
         let content = match fs::read_to_string(file_path) {
             Ok(content) => content,
@@ -70,8 +89,9 @@ impl PathRewriter {
             return Ok(());
         }
 
-        // Replace paths
-        let new_content = content.replace(src_str, dest_str);
+        // Replace paths only at path boundaries to avoid corrupting
+        // unrelated paths that share the source as a prefix.
+        let new_content = replace_at_path_boundary(&content, src_str, dest_str);
 
         // Write back if content changed
         if new_content != content {
@@ -102,6 +122,45 @@ impl PathRewriter {
             printable_ratio < 0.95
         }
     }
+}
+
+/// True when `c` can continue an absolute path token, so a match that
+/// ends right before `c` is actually a prefix of a longer, unrelated
+/// path and must not be rewritten.
+fn is_path_continuation_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-')
+}
+
+/// Replace every occurrence of `src` in `content` with `dest`, but only
+/// when the match is followed by a path boundary (end-of-string or any
+/// char that is not `[A-Za-z0-9._-]`). Prefix collisions like
+/// `/foo/repo-archive` are left intact when the source is `/foo/repo`.
+fn replace_at_path_boundary(content: &str, src: &str, dest: &str) -> String {
+    if src.is_empty() {
+        return content.to_string();
+    }
+
+    let mut result = String::with_capacity(content.len());
+    let mut last_end = 0;
+    for (start, _) in content.match_indices(src) {
+        if start < last_end {
+            // Skip overlapping matches that fall inside a span we already
+            // emitted (possible if `src` itself self-overlaps).
+            continue;
+        }
+        let after = start + src.len();
+        let next_is_boundary = match content[after..].chars().next() {
+            None => true,
+            Some(c) => !is_path_continuation_char(c),
+        };
+        if next_is_boundary {
+            result.push_str(&content[last_end..start]);
+            result.push_str(dest);
+            last_end = after;
+        }
+    }
+    result.push_str(&content[last_end..]);
+    result
 }
 
 #[cfg(test)]
@@ -135,6 +194,37 @@ mod tests {
         let rewritten_content = fs::read_to_string(dest_dir.join("activate.sh")).unwrap();
         assert!(rewritten_content.contains(&dest_dir.to_string_lossy().to_string()));
         assert!(!rewritten_content.contains(&src_dir.to_string_lossy().to_string()));
+    }
+
+    #[test]
+    fn test_replace_at_path_boundary_skips_prefix_collision() {
+        let src = "/users/me/repo";
+        let dest = "/users/me/repo-feature";
+
+        let cases = [
+            ("/users/me/repo/foo", "/users/me/repo-feature/foo"),
+            ("/users/me/repo", "/users/me/repo-feature"),
+            ("a /users/me/repo:b", "a /users/me/repo-feature:b"),
+            // prefix collisions left intact
+            ("/users/me/repo-archive/foo", "/users/me/repo-archive/foo"),
+            ("/users/me/repo_v2", "/users/me/repo_v2"),
+            ("/users/me/repo.bak", "/users/me/repo.bak"),
+            ("/users/me/repo2", "/users/me/repo2"),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(
+                replace_at_path_boundary(input, src, dest),
+                expected,
+                "input={input}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_replace_at_path_boundary_handles_repeated_matches() {
+        let out = replace_at_path_boundary("/a/b /a/b/c", "/a/b", "/x");
+        assert_eq!(out, "/x /x/c");
     }
 
     #[test]

--- a/tests/unit/rewrite_tests.rs
+++ b/tests/unit/rewrite_tests.rs
@@ -3,6 +3,8 @@ use std::fs;
 use std::path::Path;
 use tempfile::tempdir;
 
+const TWO_MIB: usize = 2 * 1024 * 1024;
+
 #[test]
 fn test_path_rewriter_creation() {
     let src_dir = "/original/project";
@@ -517,4 +519,100 @@ special_chars = "{}/àáâãäå"
             println!("Unicode path test failed: {}", e);
         }
     }
+}
+
+#[test]
+fn test_prefix_collision_preserves_unrelated_paths() {
+    let temp_dir = tempdir().unwrap();
+    let src_dir = temp_dir.path().join("repo");
+    let dst_dir = temp_dir.path().join("repo-feature");
+    let archive_dir = temp_dir.path().join("repo-archive");
+
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::create_dir_all(&dst_dir).unwrap();
+
+    fs::write(dst_dir.join(".gitignore"), "config.toml\n").unwrap();
+
+    let src_str = src_dir.to_string_lossy().into_owned();
+    let dst_str = dst_dir.to_string_lossy().into_owned();
+    let archive_str = archive_dir.to_string_lossy().into_owned();
+
+    // Mix matches that must rewrite with prefix collisions that must not.
+    let original = format!(
+        "project={src_str}\n\
+         entry={src_str}/lib/main.js\n\
+         backup={archive_str}/snapshot.tar\n\
+         neighbor={src_str}-old/data\n",
+    );
+    fs::write(dst_dir.join("config.toml"), &original).unwrap();
+
+    PathRewriter::new(&src_dir, &dst_dir)
+        .rewrite_paths()
+        .unwrap();
+
+    let rewritten = fs::read_to_string(dst_dir.join("config.toml")).unwrap();
+    let expected = format!(
+        "project={dst_str}\n\
+         entry={dst_str}/lib/main.js\n\
+         backup={archive_str}/snapshot.tar\n\
+         neighbor={src_str}-old/data\n",
+    );
+    assert_eq!(rewritten, expected);
+}
+
+#[test]
+fn test_oversized_file_is_skipped() {
+    let temp_dir = tempdir().unwrap();
+    let src_dir = temp_dir.path().join("source");
+    let dst_dir = temp_dir.path().join("destination");
+
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::create_dir_all(&dst_dir).unwrap();
+
+    fs::write(dst_dir.join(".gitignore"), "huge.log\n").unwrap();
+
+    let src_str = src_dir.to_string_lossy().into_owned();
+    // Build a file > 2 MiB that contains the source path at the start
+    // and is otherwise valid UTF-8 ASCII so a non-capped rewrite would
+    // happily rewrite it.
+    let mut payload = String::with_capacity(TWO_MIB + 4096);
+    payload.push_str(&format!("path={src_str}\n"));
+    while payload.len() <= TWO_MIB + 1024 {
+        payload.push_str("filler line that takes up space ----------------\n");
+    }
+    let huge_path = dst_dir.join("huge.log");
+    fs::write(&huge_path, &payload).unwrap();
+
+    PathRewriter::new(&src_dir, &dst_dir)
+        .rewrite_paths()
+        .unwrap();
+
+    let after = fs::read_to_string(&huge_path).unwrap();
+    assert_eq!(after, payload, "oversized file must be left untouched");
+}
+
+#[test]
+fn test_binary_with_leading_text_not_rewritten() {
+    let temp_dir = tempdir().unwrap();
+    let src_dir = temp_dir.path().join("source");
+    let dst_dir = temp_dir.path().join("destination");
+
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::create_dir_all(&dst_dir).unwrap();
+
+    fs::write(dst_dir.join(".gitignore"), "blob.dat\n").unwrap();
+
+    let src_str = src_dir.to_string_lossy().into_owned();
+    let mut content: Vec<u8> = format!("header={src_str}\n").into_bytes();
+    // Trailing block of null bytes flips the binary heuristic.
+    content.extend(std::iter::repeat(0u8).take(64));
+    let blob = dst_dir.join("blob.dat");
+    fs::write(&blob, &content).unwrap();
+
+    PathRewriter::new(&src_dir, &dst_dir)
+        .rewrite_paths()
+        .unwrap();
+
+    let after = fs::read(&blob).unwrap();
+    assert_eq!(after, content, "binary file must not be rewritten");
 }


### PR DESCRIPTION
## Summary

- Replace `String::replace` in `PathRewriter::rewrite_file` with `replace_at_path_boundary`, which only rewrites a match when the byte right after it is end-of-content or not in `[A-Za-z0-9._-]`. Prevents prefix-collision corruption where a source like `/users/me/repo` would mangle unrelated paths such as `/users/me/repo-archive/...`.
- Skip files larger than 2 MiB (`MAX_REWRITE_FILE_BYTES`) via an `fs::metadata` probe before `fs::read_to_string`, so oversized gitignored artifacts (build output, caches, large `.env`) are no longer materialized in memory just to be rejected by the binary heuristic afterwards.
- Add unit tests on the helper (`test_replace_at_path_boundary_skips_prefix_collision`, `test_replace_at_path_boundary_handles_repeated_matches`) and integration tests in `tests/unit/rewrite_tests.rs` for prefix collision, oversize skip, and binary-with-leading-text.

## Verification

Run inside the worktree on macOS:

- `cargo fmt --all -- --check` — clean.
- `cargo build --lib --bins` — clean (pre-existing warnings only).
- `cargo test --lib rewrite::` — 4/4 pass.
- `cargo test --test mod -- unit::rewrite_tests` — 13/13 pass.
- `cargo test --test mod -- --test-threads=1` — 192 pass, 1 pre-existing flake (`unit::process_tests::test_signal_handling`, also flagged in #60). Confirmed the flake reproduces in isolation on this branch and is unrelated to `src/rewrite.rs`.
- `cargo clippy --lib --bins --tests --locked` — no new warnings on `src/rewrite.rs`.
- `git diff --check origin/main` — clean.

Closes #58.