### PR TITLE
feat(release): ship Windows prebuilt binary and install.ps1 (#165)

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -30,6 +30,8 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
 
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
@@ -49,7 +51,9 @@ jobs:
       - name: Check version
         run: ./target/${{ matrix.target }}/release/warp --version
 
-      - name: Package archive
+      - name: Package archive (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
         run: |
           archive="git-warp-${RELEASE_TAG}-${{ matrix.target }}.tar.gz"
           mkdir -p dist
@@ -59,6 +63,19 @@ jobs:
           tar -czf "$archive" -C dist warp README.md
           shasum -a 256 "$archive" > "$archive.sha256"
 
+      - name: Package archive (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $archive = "git-warp-$env:RELEASE_TAG-${{ matrix.target }}.zip"
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+          Copy-Item "target/${{ matrix.target }}/release/warp.exe" "dist/warp.exe"
+          Copy-Item README.md "dist/README.md"
+          Compress-Archive -Force -Path dist/warp.exe, dist/README.md -DestinationPath $archive
+          $hash = (Get-FileHash $archive -Algorithm SHA256).Hash.ToLower()
+          $line = "$hash  $archive`n"
+          [System.IO.File]::WriteAllText((Join-Path (Get-Location) "$archive.sha256"), $line, [System.Text.UTF8Encoding]::new($false))
+
       - name: Upload release assets
         uses: softprops/action-gh-release@v3
         with:
@@ -66,3 +83,5 @@ jobs:
           files: |
             git-warp-${{ env.RELEASE_TAG }}-${{ matrix.target }}.tar.gz
             git-warp-${{ env.RELEASE_TAG }}-${{ matrix.target }}.tar.gz.sha256
+            git-warp-${{ env.RELEASE_TAG }}-${{ matrix.target }}.zip
+            git-warp-${{ env.RELEASE_TAG }}-${{ matrix.target }}.zip.sha256

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,6 +4,8 @@
 
 Install Git-Warp with one command. Rust and Cargo are not required.
 
+### macOS / Linux
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.sh | sh
 ```
@@ -17,6 +19,26 @@ warp doctor
 
 The installer downloads a prebuilt release archive for your platform and places
 the `warp` binary in `~/.local/bin`.
+
+### Windows (PowerShell)
+
+```powershell
+irm https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.ps1 | iex
+```
+
+Then verify the binary is reachable:
+
+```powershell
+warp --version
+warp doctor
+```
+
+The PowerShell installer downloads the `x86_64-pc-windows-msvc` `.zip`, verifies
+its SHA256, and places `warp.exe` in `%LOCALAPPDATA%\Programs\git-warp\bin`. You
+may need to open a new PowerShell session for the PATH update to take effect.
+
+The Bash installer (`install.sh`) detects MSYS / Git Bash / Cygwin shells and
+points you back at `install.ps1`; there is no Bash-on-Windows install path.
 
 ## PATH Setup
 
@@ -45,6 +67,13 @@ Install into another writable directory with `GIT_WARP_INSTALL_DIR`:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.sh | GIT_WARP_INSTALL_DIR=/usr/local/bin sh
+```
+
+On Windows, pass `-InstallDir` (or set `$env:GIT_WARP_INSTALL_DIR` before
+piping):
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.ps1))) -InstallDir 'C:\tools\git-warp'
 ```
 
 ## Checksum Verification
@@ -98,6 +127,26 @@ Release binaries are published for:
 - macOS Intel: `x86_64-apple-darwin`
 - Linux arm64: `aarch64-unknown-linux-gnu`
 - Linux x64: `x86_64-unknown-linux-gnu`
+- Windows x64: `x86_64-pc-windows-msvc`
+
+## Windows Manual Download
+
+If you prefer to bypass `install.ps1`, grab the archive yourself:
+
+```powershell
+$tag = 'v0.3.0'
+$asset = "git-warp-$tag-x86_64-pc-windows-msvc.zip"
+$base = "https://github.com/denysbutenko/git-warp/releases/download/$tag"
+irm "$base/$asset" -OutFile $asset
+irm "$base/$asset.sha256" -OutFile "$asset.sha256"
+$expected = (Get-Content "$asset.sha256" -TotalCount 1).Trim().Split(' ')[0]
+$actual = (Get-FileHash $asset -Algorithm SHA256).Hash.ToLowerInvariant()
+if ($expected -ne $actual) { throw "SHA256 mismatch" }
+Unblock-File $asset
+Expand-Archive -Force $asset -DestinationPath "$env:LOCALAPPDATA\Programs\git-warp\bin"
+```
+
+Then add `%LOCALAPPDATA%\Programs\git-warp\bin` to your `PATH`.
 
 ## Upgrade
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,241 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+    Install Git-Warp on Windows.
+.DESCRIPTION
+    Downloads the prebuilt Git-Warp .zip for x86_64-pc-windows-msvc, verifies
+    its SHA256, and installs warp.exe into a user-writable directory.
+
+    Defaults to the latest published release; pin with -Version or
+    $env:GIT_WARP_VERSION. Default install directory is
+    "$env:LOCALAPPDATA\Programs\git-warp\bin"; override with -InstallDir or
+    $env:GIT_WARP_INSTALL_DIR.
+.EXAMPLE
+    irm https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.ps1 | iex
+.EXAMPLE
+    & ([scriptblock]::Create((irm https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.ps1))) -InstallDir 'C:\tools\git-warp'
+#>
+[CmdletBinding()]
+param(
+    [string]$Version,
+    [string]$InstallDir,
+    [string]$RepoUrl,
+    [string]$DownloadBase,
+    [ValidateSet('binary', 'cargo')]
+    [string]$Method,
+    [switch]$SkipChecksum
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+try {
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+} catch {
+    # Older runtimes may not expose Tls12; Invoke-WebRequest will still negotiate the OS default.
+}
+
+function Coalesce {
+    param([string]$Explicit, [string]$EnvName, [string]$Default)
+    if ($Explicit) { return $Explicit }
+    $envValue = [Environment]::GetEnvironmentVariable($EnvName)
+    if ($envValue) { return $envValue }
+    return $Default
+}
+
+function Write-Err {
+    param([string]$Message)
+    [Console]::Error.WriteLine("error: $Message")
+}
+
+function Show-CargoHint {
+    param([string]$Repo)
+    [Console]::Error.WriteLine("")
+    [Console]::Error.WriteLine("If you have Rust and Cargo installed, retry with:")
+    [Console]::Error.WriteLine("  & ([scriptblock]::Create((irm $Repo/raw/main/install.ps1))) -Method cargo")
+}
+
+function Fail {
+    param([string]$Message, [string]$Repo)
+    Write-Err $Message
+    if ($Repo) { Show-CargoHint -Repo $Repo }
+    throw $Message
+}
+
+function Resolve-LatestTag {
+    param([string]$Repo)
+
+    if ($Repo -notmatch '^https://github\.com/') {
+        Fail "GIT_WARP_REPO_URL ($Repo) is not on github.com; cannot auto-resolve the latest release" $Repo
+    }
+
+    $slug = $Repo -replace '^https://github\.com/', ''
+    $api = "https://api.github.com/repos/$slug/releases/latest"
+
+    try {
+        $resp = Invoke-RestMethod -UseBasicParsing -Uri $api -Headers @{ 'User-Agent' = 'git-warp-install' }
+    } catch {
+        Fail "GitHub release lookup failed at $api ($($_.Exception.Message))" $Repo
+    }
+
+    if (-not $resp.tag_name) {
+        Fail "could not parse tag_name from $api response" $Repo
+    }
+
+    return $resp.tag_name
+}
+
+function Get-ChecksumFromSidecar {
+    param([string]$Path)
+    $first = (Get-Content -LiteralPath $Path -TotalCount 1) -as [string]
+    if (-not $first) { return $null }
+    $token = ($first.Trim() -split '\s+', 2)[0]
+    if (-not $token) { return $null }
+    return $token.ToLowerInvariant()
+}
+
+function Test-OnPath {
+    param([string]$Dir)
+    $needle = $Dir.TrimEnd('\').ToLowerInvariant()
+    foreach ($entry in $env:PATH -split ';') {
+        if (-not $entry) { continue }
+        if ($entry.TrimEnd('\').ToLowerInvariant() -eq $needle) { return $true }
+    }
+    return $false
+}
+
+function Install-Binary {
+    param(
+        [string]$Repo,
+        [string]$Tag,
+        [string]$Dir,
+        [string]$Base,
+        [bool]$Skip
+    )
+
+    $target = 'x86_64-pc-windows-msvc'
+    $asset = "git-warp-$Tag-$target.zip"
+    $sumName = "$asset.sha256"
+    $url = "$Base/$asset"
+    $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("git-warp-install-" + [System.Guid]::NewGuid().ToString('N'))
+    New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+
+    try {
+        $archive = Join-Path $tmp $asset
+        Write-Host "Downloading Git-Warp $Tag for $target"
+        try {
+            Invoke-WebRequest -UseBasicParsing -Uri $url -OutFile $archive
+        } catch {
+            Fail "failed to download $url ($($_.Exception.Message))" $Repo
+        }
+
+        if (-not $Skip) {
+            $sumPath = Join-Path $tmp $sumName
+            try {
+                Invoke-WebRequest -UseBasicParsing -Uri "$url.sha256" -OutFile $sumPath
+            } catch {
+                Fail "failed to download $url.sha256 ($($_.Exception.Message))" $Repo
+            }
+
+            $expected = Get-ChecksumFromSidecar -Path $sumPath
+            if (-not $expected) {
+                Fail "checksum sidecar for $asset is empty or malformed" $Repo
+            }
+            $actual = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+            if ($expected -ne $actual) {
+                Write-Err "checksum verification failed for $asset"
+                Write-Err "  expected: $expected"
+                Write-Err "  actual:   $actual"
+                Show-CargoHint -Repo $Repo
+                throw 'checksum mismatch'
+            }
+        } else {
+            Write-Host "Skipping checksum verification (GIT_WARP_SKIP_CHECKSUM=1)"
+        }
+
+        $extract = Join-Path $tmp 'extract'
+        New-Item -ItemType Directory -Force -Path $extract | Out-Null
+        Expand-Archive -Force -Path $archive -DestinationPath $extract
+        $binary = Join-Path $extract 'warp.exe'
+        if (-not (Test-Path -LiteralPath $binary)) {
+            Fail "release archive did not contain warp.exe" $Repo
+        }
+
+        New-Item -ItemType Directory -Force -Path $Dir | Out-Null
+        Copy-Item -Force -Path $binary -Destination (Join-Path $Dir 'warp.exe')
+    } finally {
+        Remove-Item -Recurse -Force -ErrorAction SilentlyContinue -LiteralPath $tmp
+    }
+}
+
+function Install-Cargo {
+    param(
+        [string]$Repo,
+        [string]$Tag
+    )
+
+    $cargo = Get-Command cargo -ErrorAction SilentlyContinue
+    if (-not $cargo) {
+        Fail "cargo is required for the cargo install method" $Repo
+    }
+
+    Write-Host "Installing Git-Warp $Tag from $Repo with Cargo"
+    & cargo install --locked --force --git $Repo --tag $Tag --bin warp git-warp
+    if ($LASTEXITCODE -ne 0) {
+        Fail "Cargo install failed for Git-Warp $Tag" $Repo
+    }
+}
+
+$repoUrl = Coalesce $RepoUrl 'GIT_WARP_REPO_URL' 'https://github.com/denysbutenko/git-warp'
+$method = Coalesce $Method 'GIT_WARP_INSTALL_METHOD' 'binary'
+
+$skipChecksum = $SkipChecksum.IsPresent
+if (-not $skipChecksum) {
+    $skipEnv = [Environment]::GetEnvironmentVariable('GIT_WARP_SKIP_CHECKSUM')
+    if ($skipEnv -eq '1') { $skipChecksum = $true }
+}
+
+$defaultDir = Join-Path $env:LOCALAPPDATA 'Programs\git-warp\bin'
+$installDir = Coalesce $InstallDir 'GIT_WARP_INSTALL_DIR' $defaultDir
+
+if ($Version) {
+    $tag = $Version
+} else {
+    $envVersion = [Environment]::GetEnvironmentVariable('GIT_WARP_VERSION')
+    if ($envVersion) {
+        $tag = $envVersion
+    } else {
+        $tag = Resolve-LatestTag -Repo $repoUrl
+        Write-Host "Resolved latest Git-Warp release: $tag"
+    }
+}
+
+$downloadBase = Coalesce $DownloadBase 'GIT_WARP_DOWNLOAD_BASE' "$repoUrl/releases/download/$tag"
+
+switch ($method) {
+    'binary' { Install-Binary -Repo $repoUrl -Tag $tag -Dir $installDir -Base $downloadBase -Skip $skipChecksum }
+    'cargo'  { Install-Cargo -Repo $repoUrl -Tag $tag }
+    default  { Fail "unsupported install method: $method; use 'binary' or 'cargo'" $repoUrl }
+}
+
+Write-Host ""
+
+$installed = Join-Path $installDir 'warp.exe'
+if (Test-Path -LiteralPath $installed) {
+    & $installed --version
+} elseif (Get-Command warp -ErrorAction SilentlyContinue) {
+    & warp --version
+} else {
+    Write-Host "Git-Warp installed, but 'warp' is not on PATH yet."
+}
+
+if (-not (Test-OnPath -Dir $installDir)) {
+    Write-Host ""
+    Write-Host "Add $installDir to PATH so your shell can find 'warp':"
+    Write-Host "  `$env:PATH = '$installDir;' + `$env:PATH"
+    Write-Host "Persist it across sessions with:"
+    Write-Host "  [Environment]::SetEnvironmentVariable('Path', `"$installDir;`" + [Environment]::GetEnvironmentVariable('Path', 'User'), 'User')"
+    Write-Host "Open a new terminal or run 'warp doctor' after updating PATH."
+}
+
+Write-Host "Run 'warp doctor' to check your setup."

