### PR TITLE
ci: add windows-latest to clippy and test matrix (#90)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14]
+        os: [ubuntu-latest, macos-14, windows-latest]
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14]
+        os: [ubuntu-latest, macos-14, windows-latest]
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
This PR adds `windows-latest` to the CI matrix for both the `clippy` and `test` jobs.

### Summary
- Updated `.github/workflows/ci.yml` to include `windows-latest` in the OS matrix for clippy and tests.
- This ensures that Windows-specific code paths (like the `taskkill` execution in `src/process.rs`) are checked for compilation and basic behavioral regressions.

### Verification
- `cargo fmt --check`
- `cargo check`
- `cargo test -- --test-threads=1` (363 tests passed on macOS)
- `git diff --check`

Closes #90