### PR TITLE
ci: run git diff --check on PRs and in release-check (#166)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
+      - name: git diff --check
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            range="origin/${{ github.base_ref }}...HEAD"
+          else
+            range="HEAD~1 HEAD"
+          fi
+          echo "Checking $range"
+          git diff --check $range
 
   clippy:
     name: cargo clippy (${{ matrix.os }})

--- a/src/release.rs
+++ b/src/release.rs
@@ -223,6 +223,7 @@ fn run_release_commands(repo_root: &Path, expected: &ReleaseVersion) -> Result<(
             "cargo",
             &["fmt", "--all", "--", "--check"],
         ),
+        ReleaseCommand::new("git diff --check", "git", &["diff", "--check"]),
         ReleaseCommand::new(
             "cargo clippy --all-targets --locked -- -D warnings",
             "cargo",


### PR DESCRIPTION
## Summary

`README.md` lists `git diff --check` as a pre-merge step, but neither CI nor `warp release-check` actually runs it. So trailing whitespace or stray `<<<<<<<` markers can slip onto main with every job green.

- `.github/workflows/ci.yml`: the `fmt` job now runs `git diff --check` after `cargo fmt`. On PR runs it checks `origin/<base>...HEAD`, on push to main it checks `HEAD~1 HEAD`. `actions/checkout@v6` is bumped to `fetch-depth: 0` so both ranges resolve.
- `src/release.rs`: same `git diff --check` slotted into `run_release_commands` between fmt and clippy, so the local release gate stays symmetric with CI.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` (221 passed)
- `git diff --check`
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`

Closes #166