### PR TITLE
fix(io): write hooks settings and config atomically

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use figment::{
 };
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
@@ -383,7 +383,7 @@ impl ConfigManager {
     }
 
     /// Save configuration to a specific path
-    fn save_config(&self, path: &PathBuf, config: &Config) -> Result<()> {
+    fn save_config(&self, path: &Path, config: &Config) -> Result<()> {
         // Create config directory if it doesn't exist
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
@@ -394,8 +394,10 @@ impl ConfigManager {
                 message: format!("Failed to serialize configuration: {}", e),
             })?;
 
-        fs::write(path, toml_content).map_err(|e| GitWarpError::ConfigError {
-            message: format!("Failed to write config file: {}", e),
+        crate::fs_atomic::write_atomic(path, toml_content.as_bytes()).map_err(|e| {
+            GitWarpError::ConfigError {
+                message: format!("Failed to write config file: {}", e),
+            }
         })?;
 
         Ok(())

--- a/src/fs_atomic.rs
+++ b/src/fs_atomic.rs
@@ -1,0 +1,134 @@
+//! Crash-safe file writes via temp-file + atomic rename.
+//!
+//! `std::fs::write` truncates before writing, so a crash or power loss
+//! between truncate and write leaves the destination empty. Use
+//! [`write_atomic`] when the target is user-owned configuration that may
+//! contain unrelated state we must not lose.
+
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::Path;
+use std::process;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Write `contents` to `path` atomically: write to a sibling temp file,
+/// `sync_all`, then rename over the target. On any failure before the
+/// rename, the original file is left untouched and the temp is removed.
+pub fn write_atomic(path: &Path, contents: &[u8]) -> io::Result<()> {
+    let parent = match path.parent() {
+        Some(p) if !p.as_os_str().is_empty() => p,
+        _ => Path::new("."),
+    };
+
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path has no file name"))?;
+
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tmp_name = format!(
+        "{}.tmp.{}.{}",
+        file_name.to_string_lossy(),
+        process::id(),
+        nanos
+    );
+    let tmp_path = parent.join(tmp_name);
+
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&tmp_path)?;
+
+    if let Err(e) = file.write_all(contents).and_then(|_| file.sync_all()) {
+        drop(file);
+        let _ = fs::remove_file(&tmp_path);
+        return Err(e);
+    }
+    drop(file);
+
+    if let Err(e) = fs::rename(&tmp_path, path) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(e);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn writes_new_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("settings.json");
+
+        write_atomic(&target, b"{\"a\":1}").unwrap();
+
+        assert_eq!(fs::read(&target).unwrap(), b"{\"a\":1}");
+    }
+
+    #[test]
+    fn overwrites_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("config.toml");
+        fs::write(&target, b"old").unwrap();
+
+        write_atomic(&target, b"new bytes").unwrap();
+
+        assert_eq!(fs::read(&target).unwrap(), b"new bytes");
+    }
+
+    #[test]
+    fn leaves_no_temp_sibling_on_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("settings.json");
+
+        write_atomic(&target, b"payload").unwrap();
+
+        let entries: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .collect();
+        assert_eq!(entries.len(), 1, "unexpected entries: {:?}", entries);
+        assert_eq!(entries[0], "settings.json");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn failure_preserves_original_and_cleans_temp() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("locked");
+        fs::create_dir(&parent).unwrap();
+        let target = parent.join("settings.json");
+        fs::write(&target, b"original").unwrap();
+
+        let mut perms = fs::metadata(&parent).unwrap().permissions();
+        perms.set_mode(0o500); // read+execute, no write
+        fs::set_permissions(&parent, perms).unwrap();
+
+        let err = write_atomic(&target, b"new").expect_err("expected write failure");
+        assert!(
+            matches!(err.kind(), io::ErrorKind::PermissionDenied),
+            "unexpected error: {err:?}"
+        );
+
+        // Restore perms so we can read and clean up.
+        let mut perms = fs::metadata(&parent).unwrap().permissions();
+        perms.set_mode(0o700);
+        fs::set_permissions(&parent, perms).unwrap();
+
+        assert_eq!(fs::read(&target).unwrap(), b"original");
+
+        let leftovers: Vec<_> = fs::read_dir(&parent)
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .filter(|n| n != "settings.json")
+            .collect();
+        assert!(leftovers.is_empty(), "stale temp files: {:?}", leftovers);
+    }
+}

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -483,7 +483,7 @@ impl HooksManager {
         }
 
         let content = serde_json::to_string_pretty(&settings)?;
-        fs::write(&settings_path, content)?;
+        crate::fs_atomic::write_atomic(&settings_path, content.as_bytes())?;
 
         println!(
             "{} hooks installed to: {}",
@@ -510,7 +510,7 @@ impl HooksManager {
         }
 
         let content = serde_json::to_string_pretty(&settings)?;
-        fs::write(&settings_path, content)?;
+        crate::fs_atomic::write_atomic(&settings_path, content.as_bytes())?;
 
         println!(
             "{} hooks removed from: {}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod agents;
 pub mod config;
 pub mod cow;
 pub mod error;
+pub mod fs_atomic;
 pub mod git;
 pub mod hooks;
 pub mod post_create;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod cli;
 mod config;
 mod cow;
 mod error;
+mod fs_atomic;
 mod git;
 mod hooks;
 mod post_create;


### PR DESCRIPTION
## Summary

Route the three at-risk `fs::write` call sites (`HooksManager::merge_hooks_into_settings`, `HooksManager::remove_hooks_from_settings`, `ConfigManager::save_config`) through a new `fs_atomic::write_atomic` helper. The old call sites truncated the destination before writing, so a crash or power loss between truncate and write wiped unrelated keys from user-owned `~/.claude/settings.json` and `~/.config/git-warp/config.toml`.

## What changed

- `src/fs_atomic.rs` — new `write_atomic(&Path, &[u8])`: writes a sibling `<file>.tmp.<pid>.<nanos>` opened `O_CREAT|O_EXCL`, calls `sync_all`, then `fs::rename` over the target. On any failure before rename the temp is removed and the original file is untouched. Inline tests cover new-file write, overwrite, no temp leftovers on success, and failure-preserves-original (chmod parent dir read-only, assert original bytes and no `.tmp.*` siblings remain).
- `src/hooks.rs` — `merge_hooks_into_settings` and `remove_hooks_from_settings` swap their `fs::write` for `write_atomic` on the rendered JSON.
- `src/config.rs` — `save_config` swaps `fs::write` for `write_atomic`; signature changed to `&Path` to satisfy `clippy::ptr_arg` (callers coerce via deref).
- `src/lib.rs` and `src/main.rs` register `mod fs_atomic;` so both the lib and bin crates see the helper.

No new runtime dependencies. `tempfile` stays a dev-dep; the temp file naming/cleanup is rolled by hand.

## Verification (ran on this branch)

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --locked -- -D warnings` — clean
- `cargo test --locked --lib fs_atomic` — 4/4 pass
- `cargo test --locked --lib hooks` — 12/12 pass (including `test_codex_merge_preserves_existing_hooks`, which exercises the rewritten merge path end-to-end)
- `cargo test --locked --tests config` — 17/17 pass (including `test_config_save_and_load`, which exercises `save_config`)
- `cargo test --locked` — 194/195 pass; the one failure is `unit::process_tests::test_signal_handling`, the pre-existing flake tracked in #70
- `git diff --check` — clean

Closes #68