### PR TITLE
fix(install): verify release archive sha256 before extract

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -47,6 +47,20 @@ Install into another writable directory with `GIT_WARP_INSTALL_DIR`:
 curl -fsSL https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.sh | GIT_WARP_INSTALL_DIR=/usr/local/bin sh
 ```
 
+## Checksum Verification
+
+`install.sh` downloads the release archive's companion `.sha256` file from the
+same release and verifies the digest with `shasum -a 256 -c` (falling back to
+`sha256sum -c`) before extracting. A mismatch aborts the install with both the
+expected and actual digests printed on stderr.
+
+If you install from a private mirror that does not publish digests, opt out
+with:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.sh | GIT_WARP_SKIP_CHECKSUM=1 sh
+```
+
 ## Install A Specific Version
 
 The installer defaults to the latest documented release. Pin a version with

--- a/install.sh
+++ b/install.sh
@@ -118,6 +118,40 @@ download() {
   fi
 }
 
+verify_checksum() {
+  dir="$1"
+  archive_name="$2"
+
+  if [ "${GIT_WARP_SKIP_CHECKSUM:-0}" = "1" ]; then
+    echo "Skipping checksum verification (GIT_WARP_SKIP_CHECKSUM=1)"
+    return 0
+  fi
+
+  if command -v shasum >/dev/null 2>&1; then
+    checker="shasum -a 256 -c"
+    digester="shasum -a 256"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    checker="sha256sum -c"
+    digester="sha256sum"
+  else
+    echo "error: neither shasum nor sha256sum is available to verify ${archive_name}" >&2
+    cargo_fallback_hint
+    exit 1
+  fi
+
+  if ( cd "$dir" && $checker "${archive_name}.sha256" >/dev/null 2>&1 ); then
+    return 0
+  fi
+
+  expected="$(awk '{print $1; exit}' "${dir}/${archive_name}.sha256" 2>/dev/null)"
+  actual="$( ( cd "$dir" && $digester "$archive_name" ) | awk '{print $1; exit}')"
+  echo "error: checksum verification failed for ${archive_name}" >&2
+  echo "  expected: ${expected:-<missing>}" >&2
+  echo "  actual:   ${actual:-<unknown>}" >&2
+  cargo_fallback_hint
+  exit 1
+}
+
 target_triple() {
   os="$(uname -s)"
   arch="$(uname -m)"
@@ -151,6 +185,11 @@ install_from_binary() {
 
   echo "Downloading Git-Warp ${version} for ${target}"
   download "$url" "$archive"
+
+  if [ "${GIT_WARP_SKIP_CHECKSUM:-0}" != "1" ]; then
+    download "${url}.sha256" "${archive}.sha256"
+  fi
+  verify_checksum "$tmp_dir" "$asset"
 
   tar -xzf "$archive" -C "$tmp_dir" || fail "failed to extract ${archive}; the download may be incomplete or corrupt"
 

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -319,15 +319,26 @@ fi
     write_executable(
         &fake_bin.path().join("curl"),
         r#"#!/bin/sh
+url=""
 output=""
 while [ "$#" -gt 0 ]; do
-  if [ "$1" = "-o" ]; then
-    shift
-    output="$1"
-  fi
+  case "$1" in
+    -o) shift; output="$1" ;;
+    -O) shift; output="$1" ;;
+    http*|https*) url="$1" ;;
+  esac
   shift
 done
