### PR TITLE
chore(cow): drop overlayfs placeholder on Linux

### DIFF
--- a/docs/implement-plan-v1.md
+++ b/docs/implement-plan-v1.md
@@ -146,15 +146,12 @@ This plan outlines the major phases to merge the concepts of `autowt` and `cowor
 
 **Goal:** Make the tool robust, well-documented, and available on more platforms.
 
-1.  **Linux CoW Support:**
-    *   Research and implement the `overlayfs` backend for Linux. This will be a significant feature requiring careful implementation of mounting and unmounting logic. This will likely involve more `nix` syscalls.
-
-2.  **Documentation & CI/CD:**
+1.  **Documentation & CI/CD:**
     *   Set up GitHub Actions for automated testing, linting (`clippy`), and formatting (`rustfmt`).
     *   Write comprehensive user documentation and guides.
     *   Generate and publish API documentation using `cargo doc`.
 
-3.  **Distribution:**
+2.  **Distribution:**
     *   Use `cargo-dist` or custom GitHub Actions to build and release binaries for macOS (x86_64, aarch64), Linux (x86_64, aarch64), and Windows.
     *   Create a Homebrew tap for easy installation on macOS.
 

--- a/docs/implement-plan-v2.md
+++ b/docs/implement-plan-v2.md
@@ -68,7 +68,6 @@ This plan is structured into six modules, which can be seen as sequential develo
     *   Implement `is_cow_supported()` which checks the filesystem type.
     *   Implement `clone_directory(src, dest)`. This function will contain the platform-specific logic:
         *   `#[cfg(target_os = "macos")]`: Use `nix::sys::stat::clonefile`.
-        *   `#[cfg(target_os = "linux")]`: Placeholder for future `overlayfs` implementation.
         *   The function will return a `Result` to indicate success, failure, or "unsupported".
 
 3.  **Implement `create` and `switch` Commands:**

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -171,6 +171,10 @@ match terminal_mode {
 
 ## Copy-on-Write Implementation
 
+CoW cloning runs on macOS/APFS only. On Linux, Windows, and any other platform,
+`is_cow_supported` returns `false` and worktree creation falls back to `git
+worktree add` without attempting a clone.
+
 ### APFS CoW Engine
 
 The CoW implementation leverages macOS APFS's native clonefile capability:

--- a/src/cow.rs
+++ b/src/cow.rs
@@ -9,14 +9,7 @@ pub fn is_cow_supported<P: AsRef<Path>>(path: P) -> Result<bool> {
         is_apfs(path)
     }
 
-    #[cfg(target_os = "linux")]
-    {
-        // TODO: Check for overlayfs support
-        let _ = path;
-        Ok(false)
-    }
-
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    #[cfg(not(target_os = "macos"))]
     {
         let _ = path;
         Ok(false)
@@ -40,14 +33,7 @@ pub fn clone_directory<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dest: Q) -> Resul
         clone_directory_apfs(src, dest)
     }
 
-    #[cfg(target_os = "linux")]
-    {
-        // TODO: Implement overlayfs cloning
-        let _ = dest;
-        Err(GitWarpError::CoWNotSupported.into())
-    }
-
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    #[cfg(not(target_os = "macos"))]
     {
         let _ = dest;
         Err(GitWarpError::CoWNotSupported.into())


### PR DESCRIPTION
## Summary

`src/cow.rs` had two `// TODO: ... overlayfs ...` placeholders under `cfg(target_os = "linux")` arms that have been in the tree since v0.1 and never moved. Those arms returned the same values as the catch-all `not(any(target_os = "macos", target_os = "linux"))` arm (`Ok(false)` / `Err(CoWNotSupported)`), so they added no behavior over the fallback. The `overlayfs` label is also wrong for a userland CLI — overlayfs needs mount privileges; the directly comparable Linux primitive is reflink. Issue #71 lists this as option 2: drop the placeholder rather than chase a reflink backend in the same PR.

What changed:

- `src/cow.rs`: replaced the three-armed `cfg` blocks in `is_cow_supported` and `clone_directory` with two arms (`macos` and `not(target_os = "macos")`). Removed both `// TODO: ... overlayfs ...` comments and the `let _ = path;` / `let _ = dest;` lines that only existed inside the now-deleted Linux arms.
- `docs/implement-plan-v1.md`: removed the "Linux CoW Support" bullet from Phase 4 and renumbered the remaining items.
- `docs/implement-plan-v2.md`: removed the `#[cfg(target_os = "linux")]` placeholder bullet under the CoW Abstraction list.
- `docs/technical-overview.md`: added one paragraph under "Copy-on-Write Implementation" noting that CoW runs on macOS/APFS only and Linux/Windows fall back to `git worktree add`.

Linux runtime behavior is unchanged: `is_cow_supported` returns `Ok(false)` and worktree creation falls back to `git worktree add`. `warp doctor` already prints `not available on this filesystem; Git-Warp will use git worktree add` via the same path, so its output is unchanged. README already scopes CoW to "macOS/APFS" and was not touched.

## Verification (ran on this branch)

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --locked -- -D warnings` — clean
- `cargo test --locked` — 195 passed, 0 failed
- `git diff --check` — clean
- `grep -rn overlayfs src/ docs/implement-plan-v1.md docs/implement-plan-v2.md` — no matches

Closes #71