### PR TITLE
Register SessionStart hook for immediate agent visibility

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -607,3 +607,18 @@ pub fn parse_claude_session_event_line(line: &str) -> Option<AgentSessionSummary
         source: AgentSessionSource::SessionStore,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_map_status() {
+        assert!(matches!(map_status("starting"), AgentSessionState::Starting));
+        assert!(matches!(map_status("working"), AgentSessionState::Working));
+        assert!(matches!(map_status("processing"), AgentSessionState::Processing));
+        assert!(matches!(map_status("waiting"), AgentSessionState::Waiting));
+        assert!(matches!(map_status("subagent_complete"), AgentSessionState::Completed));
+        assert!(matches!(map_status("unknown"), AgentSessionState::Unknown));
+    }
+}

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -18,6 +18,7 @@ pub enum AgentRuntime {
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum AgentSessionState {
+    Starting,
     Working,
     Processing,
     Waiting,
@@ -67,6 +68,7 @@ fn parse_timestamp(value: &str) -> Option<DateTime<Local>> {
 
 fn map_status(value: &str) -> AgentSessionState {
     match value {
+        "starting" => AgentSessionState::Starting,
         "working" => AgentSessionState::Working,
         "processing" => AgentSessionState::Processing,
         "waiting" => AgentSessionState::Waiting,

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 const GIT_WARP_HOOK_PREFIX: &str = "agent_status_";
 
 const EXPECTED_EVENTS: &[&str] = &[
+    "SessionStart",
     "UserPromptSubmit",
     "Stop",
     "PreToolUse",
@@ -420,6 +421,7 @@ impl HooksManager {
 
     fn get_hooks_config(runtime: HookRuntime) -> Value {
         let hooks = json!({
+            "SessionStart": [Self::build_hook_entry(runtime, "starting", "agent_status_sessionstart")],
             "UserPromptSubmit": [Self::build_hook_entry(runtime, "processing", "agent_status_userpromptsubmit")],
             "Stop": [Self::build_hook_entry(runtime, "waiting", "agent_status_stop")],
             "PreToolUse": [Self::build_hook_entry(runtime, "working", "agent_status_pretooluse")],
@@ -571,6 +573,7 @@ mod tests {
         assert!(config.get("hooks").is_some());
 
         let hooks = &config["hooks"];
+        assert!(hooks.get("SessionStart").is_some());
         assert!(hooks.get("UserPromptSubmit").is_some());
         assert!(
             hooks["Stop"][0]["hooks"][0]["command"]
@@ -584,6 +587,7 @@ mod tests {
     fn test_codex_hooks_config_generation() {
         let config = HooksManager::get_hooks_config(HookRuntime::Codex);
         assert!(config.get("hooks").is_none());
+        assert!(config.get("SessionStart").is_some());
         assert!(config.get("PreToolUse").is_some());
         assert!(
             config["Stop"][0]["hooks"][0]["command"]
@@ -618,7 +622,7 @@ mod tests {
 
         let settings: Value =
             serde_json::from_str(&fs::read_to_string(&hooks_path).unwrap()).unwrap();
-        assert_eq!(settings["SessionStart"].as_array().unwrap().len(), 1);
+        assert_eq!(settings["SessionStart"].as_array().unwrap().len(), 2);
         assert_eq!(settings["PreToolUse"].as_array().unwrap().len(), 2);
         assert!(
             settings["PreToolUse"]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -958,6 +958,7 @@ pub fn session_detail_lines(session: &AgentSessionSummary) -> Vec<String> {
 
 fn session_state_symbol(state: AgentSessionState) -> &'static str {
     match state {
+        AgentSessionState::Starting => "â—‹",
         AgentSessionState::Working => "●",
         AgentSessionState::Processing => "◔",
         AgentSessionState::Waiting => "!",
@@ -969,6 +970,7 @@ fn session_state_symbol(state: AgentSessionState) -> &'static str {
 
 fn session_state_label(state: AgentSessionState) -> &'static str {
     match state {
+        AgentSessionState::Starting => "starting",
         AgentSessionState::Working => "working",
         AgentSessionState::Processing => "processing",
         AgentSessionState::Waiting => "waiting",
@@ -980,6 +982,7 @@ fn session_state_label(state: AgentSessionState) -> &'static str {
 
 fn session_state_color(state: AgentSessionState) -> Color {
     match state {
+        AgentSessionState::Starting => Color::White,
         AgentSessionState::Working => Color::Green,
         AgentSessionState::Processing => Color::Cyan,
         AgentSessionState::Waiting => Color::Yellow,


### PR DESCRIPTION
## Summary
- Register the `SessionStart` event for Claude and Codex hooks to ensure immediate visibility in the agents dashboard.
- Introduce `AgentSessionState::Starting` to distinguish freshly opened sessions from active work.
- Update TUI rendering to display the `Starting` state with a white open circle symbol.
- Update hook diagnostics to include `SessionStart` in the expected event list.

Closes #112

## Verification
- `cargo test hooks::tests` (12 passed)
- `cargo test agents::tests` (1 passed)
- `cargo test tui::tests` (20 passed)
- `./target/debug/warp hooks-status` reported `Partial` after the change and `Complete` after re-install.
- Verified project-level hook installation for Claude Code.