### PR TITLE
feat: extend uninstall.sh with hook and shell-config cleanup

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -114,10 +114,13 @@ Remove the default install with the bundled uninstaller:
 curl -fsSL https://raw.githubusercontent.com/denysbutenko/git-warp/main/uninstall.sh | sh
 ```
 
-The uninstaller removes `~/.local/bin/warp` (or `$GIT_WARP_INSTALL_DIR/warp`),
-lists any other detected `warp` installs without touching them, and warns if
-`warp` is still on `PATH` after the removal. Use `--dry-run` to preview the
-removal without changing anything.
+The uninstaller:
+- Removes agent hook entries from Claude/Codex settings using the `warp` binary before its deletion (opt out with `GIT_WARP_KEEP_HOOKS=1`).
+- Removes `~/.local/bin/warp` (or `$GIT_WARP_INSTALL_DIR/warp`).
+- Scans `~/.bashrc`, `~/.zshrc`, and `~/.config/fish/config.fish` for leftover shell-config snippets and prints cleanup instructions if found.
+- Lists any other detected `warp` installs without touching them.
+
+Use `--dry-run` to preview the changes without modifying your system.
 
 If you installed Git-Warp with Cargo, also run:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2015,10 +2015,22 @@ impl Cli {
                 let rc_label = rc_path.display().to_string();
                 let configured = Self::shell_rc_has_warp_integration(rc_path);
                 if configured {
-                    Self::doctor_ok(
-                        "Shell integration",
-                        format!("warp_cd helper detected in {rc_label}"),
-                    );
+                    if active.is_none() {
+                        Self::doctor_warn(
+                            "Shell integration",
+                            format!(
+                                "warp_cd helper detected in {rc_label} but 'warp' is not on PATH"
+                            ),
+                        );
+                        next_steps.push(format!(
+                            "Remove Git-Warp snippets from {rc_label} or fix your PATH."
+                        ));
+                    } else {
+                        Self::doctor_ok(
+                            "Shell integration",
+                            format!("warp_cd helper detected in {rc_label}"),
+                        );
+                    }
                 } else {
                     Self::doctor_warn(
                         "Shell integration",

--- a/src/post_create.rs
+++ b/src/post_create.rs
@@ -33,9 +33,10 @@ impl PackageManager {
 
     pub fn install_args(self) -> &'static [&'static str] {
         match self {
-            PackageManager::Pnpm | PackageManager::Yarn | PackageManager::Bun | PackageManager::Npm => {
-                &["install"]
-            }
+            PackageManager::Pnpm
+            | PackageManager::Yarn
+            | PackageManager::Bun
+            | PackageManager::Npm => &["install"],
             PackageManager::Cargo => &["check"],
         }
     }

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -65,6 +65,44 @@ list_other_installs() {
   done
 }
 
+remove_hooks() {
+  [ -x "$target" ] || return 0
+  [ "${GIT_WARP_KEEP_HOOKS:-0}" = "1" ] && return 0
+
+  if [ "$dry_run" -eq 1 ]; then
+    echo "Would remove user hooks with: $target hooks-remove --level user --runtime all"
+    if [ -d .git ]; then
+      echo "Would remove project hooks with: $target hooks-remove --level project --runtime all"
+    fi
+  else
+    echo "Removing agent hooks..."
+    "$target" hooks-remove --level user --runtime all >/dev/null 2>&1 || echo "warning: failed to remove user hooks"
+    if [ -d .git ]; then
+      "$target" hooks-remove --level project --runtime all >/dev/null 2>&1 || echo "warning: failed to remove project hooks"
+    fi
+  fi
+}
+
+check_shell_rc() {
+  # Common shell RC files
+  files="${HOME}/.bashrc ${HOME}/.zshrc ${HOME}/.config/fish/config.fish"
+  found=0
+  for f in $files; do
+    [ -f "$f" ] || continue
+    if grep -q "warp_cd" "$f" || grep -q "warp __complete" "$f"; then
+      [ "$found" -eq 0 ] && echo && echo "Leftover shell-config snippets detected:"
+      echo "  - $f"
+      found=1
+    fi
+  done
+
+  if [ "$found" -eq 1 ]; then
+    echo "To clean up shell integration, remove lines containing 'warp_cd' or 'warp __complete' from these files."
+  fi
+}
+
+remove_hooks
+
 if [ ! -e "$target" ]; then
   echo "No Git-Warp binary found at ${target}; nothing to remove."
 else
@@ -78,6 +116,8 @@ else
     echo "Removed ${target}"
   fi
 fi
+
+check_shell_rc
 
 others="$(list_other_installs)"
 if [ -n "$others" ]; then


### PR DESCRIPTION
## Summary
- Before removing the binary, `uninstall.sh` now attempts to run `hooks-remove --runtime all` for both `user` and `project` levels.
- Added a shell RC scan (`.bashrc`, `.zshrc`, `.config/fish/config.fish`) to detect and report leftover `warp_cd` and `warp __complete` snippets after uninstallation.
- Enhanced `warp doctor` to flag cases where shell integration is present but the `warp` binary is missing from the PATH.
- Updated `docs/install.md` with the extended uninstallation flow and opt-out instructions (`GIT_WARP_KEEP_HOOKS=1`).

## Verification
- Created a reproduction script with a fake home environment, fake shell RC, and fake hook entries.
- Verified that `uninstall.sh` successfully:
  - Called the binary to remove hooks.
  - Removed the binary.
  - Reported the leftover shell RC snippet.
- Verified that `warp doctor` correctly identifies broken shell integration in the fake environment.
- Ran existing CLI surface tests: 51 passed.
- Verified `cargo fmt --check` and `git diff --check`.

Closes #113