### PR TITLE
docs: archive pre-v0.1.0 implement-plan-v[12] under docs/archive

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,14 +20,18 @@ planning material for Git-Warp.
   `v0.2.0` GitHub release.
 - [Root README](../README.md): short project overview and verified quick start.
 
-## Reference Documents
+## Historical Planning
 
-- [implement-plan-v1.md](implement-plan-v1.md): early implementation plan.
-- [implement-plan-v2.md](implement-plan-v2.md): later implementation plan.
+- [archive/implement-plan-v1.md](archive/implement-plan-v1.md): early
+  pre-v0.1.0 implementation plan.
+- [archive/implement-plan-v2.md](archive/implement-plan-v2.md): later
+  pre-v0.1.0 implementation plan.
 
-The implementation plans are historical context. The current CLI behavior is
-best checked with `warp --help`, `warp <command> --help`, and the current
-README/user guide.
+These predate v0.1.0 and are kept for historical context only. Specific
+milestones, dependencies, and API choices in them no longer reflect the
+shipped surface. For current behavior, check `warp --help`,
+`warp <command> --help`, [Technical Overview](technical-overview.md), and the
+[Changelog](../CHANGELOG.md).
 
 ## Common Paths
 

--- a/docs/archive/implement-plan-v1.md
+++ b/docs/archive/implement-plan-v1.md
@@ -1,3 +1,9 @@
+> **Historical document.** This plan predates the v0.1.0 implementation and is
+> retained only for context. Specific milestones, dependencies, and API choices
+> here do not reflect the shipped surface — see
+> [`docs/technical-overview.md`](../technical-overview.md) and
+> [`CHANGELOG.md`](../../CHANGELOG.md) for the current state.
+
 ### Project Name Idea: **Git-Warp**
 
 This name evokes speed, instantaneous action, and moving between different contexts (worktrees). It's short, memorable, and hints at the "sci-fi" level of speed that Copy-on-Write provides. The CLI command could be `warp`.

--- a/docs/archive/implement-plan-v2.md
+++ b/docs/archive/implement-plan-v2.md
@@ -1,3 +1,9 @@
+> **Historical document.** This plan predates the v0.1.0 implementation and is
+> retained only for context. Specific milestones, dependencies, and API choices
+> here do not reflect the shipped surface — see
+> [`docs/technical-overview.md`](../technical-overview.md) and
+> [`CHANGELOG.md`](../../CHANGELOG.md) for the current state.
+
 ### Project: Git-Warp v0.1.0 - A High-Performance, UX-Focused Worktree Manager
 
 **Mission:** To combine the instantaneous, Copy-on-Write worktree creation of `coworktree` with the rich user experience, terminal integration, and advanced features of `autowt`. The result will be a single, statically-linked binary written in Rust.


### PR DESCRIPTION
## Summary

- Move `docs/implement-plan-v1.md` and `docs/implement-plan-v2.md` into `docs/archive/`. The files predate v0.1.0 and list design choices that have since changed (`notify` dropped in #69/#81, `gix` dropped in #128, milestone scope diverged from the original v0.1-v0.4 roadmap).
- Prepend a short "Historical document" banner to each archived file, pointing at `docs/technical-overview.md` and `CHANGELOG.md` for the current state.
- Rework the `docs/README.md` "Reference Documents" section into "Historical Planning" so the link list and surrounding sentence make the pre-v0.1.0 status explicit and direct readers to the technical overview and changelog for shipped behavior.

## Verification

- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test --quiet` — 73 + 76 + 210 tests pass.
- `git diff --check` — clean.
- Manual link sweep on `docs/README.md` and the two archived files — every relative target resolves.

Note: `cargo fmt --check` reports a pre-existing diff in `src/post_create.rs` (from #121); unrelated to this docs-only change.

Closes #109