### PR TITLE
feat(git): support switching to tags and SHAs in warp switch

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -327,6 +327,11 @@ impl Cli {
                 "🌐 Creating worktree from remote branch '{}' (new local '{}' tracking it)",
                 remote_ref, branch
             ),
+            crate::git::BranchSource::CommitIsh { sha } => format!(
+                "🔖 Creating worktree at commit '{}' (new local branch '{}')",
+                &sha[..7],
+                branch
+            ),
             crate::git::BranchSource::NewBranch => {
                 format!("✨ Creating new branch '{}' from HEAD", branch)
             }
@@ -345,6 +350,13 @@ impl Cli {
                 "Source: remote branch '{}' (would create local '{}' tracking it)",
                 remote_ref, branch
             ),
+            crate::git::BranchSource::CommitIsh { sha } => {
+                format!(
+                    "Source: commit-ish '{}' (would create local branch '{}')",
+                    &sha[..7],
+                    branch
+                )
+            }
             crate::git::BranchSource::NewBranch => {
                 format!("Source: new branch '{}' from HEAD", branch)
             }

--- a/src/git.rs
+++ b/src/git.rs
@@ -69,6 +69,9 @@ pub enum BranchSource {
     LocalBranch,
     /// Branch only exists on the remote; a local tracking branch will be created.
     RemoteBranch { remote_ref: String },
+    /// Target is a commit-ish (tag, SHA) that isn't a local or remote branch;
+    /// a local branch will be created at this commit.
+    CommitIsh { sha: String },
     /// Neither local nor remote branch exists; a brand new branch will be created from HEAD.
     NewBranch,
 }
