### PR TITLE
chore: drop "master" from app defaults in favor of "main"

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ warp cleanup --mode merged --kill
 warp cleanup --mode merged --force
 ```
 
-Protected branches default to `main`, `master`, and `develop`. Cleanup also
-checks for dirty worktrees and running processes before removing anything.
+Protected branches default to `main` and `develop`. Cleanup also checks for
+dirty worktrees and running processes before removing anything.
 
 ## Agent Session Dashboard
 
@@ -159,7 +159,7 @@ auto_confirm = false
 
 [git]
 default_branch = "main"
-protected_branches = ["main", "master", "develop"]
+protected_branches = ["main", "develop"]
 auto_fetch = true
 auto_prune = true
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -162,7 +162,7 @@ details for diagnostics.
 ## Cleanup
 
 Git-Warp analyzes worktrees before removal. Protected branches default to
-`main`, `master`, and `develop`.
+`main` and `develop`.
 
 ```bash
 warp cleanup --mode merged
@@ -249,7 +249,7 @@ auto_confirm = false
 
 [git]
 default_branch = "main"
-protected_branches = ["main", "master", "develop"]
+protected_branches = ["main", "develop"]
 auto_fetch = true
 auto_prune = true
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,7 +48,7 @@ pub struct Config {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GitConfig {
-    /// Default branch name (main, master, develop)
+    /// Default branch name (main, develop)
     #[serde(default = "default_main_branch")]
     pub default_branch: String,
 
@@ -137,11 +137,7 @@ fn default_main_branch() -> String {
 }
 
 fn default_protected_branches() -> Vec<String> {
-    vec![
-        "main".to_string(),
-        "master".to_string(),
-        "develop".to_string(),
-    ]
+    vec!["main".to_string(), "develop".to_string()]
 }
 
 fn default_kill_timeout() -> u64 {

--- a/src/git.rs
+++ b/src/git.rs
@@ -833,7 +833,7 @@ impl GitRepository {
             .unwrap_or_else(|| self.repo_path.clone())
     }
 
-    /// Get the main branch name (main or master)
+    /// Get the main branch name. Prefers `origin/HEAD`, falls back to `main`.
     pub fn get_main_branch(&self) -> Result<String> {
         use std::process::Command;
 
@@ -852,12 +852,7 @@ impl GitRepository {
             }
         }
 
-        // Fallback: check if main exists, otherwise use master
-        if self.branch_exists("main")? {
-            Ok("main".to_string())
-        } else {
-            Ok("master".to_string())
-        }
+        Ok("main".to_string())
     }
 
     /// Check if a directory has uncommitted changes

--- a/tests/unit/config_tests.rs
+++ b/tests/unit/config_tests.rs
@@ -11,10 +11,7 @@ fn test_config_defaults() {
     assert!(config.use_cow);
     assert!(!config.auto_confirm);
     assert_eq!(config.git.default_branch, "main");
-    assert_eq!(
-        config.git.protected_branches,
-        vec!["main", "master", "develop"]
-    );
+    assert_eq!(config.git.protected_branches, vec!["main", "develop"]);
     assert!(config.git.auto_fetch);
     assert!(config.git.auto_prune);
     assert!(config.process.check_processes);


### PR DESCRIPTION
## Summary
- Default `protected_branches` and the `get_main_branch` fallback both treat `master` as a first-class peer of `main`. Drop those refs so the app's defaults match where this repo (and most upstream repos) actually live now.
- `GitRepository::get_main_branch` still asks the remote for `origin/HEAD` first, so repos that genuinely use `master` will resolve correctly when the remote advertises it. Only the offline fallback changes from `master` to `main`.
- Users who want the old behavior can pin `protected_branches = ["main", "master", "develop"]` in their own `config.toml`.

## Files
- `src/config.rs` — list + comment
- `src/git.rs` — fallback in `get_main_branch`
- `tests/unit/config_tests.rs` — defaults assertion
- `README.md`, `docs/user-guide.md` — docs match new defaults

## Test plan
- [x] cargo test on macOS (194 passed)
- [ ] cargo test on Linux CI (will likely fail until #73 lands, since this branch is cut off pre-#73 `main`)

## Note
This was branched off `main` before #73 merged, so the Linux CI jobs will keep failing on the same pre-existing issues until #73 lands and this branch is rebased.