-printf fake > "$output"
+case "$url" in
+  *.sha256)
+    archive_name="${url##*/}"
+    archive_name="${archive_name%.sha256}"
+    printf 'b5d54c39e66671c9731b9f471e585d8262cd4f54963f0c93082d8dcf334d4c78  %s\n' "$archive_name" > "$output"
+    ;;
+  *)
+    printf fake > "$output"
+    ;;
+esac
 "#,
     );
     write_executable(
@@ -376,6 +387,146 @@ chmod 755 "$dest/warp"
         stdout.contains("Open a new terminal or run 'warp doctor' after updating PATH."),
         "{stdout}"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_installer_fails_on_checksum_mismatch() {
+    let fake_bin = tempdir().unwrap();
+    let home_dir = tempdir().unwrap();
+    let install_dir = tempdir().unwrap();
+
+    write_executable(
+        &fake_bin.path().join("uname"),
+        r#"#!/bin/sh
+if [ "$1" = "-s" ]; then
+  echo Linux
+else
+  echo x86_64
+fi
+"#,
+    );
+    write_executable(
+        &fake_bin.path().join("curl"),
+        r#"#!/bin/sh
+url=""
+output=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) shift; output="$1" ;;
+    -O) shift; output="$1" ;;
+    http*|https*) url="$1" ;;
+  esac
+  shift
+done
+case "$url" in
+  *.sha256)
+    archive_name="${url##*/}"
+    archive_name="${archive_name%.sha256}"
+    printf '0000000000000000000000000000000000000000000000000000000000000000  %s\n' "$archive_name" > "$output"
+    ;;
+  *)
+    printf fake > "$output"
+    ;;
+esac
+"#,
+    );
+
+    let output = installer_command(fake_bin.path(), home_dir.path())
+        .env("GIT_WARP_INSTALL_DIR", install_dir.path())
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success(), "{stderr}");
+    assert!(
+        stderr.contains(
+            "checksum verification failed for git-warp-v9.9.9-x86_64-unknown-linux-gnu.tar.gz"
+        ),
+        "{stderr}"
+    );
+    assert!(
+        stderr
+            .contains("expected: 0000000000000000000000000000000000000000000000000000000000000000"),
+        "{stderr}"
+    );
+    assert!(
+        stderr
+            .contains("actual:   b5d54c39e66671c9731b9f471e585d8262cd4f54963f0c93082d8dcf334d4c78"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("GIT_WARP_INSTALL_METHOD=cargo"), "{stderr}");
+    assert!(
+        !install_dir.path().join("warp").exists(),
+        "warp binary should not be installed on checksum mismatch"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_installer_skips_checksum_when_opted_out() {
+    let fake_bin = tempdir().unwrap();
+    let home_dir = tempdir().unwrap();
+    let install_dir = tempdir().unwrap();
+
+    write_executable(
+        &fake_bin.path().join("uname"),
+        r#"#!/bin/sh
+if [ "$1" = "-s" ]; then
+  echo Linux
+else
+  echo x86_64
+fi
+"#,
+    );
+    write_executable(
+        &fake_bin.path().join("curl"),
+        r#"#!/bin/sh
+output=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    output="$1"
+  fi
+  shift
+done
+printf fake > "$output"
+"#,
+    );
+    write_executable(
+        &fake_bin.path().join("tar"),
+        r#"#!/bin/sh
+dest=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-C" ]; then
+    shift
+    dest="$1"
+  fi
+  shift
+done
+cat > "$dest/warp" <<'SCRIPT'
+#!/bin/sh
+echo warp 9.9.9
+SCRIPT
+chmod 755 "$dest/warp"
+"#,
+    );
+
+    let output = installer_command(fake_bin.path(), home_dir.path())
+        .env("GIT_WARP_INSTALL_DIR", install_dir.path())
+        .env("GIT_WARP_SKIP_CHECKSUM", "1")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "{stdout}{stderr}");
+    assert!(
+        stdout.contains("Skipping checksum verification"),
+        "{stdout}"
+    );
+    assert!(!stderr.contains("checksum verification failed"), "{stderr}");
+    assert!(install_dir.path().join("warp").exists());
 }
 
 #[test]
@@ -1014,15 +1165,26 @@ fi
     write_executable(
         &fake_bin.path().join("curl"),
         r#"#!/bin/sh
+url=""
 output=""
 while [ "$#" -gt 0 ]; do
-  if [ "$1" = "-o" ]; then
-    shift
-    output="$1"
-  fi
+  case "$1" in
+    -o) shift; output="$1" ;;
+    -O) shift; output="$1" ;;
+    http*|https*) url="$1" ;;
+  esac
   shift
 done
-printf fake > "$output"
+case "$url" in
+  *.sha256)
+    archive_name="${url##*/}"
+    archive_name="${archive_name%.sha256}"
+    printf 'b5d54c39e66671c9731b9f471e585d8262cd4f54963f0c93082d8dcf334d4c78  %s\n' "$archive_name" > "$output"
+    ;;
+  *)
+    printf fake > "$output"
+    ;;
+esac
 "#,
     );
     write_executable(
@@ -1091,15 +1253,26 @@ fi
     write_executable(
         &fake_bin.path().join("curl"),
         r#"#!/bin/sh
+url=""
 output=""
 while [ "$#" -gt 0 ]; do
-  if [ "$1" = "-o" ]; then
-    shift
-    output="$1"
-  fi
+  case "$1" in
+    -o) shift; output="$1" ;;
+    -O) shift; output="$1" ;;
+    http*|https*) url="$1" ;;
+  esac
   shift
 done
-printf fake > "$output"
+case "$url" in
+  *.sha256)
+    archive_name="${url##*/}"
+    archive_name="${archive_name%.sha256}"
+    printf 'b5d54c39e66671c9731b9f471e585d8262cd4f54963f0c93082d8dcf334d4c78  %s\n' "$archive_name" > "$output"
+    ;;
+  *)
+    printf fake > "$output"
+    ;;
+esac
 "#,
     );
     write_executable(


### PR DESCRIPTION
## Summary

- `install.sh` now downloads the release tarball's companion `.sha256` from the same release and verifies the digest via `shasum -a 256 -c` (with `sha256sum -c` as a fallback) before `tar -xzf`. A mismatch aborts the install and prints both the expected and actual digests alongside the existing cargo fallback hint.
- `GIT_WARP_SKIP_CHECKSUM=1` opts out for private mirrors that do not publish digests; behavior is unchanged in that mode.
- `docs/install.md` gains a short "Checksum Verification" section covering the default behavior and the opt-out env.

The release workflow (`.github/workflows/release-binaries.yml`) already publishes the `<asset>.sha256` companion, so no release-side changes are needed.

## Verification

- `cargo test --locked` — 197 passed locally, including the three updated/new installer tests:
  - `test_installer_prints_actionable_path_guidance` (happy path; fake `curl` now also serves the matching `.sha256`)
  - `test_installer_fails_on_checksum_mismatch` (mismatch surfaces expected/actual digests and skips the `tar` extract)
  - `test_installer_skips_checksum_when_opted_out` (`GIT_WARP_SKIP_CHECKSUM=1` bypasses the digest fetch and check)
- `cargo clippy --all-targets --locked -- -D warnings` — clean
- `sh -n install.sh` — clean
- `git diff --check` — clean

Closes #78