### PR TITLE
fix(shell-config): include release-check in completion lists

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -152,6 +152,21 @@ pub enum Commands {
     },
 }
 
+fn public_subcommand_names() -> Vec<String> {
+    use clap::CommandFactory;
+    let mut names = Vec::new();
+    for sub in Cli::command().get_subcommands() {
+        if sub.is_hide_set() {
+            continue;
+        }
+        names.push(sub.get_name().to_string());
+        for alias in sub.get_all_aliases() {
+            names.push(alias.to_string());
+        }
+    }
+    names
+}
+
 enum DoctorShell {
     Known {
         name: &'static str,
@@ -2227,6 +2242,8 @@ impl Cli {
             })
             .unwrap_or_else(|| "bash".to_string());
 
+        let commands = public_subcommand_names().join(" ");
+
         match detected_shell.as_str() {
             "bash" => {
                 println!("# Add to ~/.bashrc");
@@ -2236,7 +2253,7 @@ impl Cli {
     local cur prev commands branches
     cur=\"${{COMP_WORDS[COMP_CWORD]}}\"
     prev=\"${{COMP_WORDS[COMP_CWORD-1]}}\"
-    commands=\"switch ls list cleanup config agents doctor hooks-install hooks-remove hooks-status shell-config\"
+    commands=\"{commands}\"
 
     if [[ \"$prev\" == \"switch\" ]]; then
         branches=\"$(warp __complete branches \"$cur\" 2>/dev/null)\"
@@ -2261,7 +2278,7 @@ complete -F _warp_completion warp"
 
 _warp_completion() {{
     local -a commands
-    commands=(switch ls list cleanup config agents doctor hooks-install hooks-remove hooks-status shell-config)
+    commands=({commands})
 
     if (( CURRENT == 2 )); then
         compadd -- \"${{commands[@]}}\"
@@ -2279,7 +2296,7 @@ compdef _warp_completion warp"
                 println!("    eval (warp --terminal echo $argv)");
                 println!("end");
                 println!(
-                    "complete -c warp -n '__fish_use_subcommand' -a 'switch ls list cleanup config agents doctor hooks-install hooks-remove hooks-status shell-config'
+                    "complete -c warp -n '__fish_use_subcommand' -a '{commands}'
 complete -c warp -n '__fish_use_subcommand' -f -a '(warp __complete branches (commandline -ct) 2>/dev/null)'
 complete -c warp -n '__fish_seen_subcommand_from switch' -f -a '(warp __complete branches (commandline -ct) 2>/dev/null)'"
                 );

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -911,6 +911,48 @@ fn test_shell_config_fish_outputs_branch_completion_for_root_and_switch() {
     assert!(stdout.contains("warp __complete branches (commandline -ct)"));
 }
 
+// Keep in sync with the public variants of `Commands` in src/cli.rs.
+// The binary builds the live list dynamically via clap::CommandFactory, so
+// adding a new public subcommand updates the rendered snippet automatically;
+// this constant exists so the test fails loudly if anyone hides a command,
+// renames one, or drops an alias without updating the test alongside the enum.
+const PUBLIC_SUBCOMMAND_NAMES: &[&str] = &[
+    "switch",
+    "ls",
+    "list",
+    "cleanup",
+    "config",
+    "agents",
+    "doctor",
+    "release-check",
+    "hooks-install",
+    "hooks-remove",
+    "hooks-status",
+    "shell-config",
+];
+
+#[test]
+fn test_shell_config_lists_every_public_subcommand() {
+    for shell in ["bash", "zsh", "fish"] {
+        let output = Command::new(env!("CARGO_BIN_EXE_warp"))
+            .args(["shell-config", shell])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "shell-config {shell} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for name in PUBLIC_SUBCOMMAND_NAMES {
+            assert!(
+                stdout.contains(name),
+                "shell-config {shell} snippet is missing subcommand `{name}`:\n{stdout}"
+            );
+        }
+    }
+}
+
 #[cfg(unix)]
 fn uninstall_script_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("uninstall.sh")


### PR DESCRIPTION
## Summary

`warp shell-config` was emitting Bash, Zsh, and Fish completion snippets whose hard-coded command list omitted `release-check` (shipped in v0.3.0, `src/cli.rs:103`). The list was also duplicated in three places, so every future top-level subcommand would have to remember to update each one.

- `handle_shell_config` now builds the command list once at runtime via `clap::CommandFactory::command()`, filtering hidden subcommands and including all aliases. The bash, zsh, and fish snippets interpolate `{commands}` into the same template structure, so adding a new public subcommand to the `Commands` enum updates all three shells automatically.
- New integration test `test_shell_config_lists_every_public_subcommand` asserts every public subcommand name (including the `ls`/`list` alias and `release-check`) appears in each rendered snippet. The expected list is hardcoded in the test and a comment ties it back to `Commands` in `src/cli.rs`, so renames/hides will fail loudly.

## Verification

Run from inside the worktree:

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --all-targets --locked -- -D warnings` — clean.
- `cargo test --locked --test mod -- integration::cli_surface_tests::test_shell_config` — all four tests pass (3 existing + 1 new).
- `./target/debug/warp shell-config bash | grep commands=` — list now reads `switch ls list cleanup config agents doctor release-check hooks-install hooks-remove hooks-status shell-config`.
- `git diff --check` — clean.

Closes #66