### PR TITLE
perf(process): refresh sysinfo processes only and once per pass (#148)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -502,6 +502,7 @@ impl Cli {
         worktrees: &[crate::git::WorktreeInfo],
         mut process_manager: crate::process::ProcessManager,
     ) -> Vec<crate::tui::WorktreeRuntimeStatus> {
+        process_manager.refresh();
         let current_dir = std::env::current_dir().unwrap_or_else(|_| git_repo.root_path().into());
         let current_dir =
             std::fs::canonicalize(&current_dir).unwrap_or_else(|_| current_dir.clone());
@@ -1127,6 +1128,7 @@ impl Cli {
             return Ok(());
         }
 
+        process_manager.refresh();
         let mut rows: Vec<LsRow> = worktrees
             .into_iter()
             .map(|worktree| {
@@ -1427,6 +1429,9 @@ impl Cli {
 
         // Show what would be cleaned up
         println!("🧹 Cleanup candidates:");
+        if check_processes {
+            process_manager.refresh();
+        }
         let mut process_busy = Vec::new();
         for candidate in &candidates {
             let remote = if candidate.has_remote {
@@ -1518,6 +1523,9 @@ impl Cli {
         let mut cleaned = 0;
         let mut failed = 0;
 
+        if check_processes {
+            process_manager.refresh();
+        }
         for candidate in candidates {
             println!("🗑️  Removing worktree: {}", candidate.branch);
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 #[cfg(unix)]
 use std::time::Instant;
-use sysinfo::System;
+use sysinfo::{ProcessesToUpdate, System};
 
 #[derive(Debug, Clone)]
 pub struct ProcessInfo {
@@ -41,16 +41,22 @@ impl Default for ProcessManager {
 impl ProcessManager {
     pub fn new() -> Self {
         let mut system = System::new();
-        system.refresh_all();
+        system.refresh_processes(ProcessesToUpdate::All, true);
         Self { system }
     }
 
-    /// Refresh process information
+    /// Refresh process information. Call once before iterating many directories
+    /// — `find_processes_in_directory` does not refresh on its own.
     pub fn refresh(&mut self) {
-        self.system.refresh_all();
+        log::debug!("ProcessManager: refreshing process list");
+        self.system.refresh_processes(ProcessesToUpdate::All, true);
     }
 
-    /// Find all processes running in a specific directory
+    /// Find all processes whose cwd lives under `path`.
+    ///
+    /// Reads from the currently-cached `sysinfo` state. Callers that walk many
+    /// worktrees should `refresh()` once before the loop instead of paying for
+    /// a refresh per call.
     pub fn find_processes_in_directory<P: AsRef<Path>>(
         &mut self,
         path: P,
@@ -63,7 +69,6 @@ impl ProcessManager {
                     path: requested_path.display().to_string(),
                 })?;
 
-        self.refresh();
         let mut processes = Vec::new();
 
         for (pid, process) in self.system.processes() {
@@ -256,6 +261,7 @@ impl ProcessManager {
     /// Get detailed process statistics for a directory
     #[allow(dead_code)] // Public helper used by tests/embedders.
     pub fn get_directory_process_stats<P: AsRef<Path>>(&mut self, path: P) -> Result<ProcessStats> {
+        self.refresh();
         let processes = self.find_processes_in_directory(path)?;
 
         let total_count = processes.len();
@@ -280,6 +286,7 @@ impl ProcessManager {
         auto_confirm: bool,
         kill_timeout: Duration,
     ) -> Result<bool> {
+        self.refresh();
         let processes = self.find_processes_in_directory(path)?;
 
         if processes.is_empty() {

--- a/tests/unit/process_tests.rs
+++ b/tests/unit/process_tests.rs
@@ -394,8 +394,12 @@ fn find_processes_in_directory_works_without_caller_refresh() {
     let temp_dir = tempdir().unwrap();
     let mut manager = ProcessManager::new();
 
-    let first = manager.find_processes_in_directory(temp_dir.path()).unwrap();
-    let second = manager.find_processes_in_directory(temp_dir.path()).unwrap();
+    let first = manager
+        .find_processes_in_directory(temp_dir.path())
+        .unwrap();
+    let second = manager
+        .find_processes_in_directory(temp_dir.path())
+        .unwrap();
 
     assert_eq!(first.len(), second.len());
 }

--- a/tests/unit/process_tests.rs
+++ b/tests/unit/process_tests.rs
@@ -385,3 +385,30 @@ wait "$child_pid"
         }
     }
 }
+
+#[test]
+fn find_processes_in_directory_works_without_caller_refresh() {
+    // ProcessManager::new() refreshes once internally; a follow-up query
+    // against a known-empty directory must still return Ok and a stable
+    // result without an explicit caller refresh.
+    let temp_dir = tempdir().unwrap();
+    let mut manager = ProcessManager::new();
+
+    let first = manager.find_processes_in_directory(temp_dir.path()).unwrap();
+    let second = manager.find_processes_in_directory(temp_dir.path()).unwrap();
+
+    assert_eq!(first.len(), second.len());
+}
+
+#[test]
+fn get_directory_process_stats_refreshes_internally() {
+    // One-shot embedder entry point: must succeed against a fresh manager
+    // without the caller arranging a refresh.
+    let temp_dir = tempdir().unwrap();
+    let mut manager = ProcessManager::new();
+
+    let stats = manager
+        .get_directory_process_stats(temp_dir.path())
+        .expect("stats query succeeds");
+    assert_eq!(stats.total_count, stats.processes.len());
+}


### PR DESCRIPTION
## Summary

- `ProcessManager::new` / `refresh` now call `System::refresh_processes(ProcessesToUpdate::All, true)` instead of `refresh_all`. CPU/mem/components were never read by the cwd-based directory filter.
- `find_processes_in_directory` is now a pure query — the per-call `self.refresh()` is gone. Callers that walk many worktrees refresh once before the loop, so cost drops from `N + 1` refreshes per `warp` switcher pass to `1`.
- `collect_worktree_runtime_statuses`, `handle_ls`, and both cleanup loops (pre-scan + execution) refresh once up front, gated by `check_processes` where applicable.
- One-shot embedder helpers `get_directory_process_stats` and `kill_directory_processes` refresh internally so their existing single-call semantics survive.
- `refresh` emits a `log::debug!` line so future refresh-per-pass regressions are observable via `RUST_LOG=debug warp ...`.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (216 passed, 0 failed)
- `git diff --check`

New tests in `tests/unit/process_tests.rs` pin down the contract: `find_processes_in_directory` works without a caller refresh (`ProcessManager::new` still primes the state once), and `get_directory_process_stats` keeps refreshing internally for embedder use.

Closes #148