### PR TITLE
feat(config): support nested GIT_WARP_*__* env overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,13 +189,19 @@ claude_hooks = true
 for the per-key semantics. `[process].auto_kill` defers to `--kill` /
 `--no-kill` when those flags are present (`--no-kill` always wins).
 
-Environment overrides use the `GIT_WARP_` prefix:
+Environment overrides use the `GIT_WARP_` prefix. Top-level keys map
+directly; nested sections use `__` (double underscore) as the separator
+(`GIT_WARP_<section>__<field>`):
 
 ```bash
 export GIT_WARP_TERMINAL_MODE=window
 export GIT_WARP_USE_COW=false
 export GIT_WARP_AUTO_CONFIRM=true
 export GIT_WARP_WORKTREES_PATH=/custom/worktrees
+
+export GIT_WARP_GIT__DEFAULT_BRANCH=develop
+export GIT_WARP_PROCESS__AUTO_KILL=true
+export GIT_WARP_POST_CREATE__AUTO_INSTALL=false
 ```
 
 `terminal.init_commands` run after Git-Warp changes into the worktree for
@@ -205,7 +211,7 @@ terminal handoff modes that print or send shell commands.
 `<manager> install` after creating a new worktree. Lockfile detection order is
 `pnpm-lock.yaml` → `yarn.lock` → `bun.lock` → `bun.lockb` → `package-lock.json`; the first
 match wins. Set `auto_install = false` (or
-`GIT_WARP_POST_CREATE_AUTO_INSTALL=false`) to skip the install step entirely.
+`GIT_WARP_POST_CREATE__AUTO_INSTALL=false`) to skip the install step entirely.
 
 ## Shell Integration
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -305,13 +305,22 @@ creates a new worktree. Lockfile detection order is `pnpm-lock.yaml` →
 `yarn.lock` → `bun.lock` → `bun.lockb` → `package-lock.json`; the first match wins. Set
 `auto_install = false` to skip the install step entirely.
 
-Environment variables override config file values:
+Environment variables override config file values. Top-level keys map
+directly; nested sections use `__` (double underscore) as the path
+separator (`GIT_WARP_<section>__<field>`):
 
 ```bash
 export GIT_WARP_TERMINAL_MODE=window
 export GIT_WARP_USE_COW=false
 export GIT_WARP_AUTO_CONFIRM=false
 export GIT_WARP_WORKTREES_PATH=/Users/me/dev/worktrees
+
+export GIT_WARP_GIT__DEFAULT_BRANCH=develop
+export GIT_WARP_GIT__AUTO_FETCH=false
+export GIT_WARP_PROCESS__AUTO_KILL=true
+export GIT_WARP_TERMINAL__APP=iterm2
+export GIT_WARP_AGENT__REFRESH_RATE=2000
+export GIT_WARP_POST_CREATE__AUTO_INSTALL=false
 ```
 
 Command-line options have the highest priority:
