### PR TITLE
feat(config): wire process/git/agent runtime keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,12 @@ max_activities = 100
 claude_hooks = true
 ```
 
+`[git].auto_fetch`, `[git].auto_prune`, `[process].check_processes`,
+`[process].auto_kill`, `[process].kill_timeout`, `[agent].enabled`, and
+`[agent].refresh_rate` now drive runtime behavior — see `docs/user-guide.md`
+for the per-key semantics. `[process].auto_kill` defers to `--kill` /
+`--no-kill` when those flags are present (`--no-kill` always wins).
+
 Environment overrides use the `GIT_WARP_` prefix:
 
 ```bash

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -273,6 +273,17 @@ max_activities = 100
 claude_hooks = true
 ```
 
+`[git].auto_fetch` controls whether `warp cleanup` runs `git fetch --all --prune`
+before analysis. `[git].auto_prune` gates the `git worktree prune` call that
+follows worktree removal. `[process].check_processes` skips the "process-busy"
+preview and per-candidate process check when `false`; `[process].auto_kill`
+makes `warp cleanup` behave as if `--kill` was passed when neither `--kill` nor
+`--no-kill` is on the command line (`--no-kill` still wins).
+`[process].kill_timeout` is the SIGTERM grace period before Git-Warp escalates
+to SIGKILL. `[agent].enabled = false` short-circuits `warp agents` with a
+disabled banner; `[agent].refresh_rate` sets the dashboard poll interval in
+milliseconds (clamped to ≥ 250 ms).
+
 `post_create.auto_install` runs the matching `<manager> install` after Git-Warp
 creates a new worktree. Lockfile detection order is `pnpm-lock.yaml` →
 `yarn.lock` → `bun.lock` → `bun.lockb` → `package-lock.json`; the first match wins. Set

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -152,6 +152,16 @@ pub enum Commands {
     },
 }
 
+/// Resolve the effective kill behavior for cleanup. `--no-kill` always wins,
+/// matching the precedence established in #67 — explicit opt-out trumps any
+/// config-driven auto-kill.
+fn resolve_cleanup_kill(flag_kill: bool, flag_no_kill: bool, config_auto_kill: bool) -> bool {
+    if flag_no_kill {
+        return false;
+    }
+    flag_kill || config_auto_kill
+}
+
 fn public_subcommand_names() -> Vec<String> {
     use clap::CommandFactory;
     let mut names = Vec::new();
@@ -529,9 +539,11 @@ impl Cli {
     }
 
     fn handle_switcher_remove(&self, target: crate::tui::WorktreeRemovalTarget) -> Result<()> {
+        use crate::config::ConfigManager;
         use crate::git::GitRepository;
 
         let git_repo = GitRepository::find().map_err(|_| Self::not_in_git_repo_error())?;
+        let auto_prune = ConfigManager::new()?.get().git.auto_prune;
 
         println!(
             "Removing worktree for branch '{}'{}: {}",
@@ -553,7 +565,9 @@ impl Cli {
             }
         }
 
-        if let Err(err) = git_repo.prune_worktrees() {
+        if auto_prune
+            && let Err(err) = git_repo.prune_worktrees()
+        {
             log::warn!("Failed to prune worktrees: {}", err);
         }
 
@@ -561,9 +575,11 @@ impl Cli {
     }
 
     fn handle_switcher_batch_remove(&self, batch: crate::tui::WorktreeBatchRemoval) -> Result<()> {
+        use crate::config::ConfigManager;
         use crate::git::GitRepository;
 
         let git_repo = GitRepository::find().map_err(|_| Self::not_in_git_repo_error())?;
+        let auto_prune = ConfigManager::new()?.get().git.auto_prune;
 
         println!(
             "Batch removing {} selected worktree{}",
@@ -628,7 +644,9 @@ impl Cli {
             }
         }
 
-        if let Err(err) = git_repo.prune_worktrees() {
+        if auto_prune
+            && let Err(err) = git_repo.prune_worktrees()
+        {
             log::warn!("Failed to prune worktrees: {}", err);
         }
 
@@ -1267,17 +1285,23 @@ impl Cli {
 
         let git_repo = GitRepository::find().map_err(|_| Self::not_in_git_repo_error())?;
         let config_manager = ConfigManager::new()?;
-        let git_config = config_manager.get().git.clone();
+        let config = config_manager.get().clone();
+        let git_config = config.git.clone();
+        let effective_kill = resolve_cleanup_kill(kill, no_kill, config.process.auto_kill);
+        let check_processes = config.process.check_processes;
+        let kill_timeout = std::time::Duration::from_secs(config.process.kill_timeout);
         let mut process_manager = ProcessManager::new();
 
         if self.dry_run {
             println!("🔎 Dry run: previewing cleanup with mode: {}", mode);
-        } else {
+        } else if config.git.auto_fetch {
             // Fetch latest changes for accurate analysis
             println!("🔄 Fetching latest changes...");
             if !git_repo.fetch_branches()? {
                 println!("⚠️  Fetch failed, analysis may be outdated");
             }
+        } else {
+            println!("ℹ️  Skipping fetch (git.auto_fetch=false); analysis uses local refs only.");
         }
 
         let worktrees = git_repo.list_worktrees()?;
@@ -1383,13 +1407,17 @@ impl Cli {
             } else {
                 "clean"
             };
-            let busy = match process_manager.has_processes_in_directory(&candidate.path) {
-                Ok(true) => {
-                    process_busy.push(candidate.branch.clone());
-                    "; process-busy"
+            let busy = if check_processes {
+                match process_manager.has_processes_in_directory(&candidate.path) {
+                    Ok(true) => {
+                        process_busy.push(candidate.branch.clone());
+                        "; process-busy"
+                    }
+                    Ok(false) => "",
+                    Err(_) => "",
                 }
-                Ok(false) => "",
-                Err(_) => "",
+            } else {
+                ""
             };
             println!(
                 "  • {} at {} [{}; {}; {}{}]",
@@ -1401,7 +1429,7 @@ impl Cli {
                 busy,
             );
         }
-        if !process_busy.is_empty() && !force && !kill {
+        if !process_busy.is_empty() && !force && !effective_kill {
             println!(
                 "💡 {} candidate(s) have running processes. Use --kill to terminate or --force to ignore.",
                 process_busy.len()
@@ -1462,12 +1490,16 @@ impl Cli {
             println!("🗑️  Removing worktree: {}", candidate.branch);
 
             // Handle process management
-            if kill && !no_kill {
+            if effective_kill && check_processes {
                 println!("🔍 Checking for processes in worktree...");
                 match process_manager.find_processes_in_directory(&candidate.path) {
                     Ok(processes) if !processes.is_empty() => {
                         println!("⚠️  Found {} processes in worktree", processes.len());
-                        if !process_manager.terminate_processes(&processes, self.auto_confirm)? {
+                        if !process_manager.terminate_processes(
+                            &processes,
+                            self.auto_confirm,
+                            kill_timeout,
+                        )? {
                             println!("❌ Failed to terminate processes, skipping worktree");
                             failed += 1;
                             continue;
@@ -1480,7 +1512,7 @@ impl Cli {
                         println!("⚠️  Failed to check processes: {}", e);
                     }
                 }
-            } else if !no_kill {
+            } else if !no_kill && check_processes {
                 // Default behavior - check for processes but don't auto-kill
                 match process_manager.has_processes_in_directory(&candidate.path) {
                     Ok(true) => {
@@ -1537,7 +1569,9 @@ impl Cli {
         }
 
         // Prune stale worktree references
-        if let Err(e) = git_repo.prune_worktrees() {
+        if config.git.auto_prune
+            && let Err(e) = git_repo.prune_worktrees()
+        {
             log::warn!("Failed to prune worktrees: {}", e);
         }
 
@@ -2177,10 +2211,18 @@ impl Cli {
 
         let git_repo = GitRepository::find().map_err(|_| Self::not_in_git_repo_error())?;
         let config_manager = ConfigManager::new()?;
-        let dashboard = AgentsDashboard::new(AgentDiscovery::with_max_history_sessions(
-            Self::agent_monitored_paths(&git_repo)?,
-            config_manager.get().agent.max_activities,
-        ));
+        let agent_config = &config_manager.get().agent;
+        if !agent_config.enabled {
+            println!("🚫 Agent monitoring is disabled (agent.enabled=false in config).");
+            return Ok(());
+        }
+        let dashboard = AgentsDashboard::with_refresh_rate(
+            AgentDiscovery::with_max_history_sessions(
+                Self::agent_monitored_paths(&git_repo)?,
+                agent_config.max_activities,
+            ),
+            agent_config.refresh_rate,
+        );
         dashboard.run()
     }
 
@@ -2384,4 +2426,28 @@ fn worktree_last_touched(path: &Path) -> Option<SystemTime> {
         .into_iter()
         .flatten()
         .max()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_cleanup_kill_no_kill_flag_always_wins() {
+        assert!(!resolve_cleanup_kill(true, true, true));
+        assert!(!resolve_cleanup_kill(false, true, true));
+        assert!(!resolve_cleanup_kill(true, true, false));
+    }
+
+    #[test]
+    fn resolve_cleanup_kill_kill_flag_or_config_enables() {
+        assert!(resolve_cleanup_kill(true, false, false));
+        assert!(resolve_cleanup_kill(false, false, true));
+        assert!(resolve_cleanup_kill(true, false, true));
+    }
+
+    #[test]
+    fn resolve_cleanup_kill_default_is_off() {
+        assert!(!resolve_cleanup_kill(false, false, false));
+    }
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -96,6 +96,7 @@ impl ProcessManager {
         &self,
         processes: &[ProcessInfo],
         auto_confirm: bool,
+        kill_timeout: Duration,
     ) -> Result<bool> {
         if processes.is_empty() {
             return Ok(true);
@@ -114,7 +115,7 @@ impl ProcessManager {
         for process in processes {
             println!("🔪 Terminating PID {}: {}", process.pid, process.name);
 
-            if self.terminate_single_process(process.pid) {
+            if self.terminate_single_process(process.pid, kill_timeout) {
                 success_count += 1;
                 println!("  ✅ Terminated successfully");
             } else {
@@ -156,8 +157,10 @@ impl ProcessManager {
         Ok(input.trim().to_lowercase().starts_with('y'))
     }
 
-    /// Terminate a single process by PID with graceful fallback
-    fn terminate_single_process(&self, pid: u32) -> bool {
+    /// Terminate a single process by PID with graceful fallback.
+    /// `kill_timeout` caps the SIGTERM grace period; clamped to >= 100 ms.
+    fn terminate_single_process(&self, pid: u32, kill_timeout: Duration) -> bool {
+        let kill_timeout = kill_timeout.max(Duration::from_millis(100));
         #[cfg(unix)]
         {
             use std::process::Command;
@@ -175,9 +178,8 @@ impl ProcessManager {
                     // legitimate slow exit into SIGKILL or block longer than
                     // needed when SIGTERM is honored immediately.
                     const POLL_INTERVAL: Duration = Duration::from_millis(50);
-                    const GRACEFUL_BUDGET: Duration = Duration::from_secs(10);
 
-                    let deadline = Instant::now() + GRACEFUL_BUDGET;
+                    let deadline = Instant::now() + kill_timeout;
                     let mut still_running = true;
                     loop {
                         let alive = Command::new("kill")
@@ -219,6 +221,7 @@ impl ProcessManager {
 
         #[cfg(windows)]
         {
+            let _ = kill_timeout; // taskkill is immediate; timeout unused on Windows.
             use std::process::Command;
 
             let result = Command::new("taskkill")
@@ -232,6 +235,7 @@ impl ProcessManager {
 
         #[cfg(not(any(unix, windows)))]
         {
+            let _ = kill_timeout;
             false
         }
     }
@@ -267,6 +271,7 @@ impl ProcessManager {
         &mut self,
         path: P,
         auto_confirm: bool,
+        kill_timeout: Duration,
     ) -> Result<bool> {
         let processes = self.find_processes_in_directory(path)?;
 
@@ -275,7 +280,7 @@ impl ProcessManager {
             return Ok(true);
         }
 
-        self.terminate_processes(&processes, auto_confirm)
+        self.terminate_processes(&processes, auto_confirm, kill_timeout)
     }
 }
 
@@ -362,5 +367,37 @@ mod tests {
         assert_eq!(stats.total_memory, 3072);
         assert_eq!(stats.total_cpu, 20.0);
         assert_eq!(stats.high_cpu_count, 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn terminate_single_process_respects_kill_timeout() {
+        use std::process::Command as StdCommand;
+
+        // Spawn a child that ignores SIGTERM so we exercise the SIGKILL path
+        // gated on kill_timeout. `sh -c "trap '' TERM; sleep 30"` will only
+        // exit on SIGKILL.
+        let mut child = StdCommand::new("sh")
+            .args(["-c", "trap '' TERM; sleep 30"])
+            .spawn()
+            .expect("spawn sleep child");
+        let pid = child.id();
+
+        let manager = ProcessManager::new();
+        let start = Instant::now();
+        let ok = manager.terminate_single_process(pid, Duration::from_millis(200));
+        let elapsed = start.elapsed();
+
+        assert!(ok, "terminate_single_process should report success");
+        // SIGTERM grace is 200 ms; total wall time must be well under the
+        // 30 s sleep. Cap generously to avoid CI flake.
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "expected fast SIGKILL fallback, took {:?}",
+            elapsed
+        );
+
+        // Reap the child so it doesn't leak as a zombie.
+        let _ = child.wait();
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -28,7 +28,15 @@ use std::{
     time::{Duration, Instant, SystemTime},
 };
 
-const REFRESH_INTERVAL: Duration = Duration::from_secs(2);
+/// Minimum allowed agent dashboard refresh interval. Faster than this and the
+/// dashboard churns the file system reading session state.
+const MIN_REFRESH_INTERVAL: Duration = Duration::from_millis(250);
+/// Fallback when the caller does not pass a configured refresh rate.
+const DEFAULT_REFRESH_INTERVAL: Duration = Duration::from_millis(1000);
+
+fn clamp_refresh_interval(refresh_rate_ms: u64) -> Duration {
+    Duration::from_millis(refresh_rate_ms).max(MIN_REFRESH_INTERVAL)
+}
 
 struct TuiTerminalGuard {
     active: bool,
@@ -352,6 +360,7 @@ pub struct TuiApp {
     should_quit: bool,
     selected_index: usize,
     last_refresh: Instant,
+    refresh_interval: Duration,
     discovery: AgentDiscovery,
     sessions: Vec<AgentSessionSummary>,
     filters: DashboardFilters,
@@ -359,10 +368,16 @@ pub struct TuiApp {
 
 impl TuiApp {
     pub fn new(discovery: AgentDiscovery) -> Self {
+        Self::with_refresh_interval(discovery, DEFAULT_REFRESH_INTERVAL)
+    }
+
+    pub fn with_refresh_interval(discovery: AgentDiscovery, refresh_interval: Duration) -> Self {
+        let refresh_interval = refresh_interval.max(MIN_REFRESH_INTERVAL);
         Self {
             should_quit: false,
             selected_index: 0,
-            last_refresh: Instant::now() - REFRESH_INTERVAL,
+            last_refresh: Instant::now() - refresh_interval,
+            refresh_interval,
             discovery,
             sessions: Vec::new(),
             filters: DashboardFilters::default(),
@@ -409,7 +424,7 @@ impl TuiApp {
         terminal: &mut RatatuiTerminal<CrosstermBackend<io::Stdout>>,
     ) -> Result<()> {
         loop {
-            if self.last_refresh.elapsed() >= REFRESH_INTERVAL {
+            if self.last_refresh.elapsed() >= self.refresh_interval {
                 self.refresh_sessions()?;
             }
 
@@ -1106,15 +1121,27 @@ where
 
 pub struct AgentsDashboard {
     discovery: AgentDiscovery,
+    refresh_interval: Duration,
 }
 
 impl AgentsDashboard {
+    #[allow(dead_code)] // Default constructor used by integration tests and embedders.
     pub fn new(discovery: AgentDiscovery) -> Self {
-        Self { discovery }
+        Self {
+            discovery,
+            refresh_interval: DEFAULT_REFRESH_INTERVAL,
+        }
+    }
+
+    pub fn with_refresh_rate(discovery: AgentDiscovery, refresh_rate_ms: u64) -> Self {
+        Self {
+            discovery,
+            refresh_interval: clamp_refresh_interval(refresh_rate_ms),
+        }
     }
 
     pub fn run(&self) -> Result<()> {
-        let mut app = TuiApp::new(self.discovery.clone());
+        let mut app = TuiApp::with_refresh_interval(self.discovery.clone(), self.refresh_interval);
         app.run()
     }
 }
@@ -1772,6 +1799,20 @@ mod tests {
             AgentsDashboard::new(AgentDiscovery::new(vec![PathBuf::from("/tmp/repo")]));
         let _cleanup_tui = CleanupTui::new();
         let _config_tui = ConfigTui::new();
+    }
+
+    #[test]
+    fn clamp_refresh_interval_enforces_minimum() {
+        assert_eq!(clamp_refresh_interval(0), MIN_REFRESH_INTERVAL);
+        assert_eq!(clamp_refresh_interval(50), MIN_REFRESH_INTERVAL);
+        assert_eq!(clamp_refresh_interval(249), MIN_REFRESH_INTERVAL);
+    }
+
+    #[test]
+    fn clamp_refresh_interval_preserves_configured() {
+        assert_eq!(clamp_refresh_interval(250), Duration::from_millis(250));
+        assert_eq!(clamp_refresh_interval(1000), Duration::from_millis(1000));
+        assert_eq!(clamp_refresh_interval(5000), Duration::from_millis(5000));
     }
 
     #[test]

--- a/tests/unit/process_tests.rs
+++ b/tests/unit/process_tests.rs
@@ -119,7 +119,7 @@ fn test_process_termination() {
     };
 
     // Test termination
-    let result = manager.terminate_processes(&[process_info], true);
+    let result = manager.terminate_processes(&[process_info], true, Duration::from_secs(5));
 
     match result {
         Ok(success) => {
@@ -154,7 +154,7 @@ fn test_process_termination_nonexistent() {
         start_time: 0,
     };
 
-    let result = manager.terminate_processes(&[fake_process], true);
+    let result = manager.terminate_processes(&[fake_process], true, Duration::from_secs(5));
 
     // Should handle non-existent processes gracefully
     match result {
@@ -296,7 +296,7 @@ fn test_graceful_vs_force_termination() {
     };
 
     // Test auto-confirm termination (should use graceful then force)
-    let result = manager.terminate_processes(&[process_info], true);
+    let result = manager.terminate_processes(&[process_info], true, Duration::from_secs(5));
 
     match result {
         Ok(_) => {
@@ -371,7 +371,7 @@ wait "$child_pid"
         start_time: 0,
     };
 
-    let result = manager.terminate_processes(&[process_info], true);
+    let result = manager.terminate_processes(&[process_info], true, Duration::from_secs(5));
 
     match result {
         Ok(_) => {


### PR DESCRIPTION
## Summary

- `[process]`, `[git].auto_fetch` / `auto_prune`, and `[agent].enabled` / `[agent].refresh_rate` were printed by `warp config --show` and documented in `README.md` / `docs/user-guide.md`, but the bin never read them. They now drive runtime behavior.
- `process.kill_timeout` replaces the hardcoded 10 s SIGTERM grace in `terminate_single_process` (clamped to >= 100 ms). `process.auto_kill` resolves the cleanup kill flag when neither `--kill` nor `--no-kill` is on the CLI; `--no-kill` still wins (preserves #67).
- `process.check_processes = false` skips the "process-busy" preview and per-candidate check.
- `git.auto_fetch` gates the `git fetch --all --prune` call at the top of `warp cleanup`, and prints a one-line skip notice when disabled.
- `git.auto_prune` gates `git worktree prune` in cleanup and in the two switcher remove flows.
- `agent.enabled = false` short-circuits `warp agents` with a banner; the dashboard now uses `agent.refresh_rate` (clamped to >= 250 ms) instead of a 2 s constant.
- `README.md` and `docs/user-guide.md` get a short paragraph spelling out the new semantics. No structural doc rewrite.

Out of scope: `agent.claude_hooks` (the issue's suggested approach proposes no behavior to gate it on). Adding a `git fetch` to `warp switch` is mentioned in the issue but left to a follow-up.

Closes #82.

## Verification

Ran in this worktree:

- `cargo clippy --all-targets --locked -- -D warnings`: clean.
- `cargo test --locked`: 320 passed, 0 failed (lib 60, bin 63, integration 197).
- `git diff --check`: clean.

Notes: `cargo fmt --all -- --check` locally flags `src/post_create.rs:141` and the two new let-chains in `src/cli.rs`. The `post_create.rs` line is pre-existing on `origin/main` (commit 80b8fb6, untouched by this PR) and reflects the local-rustfmt vs CI-stable drift PR #96 already documented. The let-chain style in `src/cli.rs` matches existing multi-line let-chains already on `main` (for example `src/tui.rs:435`, `src/agents.rs:496`), so CI fmt accepts them.