### PR TITLE
fix(process): poll graceful exit and sync test SIGTERM readiness

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -1,6 +1,6 @@
 use crate::error::{GitWarpError, Result};
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use sysinfo::{ProcessRefreshKind, System};
 
 #[derive(Debug, Clone)]
@@ -170,22 +170,40 @@ impl ProcessManager {
 
             match graceful_result {
                 Ok(output) if output.status.success() => {
-                    // Wait for graceful shutdown
-                    std::thread::sleep(Duration::from_millis(2000));
+                    // Poll `kill -0 <pid>` until the process is gone or we hit
+                    // the grace budget. A fixed sleep would either rush a
+                    // legitimate slow exit into SIGKILL or block longer than
+                    // needed when SIGTERM is honored immediately.
+                    const POLL_INTERVAL: Duration = Duration::from_millis(50);
+                    const GRACEFUL_BUDGET: Duration = Duration::from_secs(10);
 
-                    // Check if process is still running
-                    let check_result = Command::new("kill").arg("-0").arg(pid.to_string()).output();
-
-                    match check_result {
-                        Ok(output) if output.status.success() => {
-                            // Process still running, force kill
-                            let force_result = Command::new("kill")
-                                .arg("-KILL")
-                                .arg(pid.to_string())
-                                .output();
-                            force_result.map(|o| o.status.success()).unwrap_or(false)
+                    let deadline = Instant::now() + GRACEFUL_BUDGET;
+                    let mut still_running = true;
+                    loop {
+                        let alive = Command::new("kill")
+                            .arg("-0")
+                            .arg(pid.to_string())
+                            .output()
+                            .map(|o| o.status.success())
+                            .unwrap_or(false);
+                        if !alive {
+                            still_running = false;
+                            break;
                         }
-                        _ => true, // Process gracefully terminated
+                        if Instant::now() >= deadline {
+                            break;
+                        }
+                        std::thread::sleep(POLL_INTERVAL);
+                    }
+
+                    if still_running {
+                        let force_result = Command::new("kill")
+                            .arg("-KILL")
+                            .arg(pid.to_string())
+                            .output();
+                        force_result.map(|o| o.status.success()).unwrap_or(false)
+                    } else {
+                        true
                     }
                 }
                 _ => {

--- a/tests/unit/process_tests.rs
+++ b/tests/unit/process_tests.rs
@@ -316,10 +316,15 @@ fn test_graceful_vs_force_termination() {
 #[cfg(unix)]
 #[test]
 fn test_signal_handling() {
-    // Start a process that handles SIGTERM
+    // The script touches `$1` as soon as its SIGTERM trap is installed so the
+    // test can wait for that readiness before delivering SIGTERM. Without the
+    // handshake the harness sometimes wins the race against bash startup,
+    // bash gets SIGTERM under the default disposition, and the assertion
+    // below sees a signal-killed exit instead of `exit 0`.
     let script_content = r#"#!/bin/bash
 child_pid=""
 trap 'test -n "$child_pid" && kill "$child_pid" 2>/dev/null; exit 0' TERM
+: > "$1"
 sleep 30 &
 child_pid=$!
 wait "$child_pid"
@@ -327,6 +332,7 @@ wait "$child_pid"
 
     let temp_dir = tempdir().unwrap();
     let script_path = temp_dir.path().join("signal_test.sh");
+    let ready_path = temp_dir.path().join("ready");
     fs::write(&script_path, script_content).unwrap();
 
     use std::os::unix::fs::PermissionsExt;
@@ -334,7 +340,23 @@ wait "$child_pid"
     perms.set_mode(0o755);
     fs::set_permissions(&script_path, perms).unwrap();
 
-    let mut child = Command::new("bash").arg(&script_path).spawn().unwrap();
+    let mut child = Command::new("bash")
+        .arg(&script_path)
+        .arg(&ready_path)
+        .spawn()
+        .unwrap();
+
+    // Wait for the script to install its trap; give up after a generous
+    // budget so a wedged spawn doesn't silently hang the suite.
+    let ready_deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while !ready_path.exists() {
+        if std::time::Instant::now() >= ready_deadline {
+            child.kill().ok();
+            child.wait().ok();
+            panic!("signal handler script never signaled readiness");
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
 
     let pid = child.id();
     let manager = ProcessManager::new();


### PR DESCRIPTION
## Summary

`cargo test --locked` on `origin/main` reliably fails on
`unit::process_tests::test_signal_handling`. Two root causes, one in
production code and one in the test harness, both addressed here.

The other tests #70 flagged —
`test_switch_latest_resolves_branch_from_recent_agent_session` and
`test_switch_waiting_resolves_branch_from_waiting_agent_session` — pass on
the current base (`origin/main` at `f517204`) both in isolation and as part
of the full suite. No change for those.

## What changed

- `src/process.rs` — `ProcessManager::terminate_single_process` previously
  slept a fixed `Duration::from_millis(2000)` between SIGTERM and a single
  `kill -0` liveness probe, then escalated to SIGKILL on any "still alive"
  reading. Replace that with a 50 ms-step poll loop that returns as soon as
  `kill -0` reports the PID gone and only escalates to SIGKILL after a 10 s
  total budget. The fall-through path for "initial SIGTERM did not succeed"
  is unchanged.
- `tests/unit/process_tests.rs` — `test_signal_handling` also had a
  startup race: the harness could deliver SIGTERM before `bash` reached its
  `trap ... TERM` line, so default disposition signal-killed bash and the
  `exit_status.code() == Some(0)` assertion failed. The script now takes a
  readiness path and `: > "$1"` immediately after installing the trap; the
  test polls for that marker (5 s budget) before calling
  `terminate_processes`.

No production-API change. No new dependencies. The two `tests/integration/cli_surface_tests.rs` tests #70 also flagged are not touched.

## Verification (ran on this branch)

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --locked -- -D warnings` — clean
- `cargo test --locked` — 195 passed, 0 failed
- `cargo test --locked test_signal_handling -- --test-threads=1` — 5/5 clean runs in a row
- `git diff --check` — clean

Closes #70