### PR TITLE
fix(bench): align performance_benchmarks with current git_warp API

### DIFF
--- a/benches/performance_benchmarks.rs
+++ b/benches/performance_benchmarks.rs
@@ -85,7 +85,7 @@ fn bench_git_operations(c: &mut Criterion) {
             let _ = git_repo.create_worktree_and_branch(&branch_name, &worktree_path, None);
 
             // Clean up
-            let _ = git_repo.remove_worktree(&worktree_path, false, true);
+            let _ = git_repo.remove_worktree(&worktree_path, false);
         })
     });
 
@@ -106,6 +106,8 @@ fn bench_git_operations(c: &mut Criterion) {
                     branch: branch_name,
                     head: "HEAD".to_string(),
                     is_primary: false,
+                    is_current: false,
+                    is_detached: false,
                 });
             }
         }
@@ -116,7 +118,7 @@ fn bench_git_operations(c: &mut Criterion) {
 
         // Clean up test worktrees
         for worktree in &test_worktrees {
-            let _ = git_repo.remove_worktree(&worktree.path, false, true);
+            let _ = git_repo.remove_worktree(&worktree.path, false);
         }
     });
 
@@ -167,10 +169,7 @@ fn bench_path_rewriting(c: &mut Criterion) {
             &clone_path,
             |b, clone_path| {
                 b.iter(|| {
-                    let rewriter = PathRewriter::new(
-                        repo_path.to_string_lossy(),
-                        clone_path.to_string_lossy(),
-                    );
+                    let rewriter = PathRewriter::new(repo_path, clone_path);
                     let _ = rewriter.rewrite_paths();
                 })
             },


### PR DESCRIPTION
## Summary

`benches/performance_benchmarks.rs` no longer compiled against `origin/main`. `cargo build --benches` failed with 5 errors, which is also why PR #59 had to drop `--all-targets` from the new CI clippy step.

Three mechanical alignments to current `git_warp` API:

- `WorktreeInfo` literal at line 104 now includes `is_current: false` and `is_detached: false` to match `src/git.rs:7-14`.
- The two `git_repo.remove_worktree(&path, false, true)` calls (lines 88, 119) are now `remove_worktree(&path, false)` — the current signature in `src/git.rs:457` takes `(path, force)`, no third argument.
- The two `PathRewriter::new(repo_path.to_string_lossy(), clone_path.to_string_lossy())` calls now pass `repo_path` and `clone_path` directly. `Cow<'_, str>` doesn't implement `AsRef<Path>`; both bindings are already `&Path`/`&PathBuf`, which do.

No production code touched; the bench target was the only thing dead.

## Verification

Run inside the worktree:

- `cargo fmt --all -- --check` — clean.
- `cargo build --benches` — clean (only pre-existing dead-code warnings from #62 backlog).
- `cargo build --lib --bins` — clean.
- `cargo test --lib` — 47/47 pass.
- `cargo clippy --benches --locked` — 5 pre-existing `needless_borrow` warnings in unrelated `setup_git_repository` helper (part of #62 backlog); no new warnings on the lines this PR touches.
- `git diff --check` — clean.

Once #62 clears the broader clippy backlog, the CI clippy step from #59 can be tightened to `cargo clippy --all-targets --locked -- -D warnings` and benches will stay covered.

Closes #61.