### PR TITLE
fix(cli): reject conflicting --kill and --no-kill in cleanup

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -76,7 +76,7 @@ pub enum Commands {
         #[arg(long)]
         kill: bool,
         /// Don't kill processes (override config)
-        #[arg(long)]
+        #[arg(long, conflicts_with = "kill")]
         no_kill: bool,
         /// Interactive mode
         #[arg(long, short)]

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -733,6 +733,29 @@ fn test_cleanup_uses_primary_branch_as_base_and_prints_candidate_reasons() {
 }
 
 #[test]
+fn test_cleanup_rejects_kill_and_no_kill_together() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+
+    let output = warp_command(repo_path)
+        .args(["cleanup", "--mode", "merged", "--kill", "--no-kill"])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit when --kill and --no-kill are combined; stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--kill") && stderr.contains("--no-kill"),
+        "stderr should mention both flags: {stderr}"
+    );
+}
+
+#[test]
 fn test_cleanup_dry_run_explains_candidates_and_skipped_reasons() {
     let temp_dir = setup_test_repo();
     let repo_path = temp_dir.path();


### PR DESCRIPTION
## Summary

`warp cleanup --kill --no-kill` previously parsed successfully and silently
hit the default "check but don't kill" branch in `handle_cleanup`, dropping
the explicit `--kill` on the floor with no diagnostic.

Add a clap `conflicts_with = "kill"` constraint to the `no_kill` flag so
the combination is rejected at parse time with clap's standard usage error
(non-zero exit, both flag names in the message).

## Files
- `src/cli.rs` — `#[arg(long, conflicts_with = "kill")]` on `no_kill`.
- `tests/integration/cli_surface_tests.rs` — new `test_cleanup_rejects_kill_and_no_kill_together` asserting non-zero exit and that stderr mentions both flags.

## Verification (ran on this branch)
- `cargo build --locked`
- `cargo test --locked --tests cleanup` (14 passed)
- `cargo test --locked test_cleanup_rejects_kill_and_no_kill_together` (1 passed)
- `cargo clippy --locked --all-targets -- -D warnings` (clean)
- `cargo test --locked` (194 passed; only failure is `unit::process_tests::test_signal_handling`, the pre-existing flake tracked in #70)
- `git diff --check`

Closes #67