### PR TITLE
chore(clippy): clear backlog and enforce -D warnings in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --locked --lib --bins --tests
+      - run: cargo clippy --all-targets --locked -- -D warnings
 
   test:
     name: cargo test (${{ matrix.os }})

--- a/benches/performance_benchmarks.rs
+++ b/benches/performance_benchmarks.rs
@@ -355,17 +355,17 @@ fn setup_git_repository() -> tempfile::TempDir {
     let repo_path = temp_dir.path();
 
     Command::new("git")
-        .args(&["init"])
+        .args(["init"])
         .current_dir(repo_path)
         .output()
         .unwrap();
     Command::new("git")
-        .args(&["config", "user.email", "bench@example.com"])
+        .args(["config", "user.email", "bench@example.com"])
         .current_dir(repo_path)
         .output()
         .unwrap();
     Command::new("git")
-        .args(&["config", "user.name", "Bench User"])
+        .args(["config", "user.name", "Bench User"])
         .current_dir(repo_path)
         .output()
         .unwrap();
@@ -373,12 +373,12 @@ fn setup_git_repository() -> tempfile::TempDir {
     fs::write(repo_path.join("README.md"), "# Benchmark Repo").unwrap();
 
     Command::new("git")
-        .args(&["add", "."])
+        .args(["add", "."])
         .current_dir(repo_path)
         .output()
         .unwrap();
     Command::new("git")
-        .args(&["commit", "-m", "Initial commit"])
+        .args(["commit", "-m", "Initial commit"])
         .current_dir(repo_path)
         .output()
         .unwrap();

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -7,6 +7,7 @@ use std::fs::{self, File};
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
+#[allow(dead_code)] // Used via AgentDiscovery::new (public API exercised by integration tests).
 const DEFAULT_HISTORY_LIMIT: usize = 100;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
@@ -100,7 +101,7 @@ fn is_fallback_label(runtime: AgentRuntime, label: &str) -> bool {
         )
 }
 
-fn preferred_group<'a>(items: &'a [AgentSessionSummary]) -> Vec<&'a AgentSessionSummary> {
+fn preferred_group(items: &[AgentSessionSummary]) -> Vec<&AgentSessionSummary> {
     let mut refs: Vec<&AgentSessionSummary> = items.iter().collect();
     refs.sort_by(|a, b| {
         b.is_live
@@ -176,6 +177,7 @@ fn session_file_candidates_under(
 }
 
 impl AgentDiscovery {
+    #[allow(dead_code)] // Public constructor used by tui/tests; bin path uses with_max_history_sessions.
     pub fn new(monitored_paths: Vec<PathBuf>) -> Self {
         Self::with_max_history_sessions(monitored_paths, DEFAULT_HISTORY_LIMIT)
     }
@@ -489,30 +491,26 @@ fn merge_session_group(items: Vec<&AgentSessionSummary>) -> AgentSessionSummary 
         selected.is_live = true;
     }
 
-    if selected.branch.is_none()
-        || is_fallback_label(selected.runtime, selected.agent_label.as_str())
-    {
-        if let Some(branch) = items
+    if (selected.branch.is_none()
+        || is_fallback_label(selected.runtime, selected.agent_label.as_str()))
+        && let Some(branch) = items
             .iter()
             .filter_map(|item| item.branch.clone())
             .find(|branch| !branch.is_empty())
-        {
-            selected.branch = Some(branch);
-        }
+    {
+        selected.branch = Some(branch);
     }
 
     if is_fallback_label(selected.runtime, &selected.agent_label)
         && session_store_item
             .map(|item| !is_fallback_label(selected.runtime, &item.agent_label))
             .unwrap_or(false)
-    {
-        if let Some(label) = items
+        && let Some(label) = items
             .iter()
             .map(|item| item.agent_label.as_str())
             .find(|label| !is_fallback_label(selected.runtime, label))
-        {
-            selected.agent_label = label.to_string();
-        }
+    {
+        selected.agent_label = label.to_string();
     }
 
     if selected.session_id.is_none() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -927,7 +927,7 @@ impl Cli {
         };
 
         match terminal_manager.switch_to_worktree_with_options(
-            &worktree_path,
+            worktree_path,
             terminal_mode,
             None,
             Some(terminal_app),
@@ -1986,13 +1986,12 @@ impl Cli {
         for (path, active) in paths {
             let canonical = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
             if !seen.insert(canonical.clone()) {
-                if active {
-                    if let Some(existing) = entries
+                if active
+                    && let Some(existing) = entries
                         .iter_mut()
                         .find(|e: &&mut DoctorInstallEntry| e.path == path)
-                    {
-                        existing.active = true;
-                    }
+                {
+                    existing.active = true;
                 }
                 continue;
             }
@@ -2231,55 +2230,47 @@ impl Cli {
         match detected_shell.as_str() {
             "bash" => {
                 println!("# Add to ~/.bashrc");
+                println!("warp_cd() {{ eval \"$(warp --terminal echo \"$@\")\"; }}");
                 println!(
-                    "{}",
-                    r#"warp_cd() { eval "$(warp --terminal echo "$@")"; }"#
-                );
-                println!(
-                    "{}",
-                    r#"_warp_completion() {
+                    "_warp_completion() {{
     local cur prev commands branches
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
-    commands="switch ls list cleanup config agents doctor hooks-install hooks-remove hooks-status shell-config"
+    cur=\"${{COMP_WORDS[COMP_CWORD]}}\"
+    prev=\"${{COMP_WORDS[COMP_CWORD-1]}}\"
+    commands=\"switch ls list cleanup config agents doctor hooks-install hooks-remove hooks-status shell-config\"
 
-    if [[ "$prev" == "switch" ]]; then
-        branches="$(warp __complete branches "$cur" 2>/dev/null)"
-        COMPREPLY=($(compgen -W "$branches" -- "$cur"))
+    if [[ \"$prev\" == \"switch\" ]]; then
+        branches=\"$(warp __complete branches \"$cur\" 2>/dev/null)\"
+        COMPREPLY=($(compgen -W \"$branches\" -- \"$cur\"))
     elif [[ $COMP_CWORD -eq 1 ]]; then
-        branches="$(warp __complete branches "$cur" 2>/dev/null)"
-        COMPREPLY=($(compgen -W "$commands $branches" -- "$cur"))
+        branches=\"$(warp __complete branches \"$cur\" 2>/dev/null)\"
+        COMPREPLY=($(compgen -W \"$commands $branches\" -- \"$cur\"))
     fi
-}
-complete -F _warp_completion warp"#
+}}
+complete -F _warp_completion warp"
                 );
             }
             "zsh" => {
                 println!("# Add to ~/.zshrc");
+                println!("warp_cd() {{ eval \"$(warp --terminal echo \"$@\")\"; }}");
                 println!(
-                    "{}",
-                    r#"warp_cd() { eval "$(warp --terminal echo "$@")"; }"#
-                );
-                println!(
-                    "{}",
-                    r#"_warp_branch_completions() {
+                    "_warp_branch_completions() {{
     local -a branches
-    branches=("${(@f)$(warp __complete branches "$PREFIX" 2>/dev/null)}")
-    compadd -- "${branches[@]}"
-}
+    branches=(\"${{(@f)$(warp __complete branches \"$PREFIX\" 2>/dev/null)}}\")
+    compadd -- \"${{branches[@]}}\"
+}}
 
-_warp_completion() {
+_warp_completion() {{
     local -a commands
     commands=(switch ls list cleanup config agents doctor hooks-install hooks-remove hooks-status shell-config)
 
     if (( CURRENT == 2 )); then
-        compadd -- "${commands[@]}"
+        compadd -- \"${{commands[@]}}\"
         _warp_branch_completions
-    elif [[ ${words[2]} == switch && CURRENT == 3 ]]; then
+    elif [[ ${{words[2]}} == switch && CURRENT == 3 ]]; then
         _warp_branch_completions
     fi
-}
-compdef _warp_completion warp"#
+}}
+compdef _warp_completion warp"
                 );
             }
             "fish" => {
@@ -2288,10 +2279,9 @@ compdef _warp_completion warp"#
                 println!("    eval (warp --terminal echo $argv)");
                 println!("end");
                 println!(
-                    "{}",
-                    r#"complete -c warp -n '__fish_use_subcommand' -a 'switch ls list cleanup config agents doctor hooks-install hooks-remove hooks-status shell-config'
+                    "complete -c warp -n '__fish_use_subcommand' -a 'switch ls list cleanup config agents doctor hooks-install hooks-remove hooks-status shell-config'
 complete -c warp -n '__fish_use_subcommand' -f -a '(warp __complete branches (commandline -ct) 2>/dev/null)'
-complete -c warp -n '__fish_seen_subcommand_from switch' -f -a '(warp __complete branches (commandline -ct) 2>/dev/null)'"#
+complete -c warp -n '__fish_seen_subcommand_from switch' -f -a '(warp __complete branches (commandline -ct) 2>/dev/null)'"
                 );
             }
             other => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -226,12 +226,8 @@ impl Default for AgentConfig {
 }
 
 impl Config {
-    /// Create a configuration with intelligent defaults
-    pub fn with_defaults() -> Self {
-        Self::default()
-    }
-
     /// Update configuration from environment variables
+    #[allow(dead_code)] // Exercised by config_tests integration tests.
     pub fn apply_env_overrides(&mut self) {
         // Terminal mode
         if let Ok(mode) = std::env::var("GIT_WARP_TERMINAL_MODE") {
@@ -255,6 +251,7 @@ impl Config {
     }
 
     /// Generate a sample configuration file content
+    #[allow(dead_code)] // Exercised by config_tests integration tests.
     pub fn sample_config() -> String {
         let config = Config::default();
         format!(
@@ -383,12 +380,8 @@ impl ConfigManager {
         &self.config
     }
 
-    /// Get a mutable reference to the configuration
-    pub fn get_mut(&mut self) -> &mut Config {
-        &mut self.config
-    }
-
     /// Save the configuration to file
+    #[allow(dead_code)] // Exercised by config_tests integration tests.
     pub fn save(&self) -> Result<()> {
         self.save_config(&self.config_path, &self.config)
     }
@@ -427,11 +420,6 @@ impl ConfigManager {
     pub fn config_exists(&self) -> bool {
         self.config_path.exists()
     }
-
-    /// Generate and display sample configuration
-    pub fn show_sample_config(&self) {
-        println!("{}", Config::sample_config());
-    }
 }
 
 /// Get the path to the configuration file
@@ -452,8 +440,8 @@ mod tests {
     fn test_config_defaults() {
         let config = Config::default();
         assert_eq!(config.terminal_mode, "tab");
-        assert_eq!(config.use_cow, true);
-        assert_eq!(config.auto_confirm, false);
+        assert!(config.use_cow);
+        assert!(!config.auto_confirm);
         assert_eq!(config.git.default_branch, "main");
         assert_eq!(config.process.kill_timeout, 5);
     }
@@ -495,7 +483,7 @@ mod tests {
         config.apply_env_overrides();
 
         assert_eq!(config.terminal_mode, "window");
-        assert_eq!(config.auto_confirm, true);
+        assert!(config.auto_confirm);
 
         // Clean up
         unsafe {
@@ -518,7 +506,7 @@ mod tests {
     #[test]
     fn test_post_create_defaults() {
         let config = Config::default();
-        assert_eq!(config.post_create.auto_install, true);
+        assert!(config.post_create.auto_install);
     }
 
     #[test]
@@ -527,6 +515,6 @@ mod tests {
         config.post_create.auto_install = false;
         let toml_str = toml::to_string(&config).unwrap();
         let parsed: Config = toml::from_str(&toml_str).unwrap();
-        assert_eq!(parsed.post_create.auto_install, false);
+        assert!(!parsed.post_create.auto_install);
     }
 }

--- a/src/cow.rs
+++ b/src/cow.rs
@@ -87,7 +87,10 @@ fn clone_directory_apfs<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dest: Q) -> Resu
 
     if !output.status.success() {
         let error = String::from_utf8_lossy(&output.stderr);
-        return Err(anyhow::anyhow!("Failed to clone directory with CoW: {}", error).into());
+        return Err(anyhow::anyhow!(
+            "Failed to clone directory with CoW: {}",
+            error
+        ));
     }
 
     Ok(())

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@ use thiserror::Error;
 
 pub type Result<T> = anyhow::Result<T>;
 
+#[allow(dead_code)] // Public error API; some variants are produced only via paths not reachable from `warp` bin yet.
 #[derive(Error, Debug)]
 pub enum GitWarpError {
     #[error("Not in a git repository")]

--- a/src/git.rs
+++ b/src/git.rs
@@ -72,6 +72,7 @@ pub enum BranchSource {
 }
 
 pub struct GitRepository {
+    #[allow(dead_code)] // Held to keep gix repository state alive; commands shell out to `git`.
     repo: Repository,
     repo_path: PathBuf,
 }
@@ -120,6 +121,7 @@ impl GitRepository {
     }
 
     /// Open a specific Git repository
+    #[allow(dead_code)] // Public constructor used by inline tests/embedders.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
         let repo_path = path.as_ref().to_path_buf();
         let repo = gix::open(&repo_path).map_err(|_| GitWarpError::NotInGitRepository)?;
@@ -138,13 +140,13 @@ impl GitRepository {
 
         // Use git command to list worktrees since gix doesn't have full worktree support yet
         let output = Command::new("git")
-            .args(&["worktree", "list", "--porcelain"])
+            .args(["worktree", "list", "--porcelain"])
             .current_dir(&self.repo_path)
             .output()
             .map_err(|e| anyhow::anyhow!("Failed to list worktrees: {}", e))?;
 
         if !output.status.success() {
-            return Err(anyhow::anyhow!("Git worktree list failed").into());
+            return Err(anyhow::anyhow!("Git worktree list failed"));
         }
 
         let output_str = String::from_utf8_lossy(&output.stdout);
@@ -182,10 +184,10 @@ impl GitRepository {
                 if let Some(ref mut wt) = current_worktree {
                     wt.is_primary = true;
                 }
-            } else if line == "detached" {
-                if let Some(ref mut wt) = current_worktree {
-                    wt.is_detached = true;
-                }
+            } else if line == "detached"
+                && let Some(ref mut wt) = current_worktree
+            {
+                wt.is_detached = true;
             }
         }
 
@@ -251,7 +253,7 @@ impl GitRepository {
 
         if !output.status.success() {
             let error = String::from_utf8_lossy(&output.stderr);
-            return Err(anyhow::anyhow!("Failed to list remote branches: {}", error).into());
+            return Err(anyhow::anyhow!("Failed to list remote branches: {}", error));
         }
 
         let mut origin_match: Option<String> = None;
@@ -317,8 +319,7 @@ impl GitRepository {
         match source {
             BranchSource::ExistingWorktree { .. } => Err(anyhow::anyhow!(
                 "Cannot create worktree for branch '{branch_name}': it is already checked out in another worktree"
-            )
-            .into()),
+            )),
             BranchSource::LocalBranch => {
                 let output = Command::new("git")
                     .args(["worktree", "add"])
@@ -330,7 +331,7 @@ impl GitRepository {
 
                 if !output.status.success() {
                     let error = String::from_utf8_lossy(&output.stderr);
-                    return Err(anyhow::anyhow!("Failed to create worktree: {}", error).into());
+                    return Err(anyhow::anyhow!("Failed to create worktree: {}", error));
                 }
                 Ok(())
             }
@@ -350,8 +351,7 @@ impl GitRepository {
                     return Err(anyhow::anyhow!(
                         "Failed to create worktree from remote branch '{remote_ref}': {}",
                         error
-                    )
-                    .into());
+                    ));
                 }
                 Ok(())
             }
@@ -366,9 +366,10 @@ impl GitRepository {
 
                 if !output.status.success() {
                     let error = String::from_utf8_lossy(&output.stderr);
-                    return Err(
-                        anyhow::anyhow!("Failed to create worktree and branch: {}", error).into(),
-                    );
+                    return Err(anyhow::anyhow!(
+                        "Failed to create worktree and branch: {}",
+                        error
+                    ));
                 }
                 Ok(())
             }
@@ -376,6 +377,7 @@ impl GitRepository {
     }
 
     /// Create a new worktree and branch
+    #[allow(dead_code)] // Used by integration tests/benches; bin path uses other helpers today.
     pub fn create_worktree_and_branch<P: AsRef<Path>>(
         &self,
         branch_name: &str,
@@ -390,7 +392,7 @@ impl GitRepository {
         if self.branch_exists(branch_name)? {
             // Create worktree from existing branch
             let mut cmd = Command::new("git");
-            cmd.args(&["worktree", "add"])
+            cmd.args(["worktree", "add"])
                 .arg(worktree_path)
                 .arg(branch_name)
                 .current_dir(&self.repo_path);
@@ -401,7 +403,7 @@ impl GitRepository {
 
             if !output.status.success() {
                 let error = String::from_utf8_lossy(&output.stderr);
-                return Err(anyhow::anyhow!("Failed to create worktree: {}", error).into());
+                return Err(anyhow::anyhow!("Failed to create worktree: {}", error));
             }
         } else if let Some(remote_ref) = self.find_remote_branch_ref(branch_name)? {
             // Track remote branch as new local branch
@@ -420,13 +422,12 @@ impl GitRepository {
                 return Err(anyhow::anyhow!(
                     "Failed to create worktree from remote branch '{remote_ref}': {}",
                     error
-                )
-                .into());
+                ));
             }
         } else {
             // Create new branch and worktree
             let mut cmd = Command::new("git");
-            cmd.args(&["worktree", "add", "-b", branch_name])
+            cmd.args(["worktree", "add", "-b", branch_name])
                 .arg(worktree_path);
 
             if let Some(commit) = from_commit {
@@ -443,9 +444,10 @@ impl GitRepository {
 
             if !output.status.success() {
                 let error = String::from_utf8_lossy(&output.stderr);
-                return Err(
-                    anyhow::anyhow!("Failed to create worktree and branch: {}", error).into(),
-                );
+                return Err(anyhow::anyhow!(
+                    "Failed to create worktree and branch: {}",
+                    error
+                ));
             }
         }
 
@@ -460,7 +462,7 @@ impl GitRepository {
         let worktree_path = worktree_path.as_ref();
 
         let mut cmd = Command::new("git");
-        cmd.args(&["worktree", "remove"]);
+        cmd.args(["worktree", "remove"]);
         if force {
             cmd.arg("--force");
         }
@@ -472,7 +474,7 @@ impl GitRepository {
 
         if !output.status.success() {
             let error = String::from_utf8_lossy(&output.stderr);
-            return Err(anyhow::anyhow!("Failed to remove worktree: {}", error).into());
+            return Err(anyhow::anyhow!("Failed to remove worktree: {}", error));
         }
 
         Ok(())
@@ -485,16 +487,18 @@ impl GitRepository {
         let delete_flag = if force { "-D" } else { "-d" };
 
         let output = Command::new("git")
-            .args(&["branch", delete_flag, branch_name])
+            .args(["branch", delete_flag, branch_name])
             .current_dir(&self.repo_path)
             .output()
             .map_err(|e| anyhow::anyhow!("Failed to delete branch: {}", e))?;
 
         if !output.status.success() {
             let error = String::from_utf8_lossy(&output.stderr);
-            return Err(
-                anyhow::anyhow!("Failed to delete branch {}: {}", branch_name, error).into(),
-            );
+            return Err(anyhow::anyhow!(
+                "Failed to delete branch {}: {}",
+                branch_name,
+                error
+            ));
         }
 
         Ok(())
@@ -505,20 +509,21 @@ impl GitRepository {
         use std::process::Command;
 
         let output = Command::new("git")
-            .args(&["worktree", "prune"])
+            .args(["worktree", "prune"])
             .current_dir(&self.repo_path)
             .output()
             .map_err(|e| anyhow::anyhow!("Failed to prune worktrees: {}", e))?;
 
         if !output.status.success() {
             let error = String::from_utf8_lossy(&output.stderr);
-            return Err(anyhow::anyhow!("Failed to prune worktrees: {}", error).into());
+            return Err(anyhow::anyhow!("Failed to prune worktrees: {}", error));
         }
 
         Ok(())
     }
 
     /// Analyze branches for cleanup
+    #[allow(dead_code)] // Default-config wrapper used by tests/benches.
     pub fn analyze_branches_for_cleanup(
         &self,
         worktrees: &[WorktreeInfo],
@@ -528,6 +533,7 @@ impl GitRepository {
     }
 
     /// Analyze branches for cleanup using an explicit protected branch list
+    #[allow(dead_code)] // Convenience wrapper used by tests; bin uses *_with_config.
     pub fn analyze_branches_for_cleanup_with_protected_branches(
         &self,
         worktrees: &[WorktreeInfo],
@@ -635,7 +641,7 @@ impl GitRepository {
             // Check if branch has a remote
             let has_remote = {
                 let output = Command::new("git")
-                    .args(&["config", &format!("branch.{}.remote", branch)])
+                    .args(["config", &format!("branch.{}.remote", branch)])
                     .current_dir(&self.repo_path)
                     .output()
                     .map_err(|e| anyhow::anyhow!("Failed to check remote: {}", e))?;
@@ -664,7 +670,7 @@ impl GitRepository {
             // Check for uncommitted changes
             let has_uncommitted_changes = {
                 let output = Command::new("git")
-                    .args(&["status", "--porcelain"])
+                    .args(["status", "--porcelain"])
                     .current_dir(path)
                     .output();
 
@@ -713,7 +719,7 @@ impl GitRepository {
         use std::process::Command;
 
         let output = Command::new("git")
-            .args(&["fetch", "--all", "--prune"])
+            .args(["fetch", "--all", "--prune"])
             .current_dir(&self.repo_path)
             .output()
             .map_err(|e| anyhow::anyhow!("Failed to fetch: {}", e))?;
@@ -732,7 +738,7 @@ impl GitRepository {
         use std::process::Command;
 
         let output = Command::new("git")
-            .args(&[
+            .args([
                 "show-ref",
                 "--verify",
                 "--quiet",
@@ -757,7 +763,7 @@ impl GitRepository {
 
         if !output.status.success() {
             let error = String::from_utf8_lossy(&output.stderr);
-            return Err(anyhow::anyhow!("Failed to list local branches: {}", error).into());
+            return Err(anyhow::anyhow!("Failed to list local branches: {}", error));
         }
 
         let mut branches: Vec<String> = String::from_utf8_lossy(&output.stdout)
@@ -772,18 +778,19 @@ impl GitRepository {
     }
 
     /// Get the current HEAD commit
+    #[allow(dead_code)] // Public helper kept for tests/embedders.
     pub fn get_head_commit(&self) -> Result<String> {
         use std::process::Command;
 
         let output = Command::new("git")
-            .args(&["rev-parse", "HEAD"])
+            .args(["rev-parse", "HEAD"])
             .current_dir(&self.repo_path)
             .output()
             .map_err(|e| anyhow::anyhow!("Failed to get HEAD commit: {}", e))?;
 
         if !output.status.success() {
             let error = String::from_utf8_lossy(&output.stderr);
-            return Err(anyhow::anyhow!("Failed to get HEAD commit: {}", error).into());
+            return Err(anyhow::anyhow!("Failed to get HEAD commit: {}", error));
         }
 
         let commit_hash = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -792,6 +799,7 @@ impl GitRepository {
     }
 
     /// Get the default worktree path for a branch
+    #[allow(dead_code)] // Convenience wrapper used by tests; bin path passes a base.
     pub fn get_worktree_path(&self, branch_name: &str) -> PathBuf {
         self.get_worktree_path_with_base(branch_name, None)
     }
@@ -831,16 +839,16 @@ impl GitRepository {
 
         // Try to get the default branch from remote
         let output = Command::new("git")
-            .args(&["symbolic-ref", "refs/remotes/origin/HEAD"])
+            .args(["symbolic-ref", "refs/remotes/origin/HEAD"])
             .current_dir(&self.repo_path)
             .output();
 
-        if let Ok(output) = output {
-            if output.status.success() {
-                let branch_ref = String::from_utf8_lossy(&output.stdout);
-                if let Some(branch) = branch_ref.trim().strip_prefix("refs/remotes/origin/") {
-                    return Ok(branch.to_string());
-                }
+        if let Ok(output) = output
+            && output.status.success()
+        {
+            let branch_ref = String::from_utf8_lossy(&output.stdout);
+            if let Some(branch) = branch_ref.trim().strip_prefix("refs/remotes/origin/") {
+                return Ok(branch.to_string());
             }
         }
 
@@ -857,25 +865,26 @@ impl GitRepository {
         use std::process::Command;
 
         let output = Command::new("git")
-            .args(&["status", "--porcelain"])
+            .args(["status", "--porcelain"])
             .current_dir(path.as_ref())
             .output()
             .map_err(|e| anyhow::anyhow!("Failed to check git status: {}", e))?;
 
         if !output.status.success() {
             let error = String::from_utf8_lossy(&output.stderr);
-            return Err(anyhow::anyhow!("Git status failed: {}", error).into());
+            return Err(anyhow::anyhow!("Git status failed: {}", error));
         }
 
         Ok(!output.stdout.is_empty())
     }
 
     /// Check if a branch is merged into a target branch
+    #[allow(dead_code)] // Public helper kept for tests/embedders.
     pub fn is_branch_merged(&self, branch: &str, target_branch: &str) -> Result<bool> {
         use std::process::Command;
 
         let output = Command::new("git")
-            .args(&["merge-base", "--is-ancestor", branch, target_branch])
+            .args(["merge-base", "--is-ancestor", branch, target_branch])
             .current_dir(&self.repo_path)
             .output()
             .map_err(|e| anyhow::anyhow!("Failed to check merge status: {}", e))?;
@@ -898,20 +907,20 @@ mod tests {
 
         // Initialize git repo
         Command::new("git")
-            .args(&["init"])
+            .args(["init"])
             .current_dir(repo_path)
             .output()
             .unwrap();
 
         // Configure git
         Command::new("git")
-            .args(&["config", "user.email", "test@example.com"])
+            .args(["config", "user.email", "test@example.com"])
             .current_dir(repo_path)
             .output()
             .unwrap();
 
         Command::new("git")
-            .args(&["config", "user.name", "Test User"])
+            .args(["config", "user.name", "Test User"])
             .current_dir(repo_path)
             .output()
             .unwrap();
@@ -919,13 +928,13 @@ mod tests {
         // Create initial commit
         std::fs::write(repo_path.join("test.txt"), "test").unwrap();
         Command::new("git")
-            .args(&["add", "."])
+            .args(["add", "."])
             .current_dir(repo_path)
             .output()
             .unwrap();
 
         Command::new("git")
-            .args(&["commit", "-m", "Initial commit"])
+            .args(["commit", "-m", "Initial commit"])
             .current_dir(repo_path)
             .output()
             .unwrap();

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -25,7 +25,9 @@ impl HookRuntime {
             "claude" => Ok(vec![Self::Claude]),
             "codex" => Ok(vec![Self::Codex]),
             "all" => Ok(vec![Self::Claude, Self::Codex]),
-            _ => Err(anyhow::anyhow!("Invalid runtime. Use: claude, codex, or all").into()),
+            _ => Err(anyhow::anyhow!(
+                "Invalid runtime. Use: claude, codex, or all"
+            )),
         }
     }
 
@@ -518,10 +520,7 @@ impl HooksManager {
         Ok(())
     }
 
-    fn hooks_object<'a>(
-        settings: &'a Value,
-        runtime: HookRuntime,
-    ) -> Result<&'a Map<String, Value>> {
+    fn hooks_object(settings: &Value, runtime: HookRuntime) -> Result<&Map<String, Value>> {
         let container = if runtime.wraps_hooks_at_root() {
             settings
                 .get("hooks")
@@ -532,13 +531,10 @@ impl HooksManager {
 
         container
             .as_object()
-            .ok_or_else(|| anyhow::anyhow!("Hooks config is not a JSON object").into())
+            .ok_or_else(|| anyhow::anyhow!("Hooks config is not a JSON object"))
     }
 
-    fn hooks_object_mut<'a>(
-        settings: &'a mut Value,
-        runtime: HookRuntime,
-    ) -> &'a mut Map<String, Value> {
+    fn hooks_object_mut(settings: &mut Value, runtime: HookRuntime) -> &mut Map<String, Value> {
         if !settings.is_object() {
             *settings = json!({});
         }
@@ -629,7 +625,7 @@ mod tests {
                 .as_array()
                 .unwrap()
                 .iter()
-                .any(|entry| HooksManager::is_git_warp_hook(entry))
+                .any(HooksManager::is_git_warp_hook)
         );
     }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -11,9 +11,12 @@ pub struct ProcessInfo {
     pub working_dir: PathBuf,
     pub cpu_usage: f32,
     pub memory_usage: u64,
+    // Captured for tests/future reporting; bin display path doesn't read it yet.
+    #[allow(dead_code)]
     pub start_time: u64,
 }
 
+#[allow(dead_code)] // Public stats type used by tests/embedders.
 #[derive(Debug)]
 pub struct ProcessStats {
     pub total_count: usize,
@@ -25,6 +28,12 @@ pub struct ProcessStats {
 
 pub struct ProcessManager {
     system: System,
+}
+
+impl Default for ProcessManager {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ProcessManager {
@@ -57,18 +66,18 @@ impl ProcessManager {
         let mut processes = Vec::new();
 
         for (pid, process) in self.system.processes() {
-            if let Some(cwd) = process.cwd() {
-                if cwd.starts_with(&target_path) {
-                    processes.push(ProcessInfo {
-                        pid: pid.as_u32(),
-                        name: process.name().to_string(),
-                        cmd: process.cmd().join(" "),
-                        working_dir: cwd.to_path_buf(),
-                        cpu_usage: process.cpu_usage(),
-                        memory_usage: process.memory(),
-                        start_time: process.start_time(),
-                    });
-                }
+            if let Some(cwd) = process.cwd()
+                && cwd.starts_with(&target_path)
+            {
+                processes.push(ProcessInfo {
+                    pid: pid.as_u32(),
+                    name: process.name().to_string(),
+                    cmd: process.cmd().join(" "),
+                    working_dir: cwd.to_path_buf(),
+                    cpu_usage: process.cpu_usage(),
+                    memory_usage: process.memory(),
+                    start_time: process.start_time(),
+                });
             }
         }
 
@@ -216,6 +225,7 @@ impl ProcessManager {
     }
 
     /// Get detailed process statistics for a directory
+    #[allow(dead_code)] // Public helper used by tests/embedders.
     pub fn get_directory_process_stats<P: AsRef<Path>>(&mut self, path: P) -> Result<ProcessStats> {
         let processes = self.find_processes_in_directory(path)?;
 
@@ -234,6 +244,7 @@ impl ProcessManager {
     }
 
     /// Kill all processes in a directory with confirmation
+    #[allow(dead_code)] // Public helper kept for embedders.
     pub fn kill_directory_processes<P: AsRef<Path>>(
         &mut self,
         path: P,
@@ -257,7 +268,7 @@ mod tests {
 
     #[test]
     fn test_process_manager_creation() {
-        let manager = ProcessManager::new();
+        let _manager = ProcessManager::new();
         // Just verify we can create a process manager
     }
 

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -12,6 +12,8 @@ pub enum TerminalMode {
 }
 
 impl TerminalMode {
+    // Returns Option, not Result — we deliberately don't implement std::str::FromStr.
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Option<Self> {
         match s.to_lowercase().as_str() {
             "tab" => Some(Self::Tab),
@@ -166,7 +168,7 @@ end tell
     fn is_supported(&self) -> bool {
         // Check if iTerm2 is available
         Command::new("osascript")
-            .args(&["-e", "tell application \"iTerm\" to get version"])
+            .args(["-e", "tell application \"iTerm\" to get version"])
             .output()
             .map(|output| output.status.success())
             .unwrap_or(false)
@@ -177,13 +179,13 @@ end tell
 impl ITerm2 {
     fn run_applescript(&self, script: &str) -> Result<()> {
         let output = Command::new("osascript")
-            .args(&["-e", script])
+            .args(["-e", script])
             .output()
             .map_err(|e| anyhow::anyhow!("Failed to execute AppleScript: {}", e))?;
 
         if !output.status.success() {
             let error = String::from_utf8_lossy(&output.stderr);
-            return Err(anyhow::anyhow!("AppleScript failed: {}", error).into());
+            return Err(anyhow::anyhow!("AppleScript failed: {}", error));
         }
 
         Ok(())
@@ -257,13 +259,13 @@ end tell
 impl AppleTerminal {
     fn run_applescript(&self, script: &str) -> Result<()> {
         let output = Command::new("osascript")
-            .args(&["-e", script])
+            .args(["-e", script])
             .output()
             .map_err(|e| anyhow::anyhow!("Failed to execute AppleScript: {}", e))?;
 
         if !output.status.success() {
             let error = String::from_utf8_lossy(&output.stderr);
-            return Err(anyhow::anyhow!("AppleScript failed: {}", error).into());
+            return Err(anyhow::anyhow!("AppleScript failed: {}", error));
         }
 
         Ok(())
@@ -306,7 +308,7 @@ impl Terminal for WarpTerminal {
 
     fn is_supported(&self) -> bool {
         Command::new("osascript")
-            .args(&["-e", "tell application \"Warp\" to get version"])
+            .args(["-e", "tell application \"Warp\" to get version"])
             .output()
             .map(|output| output.status.success())
             .unwrap_or(false)
@@ -326,7 +328,7 @@ impl WarpTerminal {
 
         if !output.status.success() {
             let error = String::from_utf8_lossy(&output.stderr);
-            return Err(anyhow::anyhow!("Warp URI open failed: {}", error).into());
+            return Err(anyhow::anyhow!("Warp URI open failed: {}", error));
         }
 
         Ok(())
@@ -463,9 +465,10 @@ fn enter_current_shell(path: &Path, options: &TerminalLaunchOptions) -> Result<(
         .map_err(|e| anyhow::anyhow!("Failed to start current terminal shell: {}", e))?;
 
     if !status.success() {
-        return Err(
-            anyhow::anyhow!("Current terminal shell exited with status: {}", status).into(),
-        );
+        return Err(anyhow::anyhow!(
+            "Current terminal shell exited with status: {}",
+            status
+        ));
     }
 
     Ok(())
@@ -474,6 +477,7 @@ fn enter_current_shell(path: &Path, options: &TerminalLaunchOptions) -> Result<(
 pub struct TerminalManager;
 
 impl TerminalManager {
+    #[allow(dead_code)] // Public helper used by tests/embedders.
     pub fn get_default_terminal() -> Result<Box<dyn Terminal>> {
         Self::get_terminal(None)
     }
@@ -522,6 +526,7 @@ impl TerminalManager {
         }
     }
 
+    #[allow(dead_code)] // Public convenience wrapper kept for embedders.
     pub fn switch_to_worktree<P: AsRef<Path>>(
         &self,
         path: P,
@@ -531,6 +536,7 @@ impl TerminalManager {
         self.switch_to_worktree_with_app(path, mode, session_id, None)
     }
 
+    #[allow(dead_code)] // Public convenience wrapper kept for embedders.
     pub fn switch_to_worktree_with_app<P: AsRef<Path>>(
         &self,
         path: P,

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -417,42 +417,40 @@ impl TuiApp {
 
             // Non-blocking event check
             let timeout = Duration::from_millis(100);
-            if poll(timeout)? {
-                if let Event::Key(key) = event::read()? {
-                    match key.code {
-                        KeyCode::Char('q') => {
-                            self.should_quit = true;
-                        }
-                        KeyCode::Esc => {
-                            self.should_quit = true;
-                        }
-                        KeyCode::Up | KeyCode::Char('k') => {
-                            if self.selected_index > 0 {
-                                self.selected_index -= 1;
-                            }
-                        }
-                        KeyCode::Down | KeyCode::Char('j') => {
-                            if self.selected_index < self.filtered_count().saturating_sub(1) {
-                                self.selected_index += 1;
-                            }
-                        }
-                        KeyCode::Char('r') => {
-                            self.refresh_sessions()?;
-                        }
-                        KeyCode::Char('t') => {
-                            self.filters.runtime = self.filters.runtime.next();
-                            self.selected_index = 0;
-                        }
-                        KeyCode::Char('p') => {
-                            self.filters.presence = self.filters.presence.next();
-                            self.selected_index = 0;
-                        }
-                        KeyCode::Char('c') => {
-                            self.filters = DashboardFilters::default();
-                            self.selected_index = 0;
-                        }
-                        _ => {}
+            if poll(timeout)?
+                && let Event::Key(key) = event::read()?
+            {
+                match key.code {
+                    KeyCode::Char('q') => {
+                        self.should_quit = true;
                     }
+                    KeyCode::Esc => {
+                        self.should_quit = true;
+                    }
+                    KeyCode::Up | KeyCode::Char('k') if self.selected_index > 0 => {
+                        self.selected_index -= 1;
+                    }
+                    KeyCode::Down | KeyCode::Char('j')
+                        if self.selected_index < self.filtered_count().saturating_sub(1) =>
+                    {
+                        self.selected_index += 1;
+                    }
+                    KeyCode::Char('r') => {
+                        self.refresh_sessions()?;
+                    }
+                    KeyCode::Char('t') => {
+                        self.filters.runtime = self.filters.runtime.next();
+                        self.selected_index = 0;
+                    }
+                    KeyCode::Char('p') => {
+                        self.filters.presence = self.filters.presence.next();
+                        self.selected_index = 0;
+                    }
+                    KeyCode::Char('c') => {
+                        self.filters = DashboardFilters::default();
+                        self.selected_index = 0;
+                    }
+                    _ => {}
                 }
             }
 
@@ -610,6 +608,7 @@ impl TuiApp {
     }
 }
 
+#[allow(dead_code)] // Convenience wrapper used by tui_tests integration tests.
 pub fn build_worktree_switch_model(
     worktrees: &[WorktreeInfo],
     statuses: &[WorktreeRuntimeStatus],
@@ -621,6 +620,7 @@ pub fn build_worktree_switch_model(
     )
 }
 
+#[allow(dead_code)] // Convenience wrapper used by tui_tests integration tests.
 pub fn build_worktree_switch_model_with_protected_branches(
     worktrees: &[WorktreeInfo],
     statuses: &[WorktreeRuntimeStatus],
@@ -814,6 +814,7 @@ pub fn build_worktree_switch_rows(
         .collect()
 }
 
+#[allow(dead_code)] // Convenience wrapper used by tui_tests integration tests.
 pub fn build_dashboard_model(
     sessions: &[AgentSessionSummary],
     now: DateTime<Local>,
@@ -823,6 +824,7 @@ pub fn build_dashboard_model(
     build_dashboard_model_windowed(&ordered_sessions, now, 0, ordered_sessions.len().max(1))
 }
 
+#[allow(dead_code)] // Convenience wrapper used by tui_tests integration tests.
 pub fn build_dashboard_model_windowed(
     sessions: &[AgentSessionSummary],
     now: DateTime<Local>,
@@ -1113,12 +1115,6 @@ impl AgentsDashboard {
 
     pub fn run(&self) -> Result<()> {
         let mut app = TuiApp::new(self.discovery.clone());
-        app.run()
-    }
-
-    /// Start monitoring agents in a specific worktree
-    pub fn monitor_worktree(&self, worktree_path: PathBuf) -> Result<()> {
-        let mut app = TuiApp::new(AgentDiscovery::new(vec![worktree_path]));
         app.run()
     }
 }
@@ -1555,6 +1551,12 @@ pub struct CleanupTui {
     candidates: Option<Vec<BranchStatus>>,
 }
 
+impl Default for CleanupTui {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CleanupTui {
     pub fn new() -> Self {
         Self { candidates: None }
@@ -1672,36 +1674,34 @@ impl CleanupTui {
             })?;
 
             // Handle input
-            if let Event::Key(key) = event::read()? {
-                if key.kind == KeyEventKind::Press {
-                    match key.code {
-                        KeyCode::Char('q') | KeyCode::Esc => {
-                            should_quit = true;
-                            break;
-                        }
-                        KeyCode::Up | KeyCode::Char('k') => {
-                            if selected_index > 0 {
-                                selected_index -= 1;
-                            }
-                        }
-                        KeyCode::Down | KeyCode::Char('j') => {
-                            if selected_index < branch_statuses.len() - 1 {
-                                selected_index += 1;
-                            }
-                        }
-                        KeyCode::Char(' ') => {
-                            selected_branches[selected_index] = !selected_branches[selected_index];
-                        }
-                        KeyCode::Char('a') => {
-                            let select_all = next_bulk_selection_state(&selected_branches);
-                            selected_branches.fill(select_all);
-                        }
-                        KeyCode::Enter => {
-                            confirmed = true;
-                            break;
-                        }
-                        _ => {}
+            if let Event::Key(key) = event::read()?
+                && key.kind == KeyEventKind::Press
+            {
+                match key.code {
+                    KeyCode::Char('q') | KeyCode::Esc => {
+                        should_quit = true;
+                        break;
                     }
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        selected_index = selected_index.saturating_sub(1);
+                    }
+                    KeyCode::Down | KeyCode::Char('j')
+                        if selected_index < branch_statuses.len() - 1 =>
+                    {
+                        selected_index += 1;
+                    }
+                    KeyCode::Char(' ') => {
+                        selected_branches[selected_index] = !selected_branches[selected_index];
+                    }
+                    KeyCode::Char('a') => {
+                        let select_all = next_bulk_selection_state(&selected_branches);
+                        selected_branches.fill(select_all);
+                    }
+                    KeyCode::Enter => {
+                        confirmed = true;
+                        break;
+                    }
+                    _ => {}
                 }
             }
         }
@@ -1732,13 +1732,21 @@ impl CleanupTui {
     }
 }
 
+#[allow(dead_code)] // Placeholder TUI shipped for the v0.3.1 config editor; not yet wired into bin.
 pub struct ConfigTui;
+
+impl Default for ConfigTui {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl ConfigTui {
     pub fn new() -> Self {
         Self
     }
 
+    #[allow(dead_code)] // Wired up when the v0.3.1 config editor lands.
     pub fn run(&self) -> Result<()> {
         println!("⚙️ Configuration Editor");
         println!("=======================");

--- a/tests/integration/cow_git_integration_tests.rs
+++ b/tests/integration/cow_git_integration_tests.rs
@@ -35,7 +35,7 @@ fn test_cow_clone_with_git_worktree_registration() {
 
             // Use git worktree add with existing directory
             let result = Command::new("git")
-                .args(&[
+                .args([
                     "worktree",
                     "add",
                     "--detach",
@@ -49,7 +49,7 @@ fn test_cow_clone_with_git_worktree_registration() {
                     if output.status.success() {
                         // Now create and checkout the branch
                         Command::new("git")
-                            .args(&["checkout", "-b", branch_name])
+                            .args(["checkout", "-b", branch_name])
                             .current_dir(&worktree_path)
                             .output()
                             .unwrap();
@@ -63,13 +63,13 @@ fn test_cow_clone_with_git_worktree_registration() {
                         fs::write(worktree_path.join("feature.txt"), "CoW feature").unwrap();
 
                         Command::new("git")
-                            .args(&["add", "."])
+                            .args(["add", "."])
                             .current_dir(&worktree_path)
                             .output()
                             .unwrap();
 
                         Command::new("git")
-                            .args(&["commit", "-m", "Add CoW feature"])
+                            .args(["commit", "-m", "Add CoW feature"])
                             .current_dir(&worktree_path)
                             .output()
                             .unwrap();
@@ -131,7 +131,7 @@ fn test_cow_with_path_rewriting() {
             assert!(original_script.contains(&repo_path.to_string_lossy().to_string()));
 
             // Apply path rewriting
-            let rewriter = PathRewriter::new(&repo_path, &clone_path);
+            let rewriter = PathRewriter::new(repo_path, &clone_path);
 
             let rewrite_result = rewriter.rewrite_paths();
             match rewrite_result {
@@ -170,7 +170,7 @@ fn test_cow_preserves_git_history() {
 
     // Get original git history
     let original_log = Command::new("git")
-        .args(&["log", "--oneline"])
+        .args(["log", "--oneline"])
         .current_dir(repo_path)
         .output()
         .unwrap();
@@ -186,7 +186,7 @@ fn test_cow_preserves_git_history() {
 
             // Get cloned git history
             let cloned_log = Command::new("git")
-                .args(&["log", "--oneline"])
+                .args(["log", "--oneline"])
                 .current_dir(&clone_path)
                 .output()
                 .unwrap();
@@ -198,26 +198,26 @@ fn test_cow_preserves_git_history() {
             fs::write(clone_path.join("new_file.txt"), "New content").unwrap();
 
             Command::new("git")
-                .args(&["add", "."])
+                .args(["add", "."])
                 .current_dir(&clone_path)
                 .output()
                 .unwrap();
 
             Command::new("git")
-                .args(&["commit", "-m", "Add new file in clone"])
+                .args(["commit", "-m", "Add new file in clone"])
                 .current_dir(&clone_path)
                 .output()
                 .unwrap();
 
             // Original should not have the new commit
             let new_original_log = Command::new("git")
-                .args(&["log", "--oneline"])
+                .args(["log", "--oneline"])
                 .current_dir(repo_path)
                 .output()
                 .unwrap();
 
             let new_cloned_log = Command::new("git")
-                .args(&["log", "--oneline"])
+                .args(["log", "--oneline"])
                 .current_dir(&clone_path)
                 .output()
                 .unwrap();
@@ -423,17 +423,17 @@ fn setup_git_repository() -> tempfile::TempDir {
     let repo_path = temp_dir.path();
 
     Command::new("git")
-        .args(&["init"])
+        .args(["init"])
         .current_dir(repo_path)
         .output()
         .unwrap();
     Command::new("git")
-        .args(&["config", "user.email", "test@example.com"])
+        .args(["config", "user.email", "test@example.com"])
         .current_dir(repo_path)
         .output()
         .unwrap();
     Command::new("git")
-        .args(&["config", "user.name", "Test User"])
+        .args(["config", "user.name", "Test User"])
         .current_dir(repo_path)
         .output()
         .unwrap();
@@ -442,12 +442,12 @@ fn setup_git_repository() -> tempfile::TempDir {
     fs::write(repo_path.join(".gitignore"), "node_modules/\n*.log\n").unwrap();
 
     Command::new("git")
-        .args(&["add", "."])
+        .args(["add", "."])
         .current_dir(repo_path)
         .output()
         .unwrap();
     Command::new("git")
-        .args(&["commit", "-m", "Initial commit"])
+        .args(["commit", "-m", "Initial commit"])
         .current_dir(repo_path)
         .output()
         .unwrap();
@@ -492,12 +492,12 @@ echo "Building in {}"
 
     // Add to git
     Command::new("git")
-        .args(&["add", "."])
+        .args(["add", "."])
         .current_dir(repo_path)
         .output()
         .unwrap();
     Command::new("git")
-        .args(&["commit", "-m", "Add configs"])
+        .args(["commit", "-m", "Add configs"])
         .current_dir(repo_path)
         .output()
         .unwrap();
@@ -517,12 +517,12 @@ fn setup_git_repository_with_history() -> tempfile::TempDir {
         )
         .unwrap();
         Command::new("git")
-            .args(&["add", "."])
+            .args(["add", "."])
             .current_dir(repo_path)
             .output()
             .unwrap();
         Command::new("git")
-            .args(&["commit", "-m", &format!("Commit {}", i)])
+            .args(["commit", "-m", &format!("Commit {}", i)])
             .current_dir(repo_path)
             .output()
             .unwrap();

--- a/tests/integration/full_workflow_tests.rs
+++ b/tests/integration/full_workflow_tests.rs
@@ -3,7 +3,6 @@ use git_warp::cow::clone_directory;
 use git_warp::git::GitRepository;
 use git_warp::process::ProcessManager;
 use std::fs;
-use std::path::Path;
 use std::process::Command;
 use tempfile::tempdir;
 
@@ -47,13 +46,13 @@ fn test_complete_worktree_creation_workflow() {
 
     // Commit the work
     Command::new("git")
-        .args(&["add", "."])
+        .args(["add", "."])
         .current_dir(&worktree_path)
         .output()
         .unwrap();
 
     Command::new("git")
-        .args(&["commit", "-m", "Add feature implementation"])
+        .args(["commit", "-m", "Add feature implementation"])
         .current_dir(&worktree_path)
         .output()
         .unwrap();
@@ -223,7 +222,7 @@ auto_fetch = false
     fs::write(&config_path, config_content).unwrap();
 
     // Test layered configuration loading
-    let manager = ConfigManager {
+    let _manager = ConfigManager {
         config: Config::default(),
         config_path: config_path.clone(),
     };
@@ -288,13 +287,13 @@ fn test_branch_analysis_and_cleanup_workflow() {
         .unwrap();
 
         Command::new("git")
-            .args(&["add", "."])
+            .args(["add", "."])
             .current_dir(&worktree_path)
             .output()
             .unwrap();
 
         Command::new("git")
-            .args(&["commit", "-m", &format!("Add content for {}", branch_name)])
+            .args(["commit", "-m", &format!("Add content for {}", branch_name)])
             .current_dir(&worktree_path)
             .output()
             .unwrap();
@@ -303,7 +302,7 @@ fn test_branch_analysis_and_cleanup_workflow() {
         if should_merge {
             std::env::set_current_dir(repo_path).unwrap();
             Command::new("git")
-                .args(&["merge", branch_name])
+                .args(["merge", branch_name])
                 .current_dir(repo_path)
                 .output()
                 .unwrap();
@@ -412,20 +411,20 @@ fn setup_test_repository() -> tempfile::TempDir {
 
     // Initialize git repo
     Command::new("git")
-        .args(&["init"])
+        .args(["init"])
         .current_dir(repo_path)
         .output()
         .unwrap();
 
     // Configure git
     Command::new("git")
-        .args(&["config", "user.email", "test@example.com"])
+        .args(["config", "user.email", "test@example.com"])
         .current_dir(repo_path)
         .output()
         .unwrap();
 
     Command::new("git")
-        .args(&["config", "user.name", "Test User"])
+        .args(["config", "user.name", "Test User"])
         .current_dir(repo_path)
         .output()
         .unwrap();
@@ -439,13 +438,13 @@ fn setup_test_repository() -> tempfile::TempDir {
     .unwrap();
 
     Command::new("git")
-        .args(&["add", "."])
+        .args(["add", "."])
         .current_dir(repo_path)
         .output()
         .unwrap();
 
     Command::new("git")
-        .args(&["commit", "-m", "Initial commit"])
+        .args(["commit", "-m", "Initial commit"])
         .current_dir(repo_path)
         .output()
         .unwrap();
@@ -496,13 +495,13 @@ fn setup_test_repository_with_dependencies() -> tempfile::TempDir {
 
     // Commit the changes
     Command::new("git")
-        .args(&["add", "."])
+        .args(["add", "."])
         .current_dir(repo_path)
         .output()
         .unwrap();
 
     Command::new("git")
-        .args(&["commit", "-m", "Add dependencies"])
+        .args(["commit", "-m", "Add dependencies"])
         .current_dir(repo_path)
         .output()
         .unwrap();

--- a/tests/support.rs
+++ b/tests/support.rs
@@ -8,6 +8,12 @@ pub struct CurrentDirGuard {
     original: PathBuf,
 }
 
+impl Default for CurrentDirGuard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CurrentDirGuard {
     pub fn new() -> Self {
         let lock = CURRENT_DIR_LOCK

--- a/tests/unit/agents_tests.rs
+++ b/tests/unit/agents_tests.rs
@@ -343,7 +343,7 @@ fn test_discover_merges_live_row_with_newest_of_multiple_history_rows() {
     let live_status = worktree_root.join(".codex").join("git-warp").join("status");
     let codex_sessions = temp_home.path().join(".codex").join("sessions");
 
-    fs::create_dir_all(&live_status.parent().unwrap()).unwrap();
+    fs::create_dir_all(live_status.parent().unwrap()).unwrap();
     fs::create_dir_all(&codex_sessions).unwrap();
 
     fs::write(
@@ -401,7 +401,7 @@ fn test_discover_merges_live_row_deterministically_on_equal_history_timestamps()
     let live_status = worktree_root.join(".codex").join("git-warp").join("status");
     let codex_sessions = temp_home.path().join(".codex").join("sessions");
 
-    fs::create_dir_all(&live_status.parent().unwrap()).unwrap();
+    fs::create_dir_all(live_status.parent().unwrap()).unwrap();
     fs::create_dir_all(&codex_sessions).unwrap();
 
     fs::write(
@@ -458,7 +458,7 @@ fn test_discover_keeps_live_row_even_when_older_than_cutoff() {
     let worktree_root = repo_root.path().join(".worktrees").join("feat");
     let live_status = worktree_root.join(".codex").join("git-warp").join("status");
 
-    fs::create_dir_all(&live_status.parent().unwrap()).unwrap();
+    fs::create_dir_all(live_status.parent().unwrap()).unwrap();
     fs::write(
         &live_status,
         r#"{"status":"working","last_activity":"2026-04-10T10:00:00+00:00"}"#,

--- a/tests/unit/config_tests.rs
+++ b/tests/unit/config_tests.rs
@@ -98,9 +98,11 @@ fn test_config_save_and_load() {
     let temp_dir = tempdir().unwrap();
     let config_path = temp_dir.path().join("config.toml");
 
-    let mut config = Config::default();
-    config.terminal_mode = "window".to_string();
-    config.use_cow = false;
+    let config = Config {
+        terminal_mode: "window".to_string(),
+        use_cow: false,
+        ..Config::default()
+    };
 
     let manager = ConfigManager {
         config: config.clone(),

--- a/tests/unit/git_tests.rs
+++ b/tests/unit/git_tests.rs
@@ -14,20 +14,20 @@ fn setup_test_repo_with_initial_branch(initial_branch: &str) -> tempfile::TempDi
 
     // Initialize git repo
     Command::new("git")
-        .args(&["init", "--initial-branch", initial_branch])
+        .args(["init", "--initial-branch", initial_branch])
         .current_dir(repo_path)
         .output()
         .unwrap();
 
     // Configure git
     Command::new("git")
-        .args(&["config", "user.email", "test@example.com"])
+        .args(["config", "user.email", "test@example.com"])
         .current_dir(repo_path)
         .output()
         .unwrap();
 
     Command::new("git")
-        .args(&["config", "user.name", "Test User"])
+        .args(["config", "user.name", "Test User"])
         .current_dir(repo_path)
         .output()
         .unwrap();
@@ -36,13 +36,13 @@ fn setup_test_repo_with_initial_branch(initial_branch: &str) -> tempfile::TempDi
     fs::write(repo_path.join("README.md"), "# Test Repository").unwrap();
 
     Command::new("git")
-        .args(&["add", "."])
+        .args(["add", "."])
         .current_dir(repo_path)
         .output()
         .unwrap();
 
     Command::new("git")
-        .args(&["commit", "-m", "Initial commit"])
+        .args(["commit", "-m", "Initial commit"])
         .current_dir(repo_path)
         .output()
         .unwrap();
@@ -142,7 +142,7 @@ fn test_cleanup_analysis_excludes_protected_branches() {
     let git_repo = GitRepository::find().unwrap();
 
     Command::new("git")
-        .args(&["branch", "develop"])
+        .args(["branch", "develop"])
         .current_dir(repo_path)
         .output()
         .unwrap();
@@ -173,7 +173,7 @@ fn test_cleanup_analysis_excludes_custom_protected_branches() {
     let git_repo = GitRepository::find().unwrap();
 
     Command::new("git")
-        .args(&["branch", "staging"])
+        .args(["branch", "staging"])
         .current_dir(repo_path)
         .output()
         .unwrap();
@@ -217,7 +217,7 @@ fn test_cleanup_analysis_reports_skipped_with_reasons() {
 
     // Protected branch worktree (default protected list contains "develop").
     Command::new("git")
-        .args(&["branch", "develop"])
+        .args(["branch", "develop"])
         .current_dir(repo_path)
         .output()
         .unwrap();
@@ -356,20 +356,20 @@ fn test_analyze_branches_for_cleanup() {
 
     // Create some branches
     Command::new("git")
-        .args(&["checkout", "-b", "feature-1"])
+        .args(["checkout", "-b", "feature-1"])
         .current_dir(repo_path)
         .output()
         .unwrap();
 
     Command::new("git")
-        .args(&["checkout", "-b", "feature-2"])
+        .args(["checkout", "-b", "feature-2"])
         .current_dir(repo_path)
         .output()
         .unwrap();
 
     // Go back to main
     Command::new("git")
-        .args(&["checkout", "main"])
+        .args(["checkout", "main"])
         .current_dir(repo_path)
         .output()
         .unwrap();
@@ -415,7 +415,7 @@ fn test_cleanup_analysis_uses_primary_worktree_branch_when_default_is_not_main()
     let git_repo = GitRepository::find().unwrap();
 
     Command::new("git")
-        .args(&["branch", "feature-done"])
+        .args(["branch", "feature-done"])
         .current_dir(repo_path)
         .output()
         .unwrap();
@@ -453,13 +453,13 @@ fn test_delete_branch() {
 
     // Create a branch
     Command::new("git")
-        .args(&["checkout", "-b", "test-branch"])
+        .args(["checkout", "-b", "test-branch"])
         .current_dir(repo_path)
         .output()
         .unwrap();
 
     Command::new("git")
-        .args(&["checkout", "main"])
+        .args(["checkout", "main"])
         .current_dir(repo_path)
         .output()
         .unwrap();
@@ -470,7 +470,7 @@ fn test_delete_branch() {
 
     // Verify branch is gone
     let output = Command::new("git")
-        .args(&["branch", "--list", "test-branch"])
+        .args(["branch", "--list", "test-branch"])
         .current_dir(repo_path)
         .output()
         .unwrap();
@@ -499,7 +499,7 @@ fn test_uncommitted_changes_detection() {
 
     // Stage the changes
     Command::new("git")
-        .args(&["add", "."])
+        .args(["add", "."])
         .current_dir(repo_path)
         .output()
         .unwrap();
@@ -509,7 +509,7 @@ fn test_uncommitted_changes_detection() {
 
     // Commit the changes
     Command::new("git")
-        .args(&["commit", "-m", "Add new file"])
+        .args(["commit", "-m", "Add new file"])
         .current_dir(repo_path)
         .output()
         .unwrap();
@@ -527,7 +527,7 @@ fn test_branch_merge_detection() {
 
     // Create a feature branch with some changes
     Command::new("git")
-        .args(&["checkout", "-b", "feature"])
+        .args(["checkout", "-b", "feature"])
         .current_dir(repo_path)
         .output()
         .unwrap();
@@ -535,26 +535,26 @@ fn test_branch_merge_detection() {
     fs::write(repo_path.join("feature.txt"), "Feature content").unwrap();
 
     Command::new("git")
-        .args(&["add", "."])
+        .args(["add", "."])
         .current_dir(repo_path)
         .output()
         .unwrap();
 
     Command::new("git")
-        .args(&["commit", "-m", "Add feature"])
+        .args(["commit", "-m", "Add feature"])
         .current_dir(repo_path)
         .output()
         .unwrap();
 
     // Go back to main and merge
     Command::new("git")
-        .args(&["checkout", "main"])
+        .args(["checkout", "main"])
         .current_dir(repo_path)
         .output()
         .unwrap();
 
     Command::new("git")
-        .args(&["merge", "feature"])
+        .args(["merge", "feature"])
         .current_dir(repo_path)
         .output()
         .unwrap();
@@ -567,7 +567,7 @@ fn test_branch_merge_detection() {
 
     // Test with non-merged branch
     Command::new("git")
-        .args(&["checkout", "-b", "unmerged"])
+        .args(["checkout", "-b", "unmerged"])
         .current_dir(repo_path)
         .output()
         .unwrap();
@@ -575,19 +575,19 @@ fn test_branch_merge_detection() {
     fs::write(repo_path.join("unmerged.txt"), "Unmerged content").unwrap();
 
     Command::new("git")
-        .args(&["add", "."])
+        .args(["add", "."])
         .current_dir(repo_path)
         .output()
         .unwrap();
 
     Command::new("git")
-        .args(&["commit", "-m", "Add unmerged feature"])
+        .args(["commit", "-m", "Add unmerged feature"])
         .current_dir(repo_path)
         .output()
         .unwrap();
 
     Command::new("git")
-        .args(&["checkout", "main"])
+        .args(["checkout", "main"])
         .current_dir(repo_path)
         .output()
         .unwrap();

--- a/tests/unit/process_tests.rs
+++ b/tests/unit/process_tests.rs
@@ -91,7 +91,7 @@ sleep 30
 
     // On some systems, the process might not be detected immediately
     if !sleep_processes.is_empty() {
-        assert!(sleep_processes.len() > 0);
+        assert!(!sleep_processes.is_empty());
         println!("Successfully detected running process in directory");
     } else {
         println!("Process detection test skipped (timing-dependent)");
@@ -105,7 +105,7 @@ fn test_process_termination() {
 
     let pid = child.id();
 
-    let mut manager = ProcessManager::new();
+    let manager = ProcessManager::new();
 
     // Create a mock ProcessInfo for the child process
     let process_info = ProcessInfo {

--- a/tests/unit/rewrite_tests.rs
+++ b/tests/unit/rewrite_tests.rs
@@ -1,6 +1,5 @@
 use git_warp::rewrite::PathRewriter;
 use std::fs;
-use std::path::Path;
 use tempfile::tempdir;
 
 const TWO_MIB: usize = 2 * 1024 * 1024;
@@ -10,7 +9,7 @@ fn test_path_rewriter_creation() {
     let src_dir = "/original/project";
     let dst_dir = "/cloned/project";
 
-    let rewriter = PathRewriter::new(src_dir, dst_dir);
+    let _rewriter = PathRewriter::new(src_dir, dst_dir);
 
     // PathRewriter should be created successfully
     println!("PathRewriter created for {} -> {}", src_dir, dst_dir);
@@ -399,7 +398,7 @@ vendor/
         ("package.json", false),
     ];
 
-    for (file_path, should_match) in test_files {
+    for (file_path, _should_match) in test_files {
         let full_path = dst_dir.join(file_path);
 
         if let Some(parent) = full_path.parent() {
@@ -605,7 +604,7 @@ fn test_binary_with_leading_text_not_rewritten() {
     let src_str = src_dir.to_string_lossy().into_owned();
     let mut content: Vec<u8> = format!("header={src_str}\n").into_bytes();
     // Trailing block of null bytes flips the binary heuristic.
-    content.extend(std::iter::repeat(0u8).take(64));
+    content.extend(std::iter::repeat_n(0u8, 64));
     let blob = dst_dir.join("blob.dat");
     fs::write(&blob, &content).unwrap();
 

--- a/tests/unit/terminal_tests.rs
+++ b/tests/unit/terminal_tests.rs
@@ -58,7 +58,7 @@ fn test_iterm2_detection() {
     if supported {
         // In a real test environment, we wouldn't actually execute these
         // but we can test that the script generation works
-        let temp_dir = tempdir().unwrap();
+        let _temp_dir = tempdir().unwrap();
 
         // Test that methods exist and can be called (dry run)
         println!("iTerm2 methods are callable");
@@ -116,7 +116,7 @@ fn test_terminal_commands_generation() {
 #[test]
 fn test_session_id_handling() {
     let session_id = Some("test-session-123");
-    let path = tempdir().unwrap().path().to_path_buf();
+    let _path = tempdir().unwrap().path().to_path_buf();
 
     // Test that session IDs are handled properly in method calls
     #[cfg(target_os = "macos")]
@@ -137,7 +137,7 @@ fn test_session_id_handling() {
 #[test]
 fn test_init_script_handling() {
     let init_script = Some("npm install && npm start");
-    let path = tempdir().unwrap().path().to_path_buf();
+    let _path = tempdir().unwrap().path().to_path_buf();
 
     #[cfg(target_os = "macos")]
     {
@@ -188,7 +188,7 @@ fn test_terminal_error_handling() {
 #[test]
 fn test_branch_name_in_session() {
     let branch_name = "feature/awesome-new-feature";
-    let path = tempdir().unwrap().path().to_path_buf();
+    let _path = tempdir().unwrap().path().to_path_buf();
 
     #[cfg(target_os = "macos")]
     {
@@ -210,7 +210,7 @@ fn test_branch_name_in_session() {
 
 #[test]
 fn test_terminal_modes() {
-    let path = tempdir().unwrap().path().to_path_buf();
+    let _path = tempdir().unwrap().path().to_path_buf();
 
     #[cfg(target_os = "macos")]
     {


### PR DESCRIPTION
## Summary

`cargo clippy --all-targets --locked` was reporting ~380 warnings against `origin/main` (705a812), so the CI clippy step from #59 stayed at the loose `--lib --bins --tests` form. This PR clears the backlog and tightens CI to enforce `-D warnings`, as called for in #62.

- Mechanical pass via `cargo clippy --fix --all-targets`: cleared `needless_borrows_for_generic_args` (150), `useless_conversion` (88), `collapsible_if`/`collapsible_match` (46), `needless_lifetimes` (12), `print_literal` (10), `bool_assert_comparison` (10), `new_without_default` (7), `implicit_saturating_sub` (4), and the `redundant_closure`/`manual_repeat_n`/`len_zero`/`unused_*` items.
- Manual pass on `dead_code` (33): deleted four unreachable wrappers (`Config::with_defaults`, `ConfigManager::get_mut`, `ConfigManager::show_sample_config`, `AgentsDashboard::monitor_worktree`); marked the rest with `#[allow(dead_code)]` plus a one-line reason where the surface is intentional (public helpers exercised only by integration tests/embedders, the gix `repo` handle held for lifetime, `ConfigTui` placeholder for the v0.3.1 editor, error variants in the public API).
- `should_implement_trait` on `TerminalMode::from_str`: kept the inherent `Option` return and added `#[allow(clippy::should_implement_trait)]` with a comment — switching to `FromStr` would change `.unwrap_or` semantics at five callsites for no real win.
- `field_reassign_with_default` in `tests/unit/config_tests.rs`: rewritten using a struct literal with `..Config::default()`.
- `.github/workflows/ci.yml`: clippy step is now `cargo clippy --all-targets --locked -- -D warnings`.

No production behavior changes — the only edits are lint-driven rewrites and `#[allow(...)]` annotations.

## Verification

Run from inside the worktree:

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --all-targets --locked -- -D warnings` — clean.
- `cargo build --all-targets --locked` — clean.
- `cargo test --locked` — 192/193 pass. The one failure is `unit::process_tests::test_signal_handling`, a pre-existing flake (also flakes on `origin/main`: 1 pass / 2 fails over three runs); it depends on bash's SIGTERM trap timing and isn't touched by this PR's diff.
- `git diff --check` — clean.

Closes #62.