### PR TITLE
chore(config): drop unused agent.claude_hooks knob

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,6 @@ auto_install = true
 enabled = true
 refresh_rate = 1000
 max_activities = 100
-claude_hooks = true
 ```
 
 `[git].auto_fetch`, `[git].auto_prune`, `[process].check_processes`,

--- a/benches/performance_benchmarks.rs
+++ b/benches/performance_benchmarks.rs
@@ -212,7 +212,6 @@ init_commands = ["npm install", "source .env", "echo setup"]
 enabled = true
 refresh_rate = 1000
 max_activities = 100
-claude_hooks = true
 "#;
 
     fs::write(&config_path, config_content).unwrap();

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -286,7 +286,6 @@ auto_install = true
 enabled = true
 refresh_rate = 1000
 max_activities = 100
-claude_hooks = true
 ```
 
 `[git].auto_fetch` controls whether `warp cleanup` runs `git fetch --all --prune`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1655,7 +1655,6 @@ impl Cli {
             println!("  Enabled: {}", config.agent.enabled);
             println!("  Refresh rate: {}ms", config.agent.refresh_rate);
             println!("  Max activities: {}", config.agent.max_activities);
-            println!("  Claude hooks: {}", config.agent.claude_hooks);
         } else if edit {
             if !config_manager.config_exists() {
                 config_manager.create_default_config()?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -117,10 +117,6 @@ pub struct AgentConfig {
     /// Maximum number of activities to track
     #[serde(default = "default_max_activities")]
     pub max_activities: usize,
-
-    /// Enable Claude Code hooks integration
-    #[serde(default = "default_true")]
-    pub claude_hooks: bool,
 }
 
 // Default value functions
@@ -216,7 +212,6 @@ impl Default for AgentConfig {
             enabled: true,
             refresh_rate: default_refresh_rate(),
             max_activities: default_max_activities(),
-            claude_hooks: true,
         }
     }
 }
@@ -290,9 +285,6 @@ refresh_rate = {}
 
 # Maximum activities to track
 max_activities = {}
-
-# Enable Claude Code hooks integration
-claude_hooks = {}
 "#,
             config.terminal_mode,
             config.use_cow,
@@ -310,7 +302,6 @@ claude_hooks = {}
             config.agent.enabled,
             config.agent.refresh_rate,
             config.agent.max_activities,
-            config.agent.claude_hooks,
         )
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1827,7 +1827,6 @@ pub enum ConfigFieldId {
     AgentEnabled,
     AgentRefreshRate,
     AgentMaxActivities,
-    AgentClaudeHooks,
     PostCreateAutoInstall,
 }
 
@@ -1984,13 +1983,6 @@ fn config_field_specs() -> Vec<ConfigFieldSpec> {
                 min: 1,
                 max: 10_000,
             },
-        },
-        ConfigFieldSpec {
-            id: AgentClaudeHooks,
-            section: Agent,
-            label: "claude_hooks",
-            help: "Install Claude Code hooks for agent activity tracking.",
-            kind: Bool,
         },
         ConfigFieldSpec {
             id: PostCreateAutoInstall,
@@ -2198,9 +2190,6 @@ impl ConfigEditorModel {
                 self.working.terminal.auto_activate = !self.working.terminal.auto_activate
             }
             ConfigFieldId::AgentEnabled => self.working.agent.enabled = !self.working.agent.enabled,
-            ConfigFieldId::AgentClaudeHooks => {
-                self.working.agent.claude_hooks = !self.working.agent.claude_hooks
-            }
             ConfigFieldId::PostCreateAutoInstall => {
                 self.working.post_create.auto_install = !self.working.post_create.auto_install
             }
@@ -2358,7 +2347,6 @@ fn render_field_value(config: &Config, field: &ConfigFieldSpec) -> String {
         AgentEnabled => config.agent.enabled.to_string(),
         AgentRefreshRate => config.agent.refresh_rate.to_string(),
         AgentMaxActivities => config.agent.max_activities.to_string(),
-        AgentClaudeHooks => config.agent.claude_hooks.to_string(),
         PostCreateAutoInstall => config.post_create.auto_install.to_string(),
     }
 }

--- a/tests/unit/config_tests.rs
+++ b/tests/unit/config_tests.rs
@@ -57,7 +57,6 @@ fn test_config_with_custom_values() {
             enabled: false,
             refresh_rate: 2000,
             max_activities: 50,
-            claude_hooks: false,
         },
         post_create: PostCreateConfig {
             auto_install: false,


### PR DESCRIPTION
## Summary

`config.agent.claude_hooks` was declared in `AgentConfig`, defaulted to true, printed by `warp config --show`, and toggleable in the config TUI -- but no runtime call site ever read it. Toggling had no effect, which misled anyone who set it expecting Claude Code hook installation to be gated.

Hook install/remove is already an explicit user action (`warp hooks-install` / `warp hooks-remove`), and `[agent].enabled` already gates the dashboard globally. The Claude-only knob duplicated that surface without adding control, so this drops it.

Removed:

- `claude_hooks` field on `AgentConfig` (struct, default, and `Config::sample_config()` template + format arg) in `src/config.rs`.
- The `"Claude hooks: ..."` line in `warp config --show` in `src/cli.rs`.
- `ConfigFieldId::AgentClaudeHooks`, its `ConfigFieldSpec`, the toggle arm, and the render arm in `src/tui.rs`.
- The sample-config `claude_hooks = true` line in `README.md` and `docs/user-guide.md`.
- The corresponding entries in `tests/unit/config_tests.rs` and `benches/performance_benchmarks.rs`.

Existing user `config.toml` files that already set `claude_hooks = ...` continue to load -- serde silently ignores the unknown key.

## Verification

- `cargo clippy --all-targets -- -D warnings` -- clean.
- `cargo test --quiet` -- 73 + 76 + 210 tests pass.
- `git diff --check` -- clean.
- `grep -R "claude_hooks" .` after the change -- only `src/hooks.rs:569`, which is the unrelated `test_claude_hooks_config_generation` test name.

Note: `cargo fmt --check` reports a pre-existing diff in `src/post_create.rs` (from #121); unrelated to this change.

Closes #111