### PR TITLE
fix(cli): reject invalid --terminal and config terminal_mode (#153)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,8 +28,8 @@ pub struct Cli {
     pub dry_run: bool,
 
     /// Terminal mode: tab, window, current, inplace, echo
-    #[arg(long, global = true)]
-    pub terminal: Option<String>,
+    #[arg(long, global = true, value_enum)]
+    pub terminal: Option<crate::terminal::TerminalMode>,
 
     /// Auto-confirm operations
     #[arg(long, short = 'y', global = true)]
@@ -675,15 +675,10 @@ impl Cli {
 
     fn handle_existing_worktree_jump(&self, worktree_path: &Path) -> Result<()> {
         use crate::config::ConfigManager;
-        use crate::terminal::TerminalMode;
 
         let config_manager = ConfigManager::new()?;
         let config = config_manager.get();
-        let terminal_mode = if let Some(mode_str) = &self.terminal {
-            TerminalMode::from_str(mode_str).unwrap_or(TerminalMode::Tab)
-        } else {
-            TerminalMode::from_str(&config.terminal_mode).unwrap_or(TerminalMode::Tab)
-        };
+        let terminal_mode = self.resolve_terminal_mode(&config.terminal_mode)?;
 
         let mut report = SwitchOutcomeReport::new(worktree_path.to_path_buf());
         report.skipped("Worktree creation", "already existed");
@@ -712,7 +707,6 @@ impl Cli {
         use crate::git::GitRepository;
         use crate::post_create::{PostCreateSetupStatus, run_post_create_setup};
         use crate::rewrite::PathRewriter;
-        use crate::terminal::TerminalMode;
 
         // Find the Git repository
         let git_repo = GitRepository::find().map_err(|_| Self::not_in_git_repo_error())?;
@@ -872,11 +866,7 @@ impl Cli {
             | PostCreateSetupStatus::SkippedNoLockfile => {}
         }
 
-        let terminal_mode = if let Some(mode_str) = &self.terminal {
-            TerminalMode::from_str(mode_str).unwrap_or(TerminalMode::Tab)
-        } else {
-            TerminalMode::from_str(&config.terminal_mode).unwrap_or(TerminalMode::Tab)
-        };
+        let terminal_mode = self.resolve_terminal_mode(&config.terminal_mode)?;
 
         self.record_terminal_handoff(
             &mut report,
@@ -888,6 +878,20 @@ impl Cli {
         report.finish();
 
         Ok(())
+    }
+
+    fn resolve_terminal_mode(&self, config_mode: &str) -> Result<crate::terminal::TerminalMode> {
+        use crate::terminal::TerminalMode;
+        if let Some(mode) = self.terminal {
+            return Ok(mode);
+        }
+        TerminalMode::from_str(config_mode).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Invalid terminal_mode '{}' in config. Supported modes: {}",
+                config_mode,
+                TerminalMode::SUPPORTED.join(", "),
+            )
+        })
     }
 
     fn record_branch_checkout(

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -2,16 +2,19 @@ use crate::error::{GitWarpError, Result};
 use std::path::Path;
 use std::process::Command;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum TerminalMode {
     Tab,
     Window,
+    #[value(name = "inplace")]
     InPlace,
     Echo,
     Current,
 }
 
 impl TerminalMode {
+    pub const SUPPORTED: &'static [&'static str] = &["tab", "window", "inplace", "echo", "current"];
+
     // Returns Option, not Result — we deliberately don't implement std::str::FromStr.
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Option<Self> {

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -569,6 +569,28 @@ chmod 755 "$dest/warp"
 }
 
 #[test]
+fn test_unknown_terminal_flag_value_is_rejected() {
+    let output = Command::new(env!("CARGO_BIN_EXE_warp"))
+        .args(["--terminal", "nonsense", "switch", "foo"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "warp should reject unknown terminal mode; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("tab")
+            && stderr.contains("window")
+            && stderr.contains("inplace")
+            && stderr.contains("echo")
+            && stderr.contains("current"),
+        "stderr should list supported terminal modes; got: {stderr}"
+    );
+}
+
+#[test]
 fn test_root_help_hides_removed_global_flag() {
     let output = Command::new(env!("CARGO_BIN_EXE_warp"))
         .arg("--help")


### PR DESCRIPTION
## Summary

- `Cli::terminal` is now `Option<TerminalMode>` with `clap::ValueEnum`. Clap rejects unknown `--terminal` values at parse time and prints the supported list, instead of silently falling back to `Tab`.
- New `Cli::resolve_terminal_mode` helper centralises the flag-vs-config precedence used by `handle_existing_worktree_jump` and `handle_switch`. When the config file's `terminal_mode` string does not parse, it returns an `anyhow::Error` naming the supported modes rather than swallowing the typo.
- `TerminalMode` keeps its manual `from_str` for config parsing and adds a `SUPPORTED` slice so the error message stays in sync with the accepted variants. The `InPlace` variant maps to the CLI name `inplace` via `#[value(name = "inplace")]` for backwards compatibility.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (220 passed, 0 failed; was 219 before this change)
- `git diff --check`

Closes #153