### PR TITLE
fix(release-check): mirror CI fmt/clippy/test gates

### DIFF
--- a/docs/release-check.md
+++ b/docs/release-check.md
@@ -30,8 +30,9 @@ warp release-check --metadata-only --version v0.3.0
 After metadata passes, the full command runs:
 
 ```bash
-cargo fmt --check
-cargo test
+cargo fmt --all -- --check
+cargo clippy --all-targets --locked -- -D warnings
+cargo test --locked
 cargo build --release --bin warp
 ./target/release/warp --version
 ./target/release/warp --help
@@ -39,6 +40,9 @@ cargo build --release --bin warp
 ./target/release/warp cleanup --help
 ./target/release/warp doctor
 ```
+
+These mirror the gates in `.github/workflows/ci.yml`, so a tree that passes
+release-check stays green on CI.
 
 For source builds, this covers the contributor path. For public installs, the
 metadata checks cover the install script default, pinned install docs, release

--- a/src/release.rs
+++ b/src/release.rs
@@ -216,8 +216,24 @@ fn run_release_commands(repo_root: &Path, expected: &ReleaseVersion) -> Result<(
     let release_binary = release_binary.to_string_lossy().into_owned();
 
     let steps = [
-        ReleaseCommand::new("cargo fmt --check", "cargo", &["fmt", "--check"]),
-        ReleaseCommand::new("cargo test", "cargo", &["test"]),
+        ReleaseCommand::new(
+            "cargo fmt --all -- --check",
+            "cargo",
+            &["fmt", "--all", "--", "--check"],
+        ),
+        ReleaseCommand::new(
+            "cargo clippy --all-targets --locked -- -D warnings",
+            "cargo",
+            &[
+                "clippy",
+                "--all-targets",
+                "--locked",
+                "--",
+                "-D",
+                "warnings",
+            ],
+        ),
+        ReleaseCommand::new("cargo test --locked", "cargo", &["test", "--locked"]),
         ReleaseCommand::new(
             "cargo build --release --bin warp",
             "cargo",


### PR DESCRIPTION
## Summary

- `src/release.rs::run_release_commands` now runs the same three lint/format/test commands as `.github/workflows/ci.yml`, in CI order:
  - `cargo fmt --all -- --check` (was `cargo fmt --check`)
  - `cargo clippy --all-targets --locked -- -D warnings` (new; release-check skipped clippy entirely)
  - `cargo test --locked` (was `cargo test`)
- The release-build and binary smoke steps (`--version`, `--help`, `switch --help`, `cleanup --help`, `doctor`) stay unchanged.
- `docs/release-check.md` Full Verification block now lists the same commands and notes that they mirror `.github/workflows/ci.yml`.

Closes #79.

## Verification

Ran in the worktree against this branch:

- `cargo clippy --all-targets --locked -- -D warnings` — clean.
- `cargo test --locked` — 197 passed, 0 failed.
- `rustfmt --check --edition 2024 src/release.rs` — clean.
- `git diff --check` — clean.

Notes: `cargo fmt --all -- --check` locally also flagged `src/post_create.rs:141`, but that line is pre-existing on `origin/main` (commit 80b8fb6, untouched by this PR) and reflects a local rustfmt vs CI-stable formatting drift. CI's `cargo fmt --all -- --check` step is green on `main`, so this PR leaves that file alone.