### PR TITLE
feat(post-create): detect bun.lock (Bun 1.2+) lockfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ terminal handoff modes that print or send shell commands.
 
 `post_create.auto_install` controls whether Git-Warp runs the matching
 `<manager> install` after creating a new worktree. Lockfile detection order is
-`pnpm-lock.yaml` → `yarn.lock` → `bun.lockb` → `package-lock.json`; the first
+`pnpm-lock.yaml` → `yarn.lock` → `bun.lock` → `bun.lockb` → `package-lock.json`; the first
 match wins. Set `auto_install = false` (or
 `GIT_WARP_POST_CREATE_AUTO_INSTALL=false`) to skip the install step entirely.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -275,7 +275,7 @@ claude_hooks = true
 
 `post_create.auto_install` runs the matching `<manager> install` after Git-Warp
 creates a new worktree. Lockfile detection order is `pnpm-lock.yaml` →
-`yarn.lock` → `bun.lockb` → `package-lock.json`; the first match wins. Set
+`yarn.lock` → `bun.lock` → `bun.lockb` → `package-lock.json`; the first match wins. Set
 `auto_install = false` to skip the install step entirely.
 
 Environment variables override config file values:

--- a/src/post_create.rs
+++ b/src/post_create.rs
@@ -44,6 +44,7 @@ pub enum PostCreateSetupStatus {
 const LOCKFILES: &[(&str, PackageManager)] = &[
     ("pnpm-lock.yaml", PackageManager::Pnpm),
     ("yarn.lock", PackageManager::Yarn),
+    ("bun.lock", PackageManager::Bun),
     ("bun.lockb", PackageManager::Bun),
     ("package-lock.json", PackageManager::Npm),
 ];
@@ -272,6 +273,66 @@ mod tests {
         assert_eq!(
             status,
             PostCreateSetupStatus::Installed(PackageManager::Bun)
+        );
+    }
+
+    #[test]
+    fn test_runs_bun_when_text_bun_lockfile_present() {
+        let temp = tempdir().unwrap();
+        write_package_json(temp.path());
+        fs::write(temp.path().join("bun.lock"), "").unwrap();
+
+        let bin = temp.path().join("fake-bun");
+        let marker = temp.path().join("ran.txt");
+        write_marker_script(&bin, &marker);
+
+        let status = run_post_create_setup_with_resolver(
+            temp.path(),
+            true,
+            true,
+            resolver_for(PackageManager::Bun, bin),
+        );
+
+        assert_eq!(
+            status,
+            PostCreateSetupStatus::Installed(PackageManager::Bun)
+        );
+    }
+
+    #[test]
+    fn test_bun_text_lockfile_wins_over_legacy_binary() {
+        let temp = tempdir().unwrap();
+        write_package_json(temp.path());
+        fs::write(temp.path().join("bun.lock"), "").unwrap();
+        fs::write(temp.path().join("bun.lockb"), "").unwrap();
+
+        let bin = temp.path().join("fake-bun");
+        let marker = temp.path().join("ran.txt");
+        write_marker_script(&bin, &marker);
+
+        let status = run_post_create_setup_with_resolver(
+            temp.path(),
+            true,
+            true,
+            resolver_for(PackageManager::Bun, bin),
+        );
+
+        assert_eq!(
+            status,
+            PostCreateSetupStatus::Installed(PackageManager::Bun)
+        );
+
+        let bun_lock_pos = LOCKFILES
+            .iter()
+            .position(|(name, _)| *name == "bun.lock")
+            .expect("bun.lock present in LOCKFILES");
+        let bun_lockb_pos = LOCKFILES
+            .iter()
+            .position(|(name, _)| *name == "bun.lockb")
+            .expect("bun.lockb present in LOCKFILES");
+        assert!(
+            bun_lock_pos < bun_lockb_pos,
+            "bun.lock must be detected before bun.lockb"
         );
     }
 


### PR DESCRIPTION
## Summary

`run_post_create_setup` previously detected Bun only via the legacy binary
`bun.lockb`. Bun 1.2 (2025-01-21) writes the new text-format `bun.lock` by
default, so repos created with Bun 1.2+ hit `SkippedNoLockfile` even with
`post_create.auto_install = true`. This PR adds `bun.lock` to the detection
table, ordered before `bun.lockb` so the modern lockfile wins on transitional
repos that committed both.

What changed:

- `src/post_create.rs`: insert `("bun.lock", PackageManager::Bun)` into
  `LOCKFILES` immediately before the existing `bun.lockb` entry.
- `src/post_create.rs` tests: add `test_runs_bun_when_text_bun_lockfile_present`
  (mirrors the `bun.lockb` test) and `test_bun_text_lockfile_wins_over_legacy_binary`
  (both files present; also asserts `bun.lock` precedes `bun.lockb` in `LOCKFILES`).
- `README.md:200` and `docs/user-guide.md:278`: update the detection order line
  to `pnpm-lock.yaml → yarn.lock → bun.lock → bun.lockb → package-lock.json`.

No other call sites and no public API changed.

## Verification (ran on this branch)

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --locked -- -D warnings` — clean
- `cargo test --locked` — 195 passed, 0 failed
- `git diff --check` — clean

Closes #77