### PR TITLE
feat(cli): add interactive selection TUI to warp ls

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,6 +62,9 @@ pub enum Commands {
         /// Show debug information
         #[arg(long)]
         debug: bool,
+        /// Interactive mode
+        #[arg(long, short)]
+        interactive: bool,
     },
 
     /// Clean up worktrees
@@ -398,7 +401,7 @@ impl Cli {
                 *waiting,
                 *no_cow,
             ),
-            Commands::Ls { debug } => self.handle_ls(*debug),
+            Commands::Ls { debug, interactive } => self.handle_ls(*debug, *interactive),
             Commands::Cleanup {
                 mode,
                 force,
@@ -1089,11 +1092,16 @@ impl Cli {
         Ok(monitored_paths)
     }
 
-    fn handle_ls(&self, debug: bool) -> Result<()> {
+    fn handle_ls(&self, debug: bool, interactive: bool) -> Result<()> {
         use crate::git::GitRepository;
         use crate::process::ProcessManager;
+        use std::io::IsTerminal;
 
         info!("Listing worktrees");
+
+        if interactive || (std::io::stdout().is_terminal() && !self.dry_run) {
+            return self.handle_default_switcher();
+        }
 
         let git_repo = GitRepository::find().map_err(|_| Self::not_in_git_repo_error())?;
 

--- a/src/post_create.rs
+++ b/src/post_create.rs
@@ -33,9 +33,10 @@ impl PackageManager {
 
     pub fn install_args(self) -> &'static [&'static str] {
         match self {
-            PackageManager::Pnpm | PackageManager::Yarn | PackageManager::Bun | PackageManager::Npm => {
-                &["install"]
-            }
+            PackageManager::Pnpm
+            | PackageManager::Yarn
+            | PackageManager::Bun
+            | PackageManager::Npm => &["install"],
             PackageManager::Cargo => &["check"],
         }
     }

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -853,6 +853,24 @@ fn test_ls_orders_current_then_primary_then_dirty_with_summary() {
 }
 
 #[test]
+fn test_ls_interactive_triggers_switcher_dry_run() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+    create_worktree(repo_path, "feature/interactive-ls");
+
+    let output = warp_command(repo_path)
+        .args(["ls", "--interactive", "--dry-run"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{stdout}");
+    assert!(stdout.contains("Would open interactive worktree switcher"));
+    assert!(stdout.contains("main"));
+    assert!(stdout.contains("feature/interactive-ls"));
+}
+
+#[test]
 fn test_bare_warp_dry_run_previews_interactive_switcher() {
     let temp_dir = setup_test_repo();
     let repo_path = temp_dir.path();


### PR DESCRIPTION
Adds an --interactive (or -i) flag to `warp ls`. When the flag is set, or when connected to a TTY and no redirection is used, `warp ls` now launches the interactive selection TUI (the same one used by `warp` with no args) instead of printing a static list.

Selecting a worktree in the TUI immediately triggers a switch to that worktree in the preferred terminal mode.

### Verification
- Added `test_ls_interactive_triggers_switcher_dry_run` to verify dry-run behavior.
- Verified that existing `ls` tests still pass in non-TTY environments.
- Ran full test suite: all 359 tests passed.

Closes #118