@@ -239,7 +242,34 @@ impl GitRepository {
         if let Some(remote_ref) = self.find_remote_branch_ref(branch_name)? {
             return Ok(BranchSource::RemoteBranch { remote_ref });
         }
+        if let Some(sha) = self.resolve_commit_ish(branch_name)? {
+            return Ok(BranchSource::CommitIsh { sha });
+        }
         Ok(BranchSource::NewBranch)
+    }
+
+    /// Resolve a name to a commit SHA if it is a valid commit-ish (tag, SHA, etc.)
+    pub fn resolve_commit_ish(&self, name: &str) -> Result<Option<String>> {
+        use std::process::Command;
+
+        let output = Command::new("git")
+            .args([
+                "rev-parse",
+                "--verify",
+                "--quiet",
+                &format!("{}^{{commit}}", name),
+            ])
+            .current_dir(&self.repo_path)
+            .output()
+            .map_err(|e| anyhow::anyhow!("Failed to resolve commit-ish: {}", e))?;
+
+        if output.status.success() {
+            Ok(Some(
+                String::from_utf8_lossy(&output.stdout).trim().to_string(),
+            ))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Locate the first remote that carries `branch_name`, returning the short ref
@@ -352,6 +382,24 @@ impl GitRepository {
                     let error = String::from_utf8_lossy(&output.stderr);
                     return Err(anyhow::anyhow!(
                         "Failed to create worktree from remote branch '{remote_ref}': {}",
+                        error
+                    ));
+                }
+                Ok(())
+            }
+            BranchSource::CommitIsh { sha } => {
+                let output = Command::new("git")
+                    .args(["worktree", "add", "-b", branch_name])
+                    .arg(worktree_path)
+                    .arg(sha)
+                    .current_dir(&self.repo_path)
+                    .output()
+                    .map_err(|e| anyhow::anyhow!("Failed to create worktree from commit-ish: {}", e))?;
+
+                if !output.status.success() {
+                    let error = String::from_utf8_lossy(&output.stderr);
+                    return Err(anyhow::anyhow!(
+                        "Failed to create worktree from commit-ish: {}",
                         error
                     ));
                 }

--- a/tests/integration/terminal_switch_tests.rs
+++ b/tests/integration/terminal_switch_tests.rs
@@ -135,6 +135,7 @@ fn write_config_with_terminal_options(
         format!(
             r#"
 terminal_mode = "{terminal_mode}"
+worktrees_path = ".worktrees"
 use_cow = false
 
 [terminal]
@@ -567,4 +568,125 @@ fn test_warp_switch_applescript_skips_activation_when_disabled() {
             && !osascript_contents.contains("\nactivate\n"),
         "did not expect activate command in AppleScript, got {osascript_contents}"
     );
+}
+
+#[test]
+fn test_warp_switch_to_tag_creates_branch_at_tag() {
+    let repo_dir = setup_git_repo();
+    let repo_path = repo_dir.path();
+    let home_dir = tempdir().unwrap();
+
+    write_config_with_terminal_options(home_dir.path(), "auto", "echo", true, &[]);
+
+    // 1. Create a commit and a tag
+    fs::write(repo_path.join("feature.txt"), "tag content").unwrap();
+    Command::new("git").args(["add", "."]).current_dir(repo_path).output().unwrap();
+    Command::new("git").args(["commit", "-m", "Feature commit"]).current_dir(repo_path).output().unwrap();
+
+    let rev_output = Command::new("git").args(["rev-parse", "HEAD"]).current_dir(repo_path).output().unwrap();
+    let tag_sha = String::from_utf8_lossy(&rev_output.stdout).trim().to_string();
+
+    Command::new("git").args(["tag", "v1.0.0-tag"]).current_dir(repo_path).output().unwrap();
+
+    // 2. Go back to main so HEAD is different from the tag
+    Command::new("git").args(["checkout", "-f", "main"]).current_dir(repo_path).output().unwrap();
+    fs::write(repo_path.join("README.md"), "# Updated README").unwrap();
+    Command::new("git").args(["add", "."]).current_dir(repo_path).output().unwrap();
+    Command::new("git").args(["commit", "-m", "Update main"]).current_dir(repo_path).output().unwrap();
+
+    // 3. Switch to the tag
+    let output = Command::new(env!("CARGO_BIN_EXE_warp"))
+        .args(["--terminal", "echo", "v1.0.0-tag"])
+        .current_dir(repo_path)
+        .env("HOME", home_dir.path())
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stdout={stdout}\nstderr={stderr}");
+
+    // 4. Extract the worktree path from stdout
+    // It's in a line like "✅ Switch complete: /path/to/worktree"
+    // or "⚠️  Switch incomplete: /path/to/worktree"
+    let worktree_path = stdout.lines()
+        .find(|line| line.contains("Switch complete:") || line.contains("Switch incomplete:"))
+        .map(|line| {
+            if line.contains("Switch complete: ") {
+                line.split("Switch complete: ").nth(1).unwrap().trim()
+            } else {
+                line.split("Switch incomplete: ").nth(1).unwrap().trim()
+            }
+        })
+        .map(PathBuf::from)
+        .expect("Could not find switch complete/incomplete path in stdout");
+
+    // 5. Verify the new worktree is at the tag's SHA
+    let wt_rev_output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(&worktree_path)
+        .output()
+        .unwrap();
+    let wt_sha = String::from_utf8_lossy(&wt_rev_output.stdout).trim().to_string();
+
+    assert_eq!(wt_sha, tag_sha, "Worktree at {} should be at SHA {}, but was at {}", worktree_path.display(), tag_sha, wt_sha);
+
+    // Also verify a branch named v1.0.0-tag was created
+    let branch_output = Command::new("git")
+        .args(["rev-parse", "--verify", "v1.0.0-tag"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    assert!(branch_output.status.success(), "Branch v1.0.0-tag should have been created");
+}
+
+#[test]
+fn test_warp_switch_to_sha_creates_branch_at_sha() {
+    let repo_dir = setup_git_repo();
+    let repo_path = repo_dir.path();
+    let home_dir = tempdir().unwrap();
+
+    write_config_with_terminal_options(home_dir.path(), "auto", "echo", true, &[]);
+
+    // 1. Create a commit
+    fs::write(repo_path.join("feature.txt"), "sha content").unwrap();
+    Command::new("git").args(["add", "."]).current_dir(repo_path).output().unwrap();
+    Command::new("git").args(["commit", "-m", "Feature commit"]).current_dir(repo_path).output().unwrap();
+
+    let rev_output = Command::new("git").args(["rev-parse", "HEAD"]).current_dir(repo_path).output().unwrap();
+    let target_sha = String::from_utf8_lossy(&rev_output.stdout).trim().to_string();
+    let short_sha = &target_sha[..7];
+
+    // 2. Go back to main
+    Command::new("git").args(["checkout", "-f", "main"]).current_dir(repo_path).output().unwrap();
+    fs::write(repo_path.join("README.md"), "# Updated README").unwrap();
+    Command::new("git").args(["add", "."]).current_dir(repo_path).output().unwrap();
+    Command::new("git").args(["commit", "-m", "Update main"]).current_dir(repo_path).output().unwrap();
+
+    // 3. Switch to the short SHA
+    let output = Command::new(env!("CARGO_BIN_EXE_warp"))
+        .args(["--terminal", "echo", short_sha])
+        .current_dir(repo_path)
+        .env("HOME", home_dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "stdout={}\nstderr={}", String::from_utf8_lossy(&output.stdout), String::from_utf8_lossy(&output.stderr));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let worktree_path = stdout.lines()
+        .find(|line| line.contains("Switch complete:"))
+        .map(|line| line.split("Switch complete: ").nth(1).unwrap().trim())
+        .map(PathBuf::from)
+        .expect("Could not find switch complete path in stdout");
+
+    // 4. Verify the new worktree is at the target SHA
+    let wt_rev_output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(&worktree_path)
+        .output()
+        .unwrap();
+    let wt_sha = String::from_utf8_lossy(&wt_rev_output.stdout).trim().to_string();
+
+    assert_eq!(wt_sha, target_sha, "Worktree should be at SHA {}, but was at {}", target_sha, wt_sha);
 }


### PR DESCRIPTION
## Summary
- Update `BranchSource` to include `CommitIsh` variant.
- Add `resolve_commit_ish` to `GitRepository` to resolve tags/SHAs to commits using `git rev-parse --verify <name>^{commit}`.
- Update `classify_branch_source` to identify commit-ish targets when local/remote branches are not found.
- Update `create_worktree_for_source` to handle `CommitIsh` by creating a new branch at the target SHA.
- Add integration tests for tag and SHA switching.

Closes #88

## Verification
- `cargo test --test mod integration::terminal_switch_tests` (12 passed)
- `cargo test` (201 passed)
- `git diff --check`