### PR TITLE
chore(deps): bump thiserror 1.0.61 -> 2.0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,7 +695,7 @@ dependencies = [
  "serde_json",
  "sysinfo",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "toml",
 ]
 
@@ -808,7 +808,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1db9765c69502650da68f0804e3dc2b5f8ccc6a2d104ca6c85bc40700d37540"
 dependencies = [
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -817,7 +817,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b1f1d8764958699dc764e3f727cef280ff4d1bd92c107bbf8acd85b30c1bd6f"
 dependencies = [
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -877,7 +877,7 @@ dependencies = [
  "bstr",
  "gix-path",
  "libc",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1226,7 +1226,7 @@ dependencies = [
  "gix-validate 0.10.0",
  "home",
  "once_cell",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1254,7 +1254,7 @@ dependencies = [
  "gix-config-value",
  "parking_lot",
  "rustix 0.38.44",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1265,7 +1265,7 @@ checksum = "e49357fccdb0c85c0d3a3292a9f6db32d9b3535959b5471bb9624908f4a066c6"
 dependencies = [
  "bstr",
  "gix-utils",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1465,7 +1465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77b9e00cacde5b51388d28ed746c493b18a6add1f19b5e01d686b3b9ece66d4d"
 dependencies = [
  "bstr",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2595,11 +2595,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2615,9 +2615,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ version = "1.0.117"
 version = "0.30.12"
 
 [dependencies.thiserror]
-version = "1.0.61"
+version = "2.0.18"
 
 [dependencies.toml]
 version = "0.8.13"

--- a/Cargo.toml.orig
+++ b/Cargo.toml.orig
@@ -33,7 +33,7 @@ toml = "0.8.13"
 
 # Utilities
 anyhow = "1.0.86"
-thiserror = "1.0.61"
+thiserror = "2.0.18"
 log = "0.4.21"
 env_logger = "0.11.3"
 dirs = "5.0.1"


### PR DESCRIPTION
## Summary

- Bump direct `thiserror` dep from `1.0.61` to `2.0.18`.
- `Cargo.lock` no longer carries `thiserror 1.0.69` at all: the previous duplicate that issue #99 called out goes away, and the `2.0.12` copy gix was pulling transitively consolidates to `2.0.18`.
- No `src/error.rs` changes required; the `#[derive(thiserror::Error)]` + `#[error("...")]` usage in this crate compiles unchanged against thiserror 2.x.

## Verification

- `cargo check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` (210 passed, 0 failed)
- `git diff --check`

Note: `cargo fmt --all -- --check` still reports the pre-existing untouched `src/post_create.rs` drift on `main` (also called out in #124 / #125); this branch does not touch that file.

Addresses #99 (group 1, drop-in bumps). Leaves the remaining group-1 candidates (`toml`, `figment`) for follow-up PRs since `figment` is already at its latest `0.10.x` and `toml 0.8 -> 1.x` is more than a drop-in.