### PR TITLE
feat(doctor): verify git binary is on PATH

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1696,8 +1696,22 @@ impl Cli {
                 .push("Run `warp config --edit` to create and review your config.".to_string());
         }
 
+        match &repo {
+            Some(repo) => {
+                Self::doctor_ok("Git repository", repo.root_path().display().to_string());
+            }
+            None => {
+                Self::doctor_warn("Git repository", "not detected from current directory");
+                next_steps.push(
+                    "Run this command inside a Git repository before creating worktrees."
+                        .to_string(),
+                );
+            }
+        }
+
+        Self::report_doctor_git_binary(&mut next_steps);
+
         let worktree_base = if let Some(repo) = &repo {
-            Self::doctor_ok("Git repository", repo.root_path().display().to_string());
             let sample_worktree =
                 repo.get_worktree_path_with_base("doctor-check", config.worktrees_path.as_deref());
             let base = sample_worktree
@@ -1707,10 +1721,6 @@ impl Cli {
             Self::doctor_info("Worktree base path", base.display().to_string());
             base
         } else {
-            Self::doctor_warn("Git repository", "not detected from current directory");
-            next_steps.push(
-                "Run this command inside a Git repository before creating worktrees.".to_string(),
-            );
             config
                 .worktrees_path
                 .clone()
@@ -1807,6 +1817,53 @@ impl Cli {
             }
         }
         candidate
+    }
+
+    fn report_doctor_git_binary(next_steps: &mut Vec<String>) {
+        use std::io::ErrorKind;
+        use std::process::Command;
+
+        match Command::new("git").arg("--version").output() {
+            Ok(output) if output.status.success() => {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let line = stdout
+                    .lines()
+                    .next()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or("git --version reported no output");
+                Self::doctor_ok("Git binary", line);
+            }
+            Ok(output) => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let detail = stderr
+                    .lines()
+                    .next()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or("git --version exited with a non-zero status");
+                Self::doctor_warn("Git binary", format!("git --version failed: {detail}"));
+                next_steps.push(
+                    "Reinstall git so worktree, status, and diff commands keep working."
+                        .to_string(),
+                );
+            }
+            Err(error) if error.kind() == ErrorKind::NotFound => {
+                Self::doctor_warn("Git binary", "git not found on PATH");
+                next_steps.push(
+                    "Install git (https://git-scm.com/downloads) so warp can shell out to worktree, status, and diff commands."
+                        .to_string(),
+                );
+            }
+            Err(error) => {
+                Self::doctor_warn(
+                    "Git binary",
+                    format!("could not run git --version: {error}"),
+                );
+                next_steps
+                    .push("Repair the git installation so warp can shell out to git.".to_string());
+            }
+        }
     }
 
     fn report_doctor_install(next_steps: &mut Vec<String>) {

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -654,8 +654,37 @@ fn test_doctor_inside_repo_prints_repo_and_worktree_checks() {
     assert!(stdout.contains("Git-Warp Doctor"));
     assert!(stdout.contains("Git repository"));
     assert!(stdout.contains(temp_dir.path().to_string_lossy().as_ref()));
+    assert!(stdout.contains("Git binary"), "{stdout}");
+    assert!(stdout.contains("git version"), "{stdout}");
     assert!(stdout.contains("Worktree base path"));
     assert!(stdout.contains("Next steps"));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_doctor_reports_missing_git_binary_when_not_on_path() {
+    let temp_dir = setup_test_repo();
+    let home_dir = tempdir().unwrap();
+    let empty_path_dir = tempdir().unwrap();
+
+    let output = warp_command(temp_dir.path())
+        .env("HOME", home_dir.path())
+        .env("XDG_CONFIG_HOME", home_dir.path().join(".config"))
+        .env("PATH", empty_path_dir.path())
+        .env("GIT_WARP_DOCTOR_PROBE_DIRS", empty_path_dir.path())
+        .arg("doctor")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "{stdout}{stderr}");
+    assert!(stdout.contains("Git binary"), "{stdout}");
+    assert!(stdout.contains("git not found on PATH"), "{stdout}");
+    assert!(
+        stdout.contains("Install git (https://git-scm.com/downloads)"),
+        "{stdout}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`warp doctor` now runs `git --version` between the existing `Git repository` and `Worktree base path` rows. The result is surfaced as a `Git binary` line:

- success: the parsed version string (e.g. `git version 2.45.2`).
- spawn fails with `NotFound`: warn `git not found on PATH` and push an install hint to next steps.
- non-zero exit or other spawn error: warn with the captured detail and push a reinstall hint.

Almost every other warp command shells out to `git` (`worktree list/add/remove`, `merge-base`, `diff --quiet`, `status --porcelain`, `worktree prune`), so a missing binary previously surfaced as a late `No such file or directory (os error 2)` failure. Doctor now flags it up front.

## Verification

Ran in the `84-doctor-git-check` worktree:

- `cargo clippy --all-targets --locked -- -D warnings`: clean.
- `cargo test --locked`: 198 passed (no failures).
- `git diff --check`: clean.

Added `test_doctor_reports_missing_git_binary_when_not_on_path` (Unix-only) that overrides `PATH` to a tempdir with no `git` and asserts the warning + install hint appear. The existing `test_doctor_inside_repo_prints_repo_and_worktree_checks` now also asserts the `Git binary` / `git version` line is emitted on the happy path.

`cargo fmt --all -- --check` still flags the pre-existing let-chain drift in `src/cli.rs` (`auto_prune` blocks) and `src/post_create.rs:141` documented on `main`; the lines I added format cleanly.

Closes #84.