### PR TITLE
docs(post-create): document and test Cargo support (#119)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ terminal handoff modes that print or send shell commands.
 
 `post_create.auto_install` controls whether Git-Warp runs the matching
 `<manager> install` after creating a new worktree. Lockfile detection order is
-`pnpm-lock.yaml` → `yarn.lock` → `bun.lock` → `bun.lockb` → `package-lock.json`; the first
+`pnpm-lock.yaml` â†’ `yarn.lock` â†’ `bun.lock` â†’ `bun.lockb` â†’ `package-lock.json` â†’ `Cargo.toml`; the first
 match wins. Set `auto_install = false` (or
 `GIT_WARP_POST_CREATE__AUTO_INSTALL=false`) to skip the install step entirely.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -300,8 +300,8 @@ disabled banner; `[agent].refresh_rate` sets the dashboard poll interval in
 milliseconds (clamped to ≥ 250 ms).
 
 `post_create.auto_install` runs the matching `<manager> install` after Git-Warp
-creates a new worktree. Lockfile detection order is `pnpm-lock.yaml` →
-`yarn.lock` → `bun.lock` → `bun.lockb` → `package-lock.json`; the first match wins. Set
+creates a new worktree. Lockfile detection order is `pnpm-lock.yaml` â†’
+`yarn.lock` â†’ `bun.lock` â†’ `bun.lockb` â†’ `package-lock.json` â†’ `Cargo.toml`; the first match wins. Set
 `auto_install = false` to skip the install step entirely.
 
 Environment variables override config file values. Top-level keys map

--- a/tests/integration/switch_post_create_tests.rs
+++ b/tests/integration/switch_post_create_tests.rs
@@ -127,3 +127,68 @@ fn test_warp_switch_warns_when_pnpm_install_fails_but_still_succeeds() {
     assert!(stdout.contains("Detected pnpm repo but `pnpm install` failed: install failed"));
     assert!(stdout.contains("Worktree creation: created"));
 }
+
+#[test]
+fn test_warp_switch_runs_cargo_check_for_rust_repo() {
+    let temp_dir = tempdir().unwrap();
+    let repo_path = temp_dir.path();
+
+    Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    fs::write(repo_path.join("Cargo.toml"), "[package]\nname = \"test\"\n").unwrap();
+
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    Command::new("git")
+        .args(["commit", "-m", "Initial commit"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    let bin_dir = tempdir().unwrap();
+    let marker_path = temp_dir.path().join("cargo-runs.txt");
+
+    let cargo_path = bin_dir.path().join("cargo");
+    fs::write(
+        &cargo_path,
+        format!(
+            "#!/bin/sh\nprintf \"%s\\n\" \"$PWD\" >> \"{}\"\nexit 0\n",
+            marker_path.display()
+        ),
+    )
+    .unwrap();
+    #[cfg(unix)]
+    make_executable(&cargo_path);
+
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    let path_env = format!("{}:{}", bin_dir.path().display(), original_path);
+
+    let output = run_warp_switch(repo_path, "feature/cargo-check", &path_env);
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Detected cargo repo, ran `cargo check`"));
+
+    let marker_contents = fs::read_to_string(marker_path).unwrap();
+    assert_eq!(marker_contents.lines().count(), 1);
+}


### PR DESCRIPTION
## Summary
- Updated `README.md` and `docs/user-guide.md` to include `Cargo.toml` in the `post_create.auto_install` lockfile detection order.
- Added an integration test `test_warp_switch_runs_cargo_check_for_rust_repo` to verify that `warp switch` correctly runs `cargo check` in Rust repositories.

## Verification
- `cargo fmt --check` (PASS)
- `cargo clippy --all-targets -- -D warnings` (PASS)
- `cargo test` (All 364 tests PASS)
- `git diff --check` (PASS)

Closes #119