### PR TITLE
fix(cli): make --debug actually enable debug logging (#147)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -367,12 +367,6 @@ impl Cli {
     }
 
     pub fn run(&self) -> Result<()> {
-        if self.debug {
-            unsafe {
-                std::env::set_var("RUST_LOG", "debug");
-            }
-        }
-
         match &self.command {
             Some(command) => self.handle_command(command),
             None => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,12 +18,16 @@ use clap::Parser;
 use cli::Cli;
 
 fn main() -> Result<()> {
-    // Initialize logger
-    env_logger::init();
+    // Resolve --debug before initializing the logger; env_logger captures the
+    // filter at init time, so flipping RUST_LOG inside Cli::run is too late.
+    let want_debug = std::env::args().any(|arg| arg == "--debug" || arg == "-d");
+    let mut builder = env_logger::Builder::from_default_env();
+    if want_debug && std::env::var_os("RUST_LOG").is_none() {
+        builder.filter_level(log::LevelFilter::Debug);
+    }
+    builder.init();
+    log::debug!("Debug logging enabled");
 
-    // Parse CLI arguments
     let cli = Cli::parse();
-
-    // Handle the command
     cli.run()
 }

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -1914,3 +1914,63 @@ fn test_bare_warp_dry_run_marks_local_only_branch_in_switcher() {
         .expect(&stdout);
     assert!(!tracked_line.contains("local-only"), "{tracked_line}");
 }
+
+#[test]
+fn test_debug_flag_enables_debug_logging() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+
+    let output = warp_command(repo_path)
+        .env_remove("RUST_LOG")
+        .args(["--debug", "ls"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "{stdout}{stderr}");
+    assert!(
+        stderr.contains("Debug logging enabled"),
+        "--debug should emit debug-level logs on stderr: {stderr}"
+    );
+}
+
+#[test]
+fn test_default_logger_stays_quiet_without_debug_flag() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+
+    let output = warp_command(repo_path)
+        .env_remove("RUST_LOG")
+        .arg("ls")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "{stdout}{stderr}");
+    assert!(
+        !stderr.contains("Debug logging enabled"),
+        "default filter should suppress debug logs: {stderr}"
+    );
+}
+
+#[test]
+fn test_existing_rust_log_overrides_debug_flag_default() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+
+    let output = warp_command(repo_path)
+        .env("RUST_LOG", "error")
+        .args(["--debug", "ls"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "{stdout}{stderr}");
+    assert!(
+        !stderr.contains("Debug logging enabled"),
+        "explicit RUST_LOG=error should win over --debug: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

- `warp --debug <cmd>` did nothing. `env_logger::init()` ran in `main` before `Cli::parse`, so the later `RUST_LOG=debug` assignment in `Cli::run` had no effect on the already-initialized logger.
- Now `main` checks `--debug` / `-d` before `env_logger` init and bumps the builder to `LevelFilter::Debug` when `RUST_LOG` is unset. An explicit `RUST_LOG` still wins.
- Dropped the dead `unsafe { set_var(...) }` block from `Cli::run` (also unsafe under edition 2024).
- New `cli_surface_tests` cover three states: `--debug` on, `--debug` off, and `RUST_LOG=error` overriding `--debug`.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --test mod -- integration::cli_surface_tests` (55 passed)
- `git diff --check`

Closes #147