--- a/install.sh
+++ b/install.sh
@@ -24,6 +24,7 @@ Supported prebuilt targets:
   - macOS Intel: x86_64-apple-darwin
   - Linux arm64: aarch64-unknown-linux-gnu
   - Linux x64: x86_64-unknown-linux-gnu
+  - Windows x64: x86_64-pc-windows-msvc (install with install.ps1)
 EOF
 }
 
@@ -199,6 +200,12 @@ target_triple() {
   case "$os" in
     Darwin) os_part="apple-darwin" ;;
     Linux) os_part="unknown-linux-gnu" ;;
+    MINGW*|MSYS*|CYGWIN*)
+      echo "error: install.sh does not run on Windows; use install.ps1 instead:" >&2
+      echo "  irm ${repo_url}/raw/main/install.ps1 | iex" >&2
+      cargo_fallback_hint
+      exit 1
+      ;;
     *) fail_unsupported_target "operating system" "$os" ;;
   esac
 


### PR DESCRIPTION
## Summary

- New `windows-latest` / `x86_64-pc-windows-msvc` row in `.github/workflows/release-binaries.yml`. The package step now branches: POSIX rows keep producing `tar.gz` + a `shasum` sidecar; the Windows row produces `git-warp-<tag>-x86_64-pc-windows-msvc.zip` and a SHA256 sidecar written via `Get-FileHash`.
- `install.ps1` (new) mirrors the env knobs `install.sh` already supports: latest-tag resolution, `-Version` / `GIT_WARP_VERSION`, `-InstallDir` / `GIT_WARP_INSTALL_DIR`, `-SkipChecksum` / `GIT_WARP_SKIP_CHECKSUM`, plus a `-Method cargo` fallback. Default install dir is `%LOCALAPPDATA%\Programs\git-warp\bin`, so no admin token is needed. Web calls are `Invoke-WebRequest` only and TLS 1.2 is forced defensively for Win10 RTM.
- `install.sh` now matches `MINGW*|MSYS*|CYGWIN*` in `target_triple()` and points the user at `install.ps1` instead of dying with the generic "unsupported operating system" line.
- `docs/install.md` picks up a Windows quick-install section, a `-InstallDir` example, a manual `.zip` walkthrough (uses `Unblock-File` + `Expand-Archive`), and the new triple in the supported list.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` (221 passed)
- `git diff --check`
- `sh -n install.sh && bash -n install.sh`
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-binaries.yml'))"`

## Caveats

- I do not have `pwsh` locally, so `install.ps1` has not been parsed by PowerShell itself. Worth running `pwsh -NoProfile -Command "[scriptblock]::Create((Get-Content ./install.ps1 -Raw)) | Out-Null"` on a Windows box before the next release goes out.
- The release workflow only fires on `v*` tags or `workflow_dispatch`, so the new Windows row will not be exercised by this PR. CI's existing `windows-latest` clippy + test rows still cover the Rust build on every PR.

Closes #165