### PR TITLE
feat(fs): fsync parent directory after rename in write_atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
   List-valued fields render read-only and still require editing the TOML file
   directly.
 
+### Fixed
+
+- Ensure durability of atomic writes on Unix systems by calling `fsync` on the
+  parent directory after renaming the temporary file. (#102)
+- Use atomic writes for path rewriting and git exclude updates to prevent file
+  corruption on crash.
+
 ## v0.3.0 - 2026-05-06
 
 Second public Git-Warp release. Adds per-worktree cleanup eligibility output,

--- a/src/fs_atomic.rs
+++ b/src/fs_atomic.rs
@@ -52,6 +52,16 @@ pub fn write_atomic(path: &Path, contents: &[u8]) -> io::Result<()> {
         let _ = fs::remove_file(&tmp_path);
         return Err(e);
     }
+
+    #[cfg(unix)]
+    {
+        // Fsync the parent directory to ensure the rename is persisted.
+        // We open it read-only as that is sufficient for fsync on most Unix systems.
+        if let Ok(dir) = fs::File::open(parent) {
+            let _ = dir.sync_all();
+        }
+    }
+
     Ok(())
 }
 
@@ -59,6 +69,14 @@ pub fn write_atomic(path: &Path, contents: &[u8]) -> io::Result<()> {
 mod tests {
     use super::*;
     use std::fs;
+
+    #[test]
+    fn write_atomic_full_cycle() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("full_cycle.txt");
+        write_atomic(&target, b"content").expect("Write should succeed");
+        assert_eq!(fs::read_to_string(&target).unwrap(), "content");
+    }
 
     #[test]
     fn writes_new_file() {

--- a/src/git.rs
+++ b/src/git.rs
@@ -394,7 +394,9 @@ impl GitRepository {
                     .arg(sha)
                     .current_dir(&self.repo_path)
                     .output()
-                    .map_err(|e| anyhow::anyhow!("Failed to create worktree from commit-ish: {}", e))?;
+                    .map_err(|e| {
+                        anyhow::anyhow!("Failed to create worktree from commit-ish: {}", e)
+                    })?;
 
                 if !output.status.success() {
                     let error = String::from_utf8_lossy(&output.stderr);
@@ -699,7 +701,12 @@ impl GitRepository {
                 let has_remote = remotes_ref.contains(branch);
 
                 let is_merged = Command::new("git")
-                    .args(["merge-base", "--is-ancestor", branch, cleanup_base_branch_ref])
+                    .args([
+                        "merge-base",
+                        "--is-ancestor",
+                        branch,
+                        cleanup_base_branch_ref,
+                    ])
                     .current_dir(repo_path)
                     .output()
                     .map(|output| output.status.success())

--- a/src/post_create.rs
+++ b/src/post_create.rs
@@ -164,7 +164,7 @@ pub fn ensure_agent_state_excluded(worktree_path: &Path) {
         out.push_str(entry);
         out.push('\n');
     }
-    let _ = std::fs::write(&exclude_path, out);
+    let _ = crate::fs_atomic::write_atomic(&exclude_path, out.as_bytes());
 }
 
 fn detect_manager(worktree_path: &Path) -> Option<PackageManager> {

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -95,7 +95,7 @@ impl PathRewriter {
 
         // Write back if content changed
         if new_content != content {
-            fs::write(file_path, new_content)?;
+            crate::fs_atomic::write_atomic(file_path, new_content.as_bytes())?;
             log::debug!("Rewrote paths in: {}", file_path.display());
         }
 

--- a/tests/integration/terminal_switch_tests.rs
+++ b/tests/integration/terminal_switch_tests.rs
@@ -580,19 +580,49 @@ fn test_warp_switch_to_tag_creates_branch_at_tag() {
 
     // 1. Create a commit and a tag
     fs::write(repo_path.join("feature.txt"), "tag content").unwrap();
-    Command::new("git").args(["add", "."]).current_dir(repo_path).output().unwrap();
-    Command::new("git").args(["commit", "-m", "Feature commit"]).current_dir(repo_path).output().unwrap();
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "Feature commit"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
 
-    let rev_output = Command::new("git").args(["rev-parse", "HEAD"]).current_dir(repo_path).output().unwrap();
-    let tag_sha = String::from_utf8_lossy(&rev_output.stdout).trim().to_string();
+    let rev_output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    let tag_sha = String::from_utf8_lossy(&rev_output.stdout)
+        .trim()
+        .to_string();
 
-    Command::new("git").args(["tag", "v1.0.0-tag"]).current_dir(repo_path).output().unwrap();
+    Command::new("git")
+        .args(["tag", "v1.0.0-tag"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
 
     // 2. Go back to main so HEAD is different from the tag
-    Command::new("git").args(["checkout", "-f", "main"]).current_dir(repo_path).output().unwrap();
+    Command::new("git")
+        .args(["checkout", "-f", "main"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
     fs::write(repo_path.join("README.md"), "# Updated README").unwrap();
-    Command::new("git").args(["add", "."]).current_dir(repo_path).output().unwrap();
-    Command::new("git").args(["commit", "-m", "Update main"]).current_dir(repo_path).output().unwrap();
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "Update main"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
 
     // 3. Switch to the tag
     let output = Command::new(env!("CARGO_BIN_EXE_warp"))
@@ -609,7 +639,8 @@ fn test_warp_switch_to_tag_creates_branch_at_tag() {
     // 4. Extract the worktree path from stdout
     // It's in a line like "✅ Switch complete: /path/to/worktree"
     // or "⚠️  Switch incomplete: /path/to/worktree"
-    let worktree_path = stdout.lines()
+    let worktree_path = stdout
+        .lines()
         .find(|line| line.contains("Switch complete:") || line.contains("Switch incomplete:"))
         .map(|line| {
             if line.contains("Switch complete: ") {
@@ -627,9 +658,18 @@ fn test_warp_switch_to_tag_creates_branch_at_tag() {
         .current_dir(&worktree_path)
         .output()
         .unwrap();
-    let wt_sha = String::from_utf8_lossy(&wt_rev_output.stdout).trim().to_string();
+    let wt_sha = String::from_utf8_lossy(&wt_rev_output.stdout)
+        .trim()
+        .to_string();
 
-    assert_eq!(wt_sha, tag_sha, "Worktree at {} should be at SHA {}, but was at {}", worktree_path.display(), tag_sha, wt_sha);
+    assert_eq!(
+        wt_sha,
+        tag_sha,
+        "Worktree at {} should be at SHA {}, but was at {}",
+        worktree_path.display(),
+        tag_sha,
+        wt_sha
+    );
 
     // Also verify a branch named v1.0.0-tag was created
     let branch_output = Command::new("git")
@@ -637,7 +677,10 @@ fn test_warp_switch_to_tag_creates_branch_at_tag() {
         .current_dir(repo_path)
         .output()
         .unwrap();
-    assert!(branch_output.status.success(), "Branch v1.0.0-tag should have been created");
+    assert!(
+        branch_output.status.success(),
+        "Branch v1.0.0-tag should have been created"
+    );
 }
 
 #[test]
@@ -650,18 +693,44 @@ fn test_warp_switch_to_sha_creates_branch_at_sha() {
 
     // 1. Create a commit
     fs::write(repo_path.join("feature.txt"), "sha content").unwrap();
-    Command::new("git").args(["add", "."]).current_dir(repo_path).output().unwrap();
-    Command::new("git").args(["commit", "-m", "Feature commit"]).current_dir(repo_path).output().unwrap();
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "Feature commit"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
 
-    let rev_output = Command::new("git").args(["rev-parse", "HEAD"]).current_dir(repo_path).output().unwrap();
-    let target_sha = String::from_utf8_lossy(&rev_output.stdout).trim().to_string();
+    let rev_output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    let target_sha = String::from_utf8_lossy(&rev_output.stdout)
+        .trim()
+        .to_string();
     let short_sha = &target_sha[..7];
 
     // 2. Go back to main
-    Command::new("git").args(["checkout", "-f", "main"]).current_dir(repo_path).output().unwrap();
+    Command::new("git")
+        .args(["checkout", "-f", "main"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
     fs::write(repo_path.join("README.md"), "# Updated README").unwrap();
-    Command::new("git").args(["add", "."]).current_dir(repo_path).output().unwrap();
-    Command::new("git").args(["commit", "-m", "Update main"]).current_dir(repo_path).output().unwrap();
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "Update main"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
 
     // 3. Switch to the short SHA
     let output = Command::new(env!("CARGO_BIN_EXE_warp"))
@@ -671,10 +740,16 @@ fn test_warp_switch_to_sha_creates_branch_at_sha() {
         .output()
         .unwrap();
 
-    assert!(output.status.success(), "stdout={}\nstderr={}", String::from_utf8_lossy(&output.stdout), String::from_utf8_lossy(&output.stderr));
+    assert!(
+        output.status.success(),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let worktree_path = stdout.lines()
+    let worktree_path = stdout
+        .lines()
         .find(|line| line.contains("Switch complete:"))
         .map(|line| line.split("Switch complete: ").nth(1).unwrap().trim())
         .map(PathBuf::from)
@@ -686,7 +761,13 @@ fn test_warp_switch_to_sha_creates_branch_at_sha() {
         .current_dir(&worktree_path)
         .output()
         .unwrap();
-    let wt_sha = String::from_utf8_lossy(&wt_rev_output.stdout).trim().to_string();
+    let wt_sha = String::from_utf8_lossy(&wt_rev_output.stdout)
+        .trim()
+        .to_string();
 
-    assert_eq!(wt_sha, target_sha, "Worktree should be at SHA {}, but was at {}", target_sha, wt_sha);
+    assert_eq!(
+        wt_sha, target_sha,
+        "Worktree should be at SHA {}, but was at {}",
+        target_sha, wt_sha
+    );
 }


### PR DESCRIPTION
## Summary
- Ensure durability of atomic writes on Unix systems by calling `fsync` on the parent directory after the temporary file has been renamed to the target path.
- Added a full cycle verification test for `write_atomic`.

## Test Plan
- [x] Ran `cargo test fs_atomic` (passes on Darwin)
- [x] Ran full suite `cargo test` (all 350 tests passed)
- [x] Verified `fs::File::open` works on directories on the current Unix system.

Closes #102