### PR TITLE
refactor(error): drop unused GitWarpError variants (#155)

### DIFF
--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -481,15 +481,18 @@ pub struct ConfigManager {
 pub enum GitWarpError {
     #[error("Not in a git repository")]
     NotInGitRepository,
-    
+
+    #[error("Worktree '{path}' not found")]
+    WorktreeNotFound { path: String },
+
     #[error("Copy-on-Write is not supported on this filesystem")]
     CoWNotSupported,
-    
+
+    #[error("Terminal integration not supported on this platform")]
+    TerminalNotSupported,
+
     #[error("Configuration error: {message}")]
     ConfigError { message: String },
-    
-    #[error("Failed to terminate processes: {reason}")]
-    ProcessTerminationFailed { reason: String },
 }
 ```
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,38 +2,22 @@ use thiserror::Error;
 
 pub type Result<T> = anyhow::Result<T>;
 
-#[allow(dead_code)] // Public error API; some variants are produced only via paths not reachable from `warp` bin yet.
 #[derive(Error, Debug)]
 pub enum GitWarpError {
     #[error("Not in a git repository")]
     NotInGitRepository,
 
-    #[error("Branch '{branch}' already exists")]
-    BranchAlreadyExists { branch: String },
-
-    #[error("Worktree '{path}' already exists")]
-    WorktreeAlreadyExists { path: String },
-
-    #[error("Branch '{branch}' not found")]
-    BranchNotFound { branch: String },
-
     #[error("Worktree '{path}' not found")]
     WorktreeNotFound { path: String },
 
+    // Constructed only on the macOS APFS path and the non-CoW fallback; never
+    // on Linux, where the reflink probe reports support via a bool instead.
+    #[cfg_attr(target_os = "linux", allow(dead_code))]
     #[error("Copy-on-Write is not supported on this filesystem")]
     CoWNotSupported,
 
-    #[error("Failed to create worktree: {reason}")]
-    WorktreeCreationFailed { reason: String },
-
     #[error("Terminal integration not supported on this platform")]
     TerminalNotSupported,
-
-    #[error("No processes found in directory '{path}'")]
-    NoProcessesFound { path: String },
-
-    #[error("Failed to terminate processes: {reason}")]
-    ProcessTerminationFailed { reason: String },
 
     #[error("Configuration error: {message}")]
     ConfigError { message: String },


### PR DESCRIPTION
## Summary

- Six `GitWarpError` variants have zero constructors in the crate (verified with `grep -rn "GitWarpError::<variant>" src/`): `BranchAlreadyExists`, `WorktreeAlreadyExists`, `BranchNotFound`, `WorktreeCreationFailed`, `NoProcessesFound`, `ProcessTerminationFailed`.
- The type-level `#[allow(dead_code)]` on the enum was hiding them from clippy and `cargo check`. Drop the variants and the blanket allow so future additions have to be wired up or fail the build.
- Update the `docs/technical-overview.md` enum snippet to match the live variants.
- Existing `anyhow::anyhow!(...)` call sites stay as they are — the issue only suggested migrating them to typed variants if a downstream matcher wanted them, and none does today.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (221 passed)
- `git diff --check`

Closes #155