### PR TITLE
fix(install): resolve latest release tag from GitHub API

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -63,12 +63,20 @@ curl -fsSL https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.
 
 ## Install A Specific Version
 
-The installer defaults to the latest documented release. Pin a version with
-`GIT_WARP_VERSION`:
+With no env override, the installer resolves the latest published release from
+the GitHub releases API
+(`https://api.github.com/repos/denysbutenko/git-warp/releases/latest`) and
+installs that tag. The resolved tag is printed before the download starts.
+
+Pin a specific version with `GIT_WARP_VERSION` to skip the API lookup:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.sh | GIT_WARP_VERSION=v0.3.0 sh
 ```
+
+If the API lookup fails (no network, rate-limited, custom non-`github.com`
+`GIT_WARP_REPO_URL`), the installer aborts and points at the `GIT_WARP_VERSION`
+pin or the Cargo fallback.
 
 ## Supported Prebuilt Binaries
 

--- a/docs/release-check.md
+++ b/docs/release-check.md
@@ -17,7 +17,9 @@ commands. It stops at the first failing command.
 - `CHANGELOG.md` has a `v0.3.0` release heading.
 - `docs/releases/v0.3.0.md` exists.
 - `docs/install.md` mentions `GIT_WARP_VERSION=v0.3.0`.
-- `install.sh` defaults `GIT_WARP_VERSION` to `v0.3.0`.
+- `install.sh` keeps the `${GIT_WARP_VERSION:-...}` env override and resolves
+  the latest tag via `api.github.com/repos/.../releases/latest`. This is a
+  shape check, independent of the prepared tag.
 
 Use the fast metadata-only mode while preparing notes:
 

--- a/install.sh
+++ b/install.sh
@@ -2,9 +2,7 @@
 set -eu
 
 repo_url="${GIT_WARP_REPO_URL:-https://github.com/denysbutenko/git-warp}"
-version="${GIT_WARP_VERSION:-v0.3.0}"
 method="${GIT_WARP_INSTALL_METHOD:-binary}"
-download_base="${GIT_WARP_DOWNLOAD_BASE:-${repo_url}/releases/download/${version}}"
 
 if [ -n "${GIT_WARP_INSTALL_DIR:-}" ]; then
   install_dir="$GIT_WARP_INSTALL_DIR"
@@ -117,6 +115,48 @@ download() {
     exit 1
   fi
 }
+
+fail_version_lookup() {
+  echo "error: $*" >&2
+  echo "Pin a version explicitly to skip the GitHub API lookup:" >&2
+  echo "  curl -fsSL ${repo_url}/raw/main/install.sh | GIT_WARP_VERSION=vX.Y.Z sh" >&2
+  cargo_fallback_hint
+  exit 1
+}
+
+resolve_latest_version() {
+  case "$repo_url" in
+    https://github.com/*) ;;
+    *) fail_version_lookup "GIT_WARP_REPO_URL ($repo_url) is not on github.com; cannot auto-resolve the latest release" ;;
+  esac
+
+  api_url="https://api.github.com/repos/${repo_url#https://github.com/}/releases/latest"
+
+  if command -v curl >/dev/null 2>&1; then
+    body="$(curl -fsSL "$api_url" 2>/dev/null)" || fail_version_lookup "GitHub release lookup failed at $api_url"
+  elif command -v wget >/dev/null 2>&1; then
+    body="$(wget -qO- "$api_url" 2>/dev/null)" || fail_version_lookup "GitHub release lookup failed at $api_url"
+  else
+    fail_version_lookup "curl or wget is required to resolve the latest Git-Warp release"
+  fi
+
+  tag="$(printf '%s' "$body" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
+
+  if [ -z "$tag" ]; then
+    fail_version_lookup "could not parse tag_name from $api_url response"
+  fi
+
+  printf '%s\n' "$tag"
+}
+
+if [ -n "${GIT_WARP_VERSION:-}" ]; then
+  version="$GIT_WARP_VERSION"
+else
+  version="$(resolve_latest_version)"
+  echo "Resolved latest Git-Warp release: ${version}"
+fi
+
+download_base="${GIT_WARP_DOWNLOAD_BASE:-${repo_url}/releases/download/${version}}"
 
 verify_checksum() {
   dir="$1"

--- a/src/release.rs
+++ b/src/release.rs
@@ -178,21 +178,18 @@ pub fn collect_metadata_checks(
         ));
     }
 
-    if install_script.contains(&format!(
-        "version=\"${{GIT_WARP_VERSION:-{}}}\"",
-        expected.tag
-    )) {
+    let has_env_override = install_script.contains("${GIT_WARP_VERSION:-");
+    let has_api_lookup = install_script.contains("api.github.com/repos/");
+
+    if has_env_override && has_api_lookup {
         checks.push(ReleaseCheck::pass(
             "install.sh",
-            format!("defaults to {}", expected.tag),
+            "resolves GIT_WARP_VERSION dynamically from the GitHub releases API",
         ));
     } else {
         checks.push(ReleaseCheck::fail(
             "install.sh",
-            format!(
-                "install.sh default GIT_WARP_VERSION is not {}",
-                expected.tag
-            ),
+            "install.sh must keep the ${GIT_WARP_VERSION:-...} override and call api.github.com/repos/.../releases/latest",
         ));
     }
 

--- a/tests/unit/release_tests.rs
+++ b/tests/unit/release_tests.rs
@@ -82,10 +82,11 @@ fn test_collect_metadata_checks_all_pass() {
     )
     .unwrap();
 
-    // 4. install.sh with version default
+    // 4. install.sh with env override + GitHub API lookup
     fs::write(
         temp.path().join("install.sh"),
-        format!("version=\"${{GIT_WARP_VERSION:-{tag}}}\""),
+        "version=\"${GIT_WARP_VERSION:-}\"\n\
+         api_url=\"https://api.github.com/repos/denysbutenko/git-warp/releases/latest\"\n",
     )
     .unwrap();
 
@@ -133,8 +134,31 @@ fn test_collect_metadata_checks_failures() {
     assert!(
         checks[4]
             .detail
-            .contains("install.sh default GIT_WARP_VERSION is not v0.3.0")
+            .contains("api.github.com/repos/.../releases/latest")
     );
+}
+
+#[test]
+fn test_install_script_partial_lookup_fails() {
+    let temp = tempdir().unwrap();
+    let expected = ReleaseVersion {
+        number: "0.3.0".to_string(),
+        tag: "v0.3.0".to_string(),
+    };
+
+    // install.sh keeps env override but lost the API lookup line.
+    fs::write(
+        temp.path().join("install.sh"),
+        "version=\"${GIT_WARP_VERSION:-v0.3.0}\"\n",
+    )
+    .unwrap();
+
+    let checks = collect_metadata_checks(temp.path(), &expected, "0.3.0").unwrap();
+    assert!(
+        !checks[4].ok,
+        "install.sh missing API lookup should fail the check"
+    );
+    assert_eq!(checks[4].label, "install.sh");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Drop the hardcoded `v0.3.0` default in `install.sh`. When `GIT_WARP_VERSION` is unset, resolve the latest published tag from `api.github.com/repos/denysbutenko/git-warp/releases/latest` and install it.
- Fail closed on lookup failure (no curl/wget, network error, malformed JSON, non-`github.com` `GIT_WARP_REPO_URL`): print how to pin and the cargo fallback hint, exit 1. No silent fallback to a stale literal.
- `release-check` now asserts `install.sh` keeps the `${GIT_WARP_VERSION:-...}` override and calls `api.github.com/repos/.../releases/latest`, instead of comparing against the literal default for the prepared tag.
- Docs: update `docs/install.md` "Install A Specific Version" and the `install.sh` bullet in `docs/release-check.md`.

## Verification
- `sh -n install.sh`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` (208 passed, 0 failed)
- `git diff --check`

Closes #91.