### PR TITLE
fix(process): signal via nix instead of shelling out to kill

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,10 @@ version = "0.4.21"
 
 [dependencies.nix]
 version = "0.28.0"
-features = ["fs"]
+features = [
+    "fs",
+    "signal",
+]
 
 [dependencies.ratatui]
 version = "0.26.2"

--- a/Cargo.toml.orig
+++ b/Cargo.toml.orig
@@ -20,7 +20,7 @@ crossterm = "0.27.0"
 
 # Core Logic
 gix = "0.62.0"
-nix = { version = "0.28.0", features = ["fs"] }
+nix = { version = "0.28.0", features = ["fs", "signal"] }
 rayon = "1.10.0"
 ignore = "0.4.22"
 sysinfo = "0.30.12"

--- a/src/process.rs
+++ b/src/process.rs
@@ -163,58 +163,59 @@ impl ProcessManager {
         let kill_timeout = kill_timeout.max(Duration::from_millis(100));
         #[cfg(unix)]
         {
-            use std::process::Command;
+            use nix::errno::Errno;
+            use nix::sys::signal::{self, Signal};
+            use nix::unistd::Pid;
 
-            // Try graceful termination first (SIGTERM)
-            let graceful_result = Command::new("kill")
-                .arg("-TERM")
-                .arg(pid.to_string())
-                .output();
+            let nix_pid = Pid::from_raw(pid as i32);
 
-            match graceful_result {
-                Ok(output) if output.status.success() => {
-                    // Poll `kill -0 <pid>` until the process is gone or we hit
-                    // the grace budget. A fixed sleep would either rush a
-                    // legitimate slow exit into SIGKILL or block longer than
-                    // needed when SIGTERM is honored immediately.
-                    const POLL_INTERVAL: Duration = Duration::from_millis(50);
+            match signal::kill(nix_pid, Some(Signal::SIGTERM)) {
+                Ok(()) => {}
+                Err(Errno::ESRCH) => return true,
+                Err(Errno::EPERM) => {
+                    log::warn!("no permission to signal pid {pid}");
+                    return false;
+                }
+                Err(err) => {
+                    log::warn!("SIGTERM to pid {pid} failed: {err}");
+                }
+            }
 
-                    let deadline = Instant::now() + kill_timeout;
-                    let mut still_running = true;
-                    loop {
-                        let alive = Command::new("kill")
-                            .arg("-0")
-                            .arg(pid.to_string())
-                            .output()
-                            .map(|o| o.status.success())
-                            .unwrap_or(false);
-                        if !alive {
-                            still_running = false;
-                            break;
-                        }
-                        if Instant::now() >= deadline {
-                            break;
-                        }
-                        std::thread::sleep(POLL_INTERVAL);
+            // Poll the process with signal 0 until it exits or the grace
+            // budget expires. A fixed sleep would either rush a legitimate
+            // slow exit into SIGKILL or block longer than needed when SIGTERM
+            // is honored immediately.
+            const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+            let deadline = Instant::now() + kill_timeout;
+            let mut still_running = true;
+            loop {
+                match signal::kill(nix_pid, None) {
+                    Ok(()) => {}
+                    Err(Errno::ESRCH) => {
+                        still_running = false;
+                        break;
                     }
-
-                    if still_running {
-                        let force_result = Command::new("kill")
-                            .arg("-KILL")
-                            .arg(pid.to_string())
-                            .output();
-                        force_result.map(|o| o.status.success()).unwrap_or(false)
-                    } else {
-                        true
+                    Err(err) => {
+                        log::warn!("liveness probe for pid {pid} failed: {err}");
+                        break;
                     }
                 }
-                _ => {
-                    // Graceful termination failed, force kill immediately
-                    let force_result = Command::new("kill")
-                        .arg("-KILL")
-                        .arg(pid.to_string())
-                        .output();
-                    force_result.map(|o| o.status.success()).unwrap_or(false)
+                if Instant::now() >= deadline {
+                    break;
+                }
+                std::thread::sleep(POLL_INTERVAL);
+            }
+
+            if !still_running {
+                return true;
+            }
+
+            match signal::kill(nix_pid, Some(Signal::SIGKILL)) {
+                Ok(()) | Err(Errno::ESRCH) => true,
+                Err(err) => {
+                    log::warn!("SIGKILL to pid {pid} failed: {err}");
+                    false
                 }
             }
         }
@@ -367,6 +368,24 @@ mod tests {
         assert_eq!(stats.total_memory, 3072);
         assert_eq!(stats.total_cpu, 20.0);
         assert_eq!(stats.high_cpu_count, 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn terminate_single_process_handles_missing_pid() {
+        use std::process::Command as StdCommand;
+
+        // Spawn a short-lived child, wait for it to exit, then reap it. The
+        // resulting PID is guaranteed gone so signal::kill should report
+        // ESRCH, which the function maps to success.
+        let mut child = StdCommand::new("true").spawn().expect("spawn true");
+        let pid = child.id();
+        let _ = child.wait();
+
+        let manager = ProcessManager::new();
+        let ok = manager.terminate_single_process(pid, Duration::from_millis(200));
+
+        assert!(ok, "ESRCH should be treated as success");
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

Replace the three `Command::new("kill")` spawns in `ProcessManager::terminate_single_process` with `nix::sys::signal::kill`. SIGTERM, the signal-0 liveness probe, and SIGKILL all run in-process. ESRCH maps to success (the process is already gone); EPERM is logged and reported as failure. Other errnos log a warning and fall through to the next step.

Adds the `signal` feature to the existing `nix = "0.28.0"` dep in both `Cargo.toml.orig` and the generated `Cargo.toml`.

The Windows `taskkill` arm and the `cfg(not(any(unix, windows)))` arm are unchanged.

## Verification

Ran in the `83-nix-signal-kill` worktree:

- `cargo clippy --all-targets --locked -- -D warnings`: clean.
- `cargo test --locked`: 322 passed (lib 61, bin 64, integration 197).
- `git diff --check`: clean.

Added a Unix-only unit test `terminate_single_process_handles_missing_pid` that reaps a `true` child and asserts the function returns true for the already-gone PID.

`cargo fmt --all -- --check` only flags pre-existing let-chain drift in `src/cli.rs` and the `post_create.rs:141` line documented on `main`; my files are not in the diff.

Closes #83.