### PR TITLE
fix(cow): probe nearest existing ancestor for CoW support (#159)

### DIFF
--- a/src/cow.rs
+++ b/src/cow.rs
@@ -1,24 +1,39 @@
 use crate::error::{GitWarpError, Result};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-/// Check if Copy-on-Write is supported for the given path
+/// Check if Copy-on-Write is supported for the given path.
+///
+/// Resolves to the nearest existing ancestor first so callers can probe a
+/// not-yet-created worktree path without the underlying filesystem syscalls
+/// failing with `ENOENT`.
 pub fn is_cow_supported<P: AsRef<Path>>(path: P) -> Result<bool> {
+    let probe = nearest_existing_ancestor(path.as_ref());
+
     #[cfg(target_os = "macos")]
     {
-        // Check if the path is on an APFS filesystem
-        is_apfs(path)
+        is_apfs(&probe)
     }
 
     #[cfg(target_os = "linux")]
     {
-        is_linux_reflink_supported(path)
+        is_linux_reflink_supported(&probe)
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     {
-        let _ = path;
+        let _ = probe;
         Ok(false)
     }
+}
+
+fn nearest_existing_ancestor(path: &Path) -> PathBuf {
+    let mut candidate = path.to_path_buf();
+    while !candidate.exists() {
+        if !candidate.pop() {
+            return PathBuf::from(".");
+        }
+    }
+    candidate
 }
 
 /// Clone a directory using Copy-on-Write
@@ -68,9 +83,6 @@ fn is_linux_reflink_supported<P: AsRef<Path>>(path: P) -> Result<bool> {
     use std::process::Command;
 
     let path = path.as_ref();
-    if !path.exists() {
-        return Ok(false);
-    }
 
     // Attempt to create a temp file in the target directory to test reflink
     let temp_dir = if path.is_dir() {
@@ -181,6 +193,20 @@ mod tests {
     fn test_cow_support_check() {
         let result = is_cow_supported(".");
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_cow_support_resolves_missing_path() {
+        let temp_dir = tempdir().unwrap();
+        let missing = temp_dir.path().join("does-not-exist-yet");
+        assert!(!missing.exists());
+
+        let probed = is_cow_supported(&missing).expect("probe should not error");
+        let parent = is_cow_supported(temp_dir.path()).expect("probe should not error");
+        assert_eq!(
+            probed, parent,
+            "missing child must yield same CoW verdict as its existing parent",
+        );
     }
 
     #[test]

--- a/tests/unit/cow_tests.rs
+++ b/tests/unit/cow_tests.rs
@@ -22,11 +22,18 @@ fn test_cow_support_detection() {
     }
 }
 
-#[cfg(target_os = "macos")]
 #[test]
-fn test_cow_support_nonexistent_path() {
-    let result = is_cow_supported("/nonexistent/path/that/should/not/exist");
-    assert!(result.is_err());
+fn test_cow_support_nonexistent_path_resolves_to_ancestor() {
+    let temp_dir = tempdir().unwrap();
+    let missing = temp_dir.path().join("a/b/c/does-not-exist");
+    assert!(!missing.exists());
+
+    let probed = is_cow_supported(&missing).expect("probe must walk up to existing ancestor");
+    let parent = is_cow_supported(temp_dir.path()).expect("parent probe should not error");
+    assert_eq!(
+        probed, parent,
+        "probe on missing path must match probe on its nearest existing ancestor",
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- `warp switch` was calling `cow::is_cow_supported` against the future worktree path. On Linux the probe early-returned `false` when the path was missing; on macOS `statfs` returned `ENOENT` and the wrapping `.unwrap_or(false)` swallowed it. New worktrees silently fell back to a plain `git worktree add`, so the APFS clone and Linux reflink paths never ran.
- Pushed parent-resolution into `cow::is_cow_supported` itself. It walks up to the nearest existing ancestor before delegating to the platform probe, and the redundant `path.exists()` short-circuit in `is_linux_reflink_supported` is gone.
- Replaced the macOS-only `test_cow_support_nonexistent_path` (which pinned the old `Err` behavior) with a cross-platform regression that asserts the missing-path probe matches the parent probe.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (221 passed)
- `git diff --check`

Closes #159