@@ -362,7 +371,7 @@ auto_install = false
 ```
 
 in `~/.config/git-warp/config.toml`, or export
-`GIT_WARP_POST_CREATE_AUTO_INSTALL=false`.
+`GIT_WARP_POST_CREATE__AUTO_INSTALL=false`.
 
 ### Cleanup Is Blocked
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1683,6 +1683,14 @@ impl Cli {
             println!("  GIT_WARP_USE_COW=true|false");
             println!("  GIT_WARP_AUTO_CONFIRM=true|false");
             println!("  GIT_WARP_WORKTREES_PATH=/custom/path");
+            println!();
+            println!("Nested sections use `__` (double underscore) as the separator:");
+            println!("  GIT_WARP_GIT__DEFAULT_BRANCH=develop");
+            println!("  GIT_WARP_GIT__AUTO_FETCH=false");
+            println!("  GIT_WARP_PROCESS__AUTO_KILL=true");
+            println!("  GIT_WARP_TERMINAL__APP=iterm2");
+            println!("  GIT_WARP_AGENT__REFRESH_RATE=2000");
+            println!("  GIT_WARP_POST_CREATE__AUTO_INSTALL=false");
         }
 
         Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -222,30 +222,6 @@ impl Default for AgentConfig {
 }
 
 impl Config {
-    /// Update configuration from environment variables
-    #[allow(dead_code)] // Exercised by config_tests integration tests.
-    pub fn apply_env_overrides(&mut self) {
-        // Terminal mode
-        if let Ok(mode) = std::env::var("GIT_WARP_TERMINAL_MODE") {
-            self.terminal_mode = mode;
-        }
-
-        // Auto-confirm
-        if let Ok(confirm) = std::env::var("GIT_WARP_AUTO_CONFIRM") {
-            self.auto_confirm = confirm.parse().unwrap_or(false);
-        }
-
-        // CoW usage
-        if let Ok(cow) = std::env::var("GIT_WARP_USE_COW") {
-            self.use_cow = cow.parse().unwrap_or(true);
-        }
-
-        // Worktrees path
-        if let Ok(path) = std::env::var("GIT_WARP_WORKTREES_PATH") {
-            self.worktrees_path = Some(PathBuf::from(path));
-        }
-    }
-
     /// Generate a sample configuration file content
     #[allow(dead_code)] // Exercised by config_tests integration tests.
     pub fn sample_config() -> String {
@@ -357,11 +333,12 @@ impl ConfigManager {
 
     /// Load configuration from file, environment, and defaults
     fn load_config(config_path: &PathBuf) -> Result<Config> {
+        // `__` splits env keys into nested fields:
+        // GIT_WARP_GIT__DEFAULT_BRANCH=develop -> git.default_branch.
+        // Single-segment vars (GIT_WARP_TERMINAL_MODE) still hit top-level fields.
         let figment = Figment::new()
-            // Override with config file if it exists
             .merge(Toml::file(config_path))
-            // Override with environment variables
-            .merge(Env::prefixed("GIT_WARP_"));
+            .merge(Env::prefixed("GIT_WARP_").split("__"));
 
         figment.extract().map_err(|e| {
             GitWarpError::ConfigError {
@@ -471,28 +448,6 @@ mod tests {
         };
 
         assert_eq!(manager.get().terminal_mode, "tab");
-    }
-
-    #[test]
-    fn test_config_environment_overrides() {
-        let mut config = Config::default();
-
-        // Set environment variable
-        unsafe {
-            std::env::set_var("GIT_WARP_TERMINAL_MODE", "window");
-            std::env::set_var("GIT_WARP_AUTO_CONFIRM", "true");
-        }
-
-        config.apply_env_overrides();
-
-        assert_eq!(config.terminal_mode, "window");
-        assert!(config.auto_confirm);
-
-        // Clean up
-        unsafe {
-            std::env::remove_var("GIT_WARP_TERMINAL_MODE");
-            std::env::remove_var("GIT_WARP_AUTO_CONFIRM");
-        }
     }
 
     #[test]

--- a/tests/unit/config_tests.rs
+++ b/tests/unit/config_tests.rs
@@ -174,6 +174,49 @@ fn test_nested_config_structures() {
 }
 
 #[test]
+fn test_env_nested_overrides_via_figment() {
+    unsafe {
+        std::env::set_var("GIT_WARP_GIT__DEFAULT_BRANCH", "develop");
+        std::env::set_var("GIT_WARP_POST_CREATE__AUTO_INSTALL", "false");
+        std::env::set_var("GIT_WARP_AGENT__REFRESH_RATE", "2500");
+    }
+
+    let figment =
+        figment::Figment::new().merge(figment::providers::Env::prefixed("GIT_WARP_").split("__"));
+    let config: Config = figment.extract().unwrap();
+
+    assert_eq!(config.git.default_branch, "develop");
+    assert!(!config.post_create.auto_install);
+    assert_eq!(config.agent.refresh_rate, 2500);
+
+    unsafe {
+        std::env::remove_var("GIT_WARP_GIT__DEFAULT_BRANCH");
+        std::env::remove_var("GIT_WARP_POST_CREATE__AUTO_INSTALL");
+        std::env::remove_var("GIT_WARP_AGENT__REFRESH_RATE");
+    }
+}
+
+#[test]
+fn test_env_flat_top_level_still_works() {
+    unsafe {
+        std::env::set_var("GIT_WARP_TERMINAL_MODE", "inplace");
+        std::env::set_var("GIT_WARP_USE_COW", "false");
+    }
+
+    let figment =
+        figment::Figment::new().merge(figment::providers::Env::prefixed("GIT_WARP_").split("__"));
+    let config: Config = figment.extract().unwrap();
+
+    assert_eq!(config.terminal_mode, "inplace");
+    assert!(!config.use_cow);
+
+    unsafe {
+        std::env::remove_var("GIT_WARP_TERMINAL_MODE");
+        std::env::remove_var("GIT_WARP_USE_COW");
+    }
+}
+
+#[test]
 fn test_config_validation() {
     // Test that invalid values are handled gracefully
     let toml_str = r#"


### PR DESCRIPTION
## Summary
- Add `.split("__")` to the `Env::prefixed("GIT_WARP_")` provider in `ConfigManager::load_config` so nested sections (`git`, `process`, `terminal`, `agent`, `post_create`) can be overridden via env vars.
- Delete `Config::apply_env_overrides` and its inline test so figment is the only env-loading code path.
- Refresh `warp config` help, README, and user-guide env sections to show the nested form and fix the broken `GIT_WARP_POST_CREATE_AUTO_INSTALL` example.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` (210 passed, 0 failed)
- `git diff --check`

Closes #92.