### PR TITLE
fix(tui): decode Windows-1252 mojibake in TUI strings and docs (#171)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ terminal handoff modes that print or send shell commands.
 
 `post_create.auto_install` controls whether Git-Warp runs the matching
 `<manager> install` after creating a new worktree. Lockfile detection order is
-`pnpm-lock.yaml` â†’ `yarn.lock` â†’ `bun.lock` â†’ `bun.lockb` â†’ `package-lock.json` â†’ `Cargo.toml`; the first
+`pnpm-lock.yaml` → `yarn.lock` → `bun.lock` → `bun.lockb` → `package-lock.json` → `Cargo.toml`; the first
 match wins. Set `auto_install = false` (or
 `GIT_WARP_POST_CREATE__AUTO_INSTALL=false`) to skip the install step entirely.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -300,8 +300,8 @@ disabled banner; `[agent].refresh_rate` sets the dashboard poll interval in
 milliseconds (clamped to ≥ 250 ms).
 
 `post_create.auto_install` runs the matching `<manager> install` after Git-Warp
-creates a new worktree. Lockfile detection order is `pnpm-lock.yaml` â†’
-`yarn.lock` â†’ `bun.lock` â†’ `bun.lockb` â†’ `package-lock.json` â†’ `Cargo.toml`; the first match wins. Set
+creates a new worktree. Lockfile detection order is `pnpm-lock.yaml` →
+`yarn.lock` → `bun.lock` → `bun.lockb` → `package-lock.json` → `Cargo.toml`; the first match wins. Set
 `auto_install = false` to skip the install step entirely.
 
 Environment variables override config file values. Top-level keys map

--- a/src/tui/agents.rs
+++ b/src/tui/agents.rs
@@ -315,7 +315,7 @@ impl TuiApp {
         );
         let header_text = if self.filters.is_active() {
             format!(
-                "Warp Agents ({}/{}) â€” {}",
+                "Warp Agents ({}/{}) — {}",
                 preview_model.total_rows,
                 preview_model.total_unfiltered,
                 preview_model.filter_summary
@@ -409,7 +409,7 @@ impl TuiApp {
 
         // Help
         let help_text =
-            "â†‘â†“/jk: Navigate | r: Refresh | t: Runtime | p: Presence | c: Clear | q/Esc: Quit";
+            "↑↓/jk: Navigate | r: Refresh | t: Runtime | p: Presence | c: Clear | q/Esc: Quit";
         let help = Paragraph::new(help_text)
             .style(Style::default().fg(Color::Gray))
             .alignment(Alignment::Center)
@@ -551,7 +551,7 @@ pub fn session_detail_lines(session: &AgentSessionSummary) -> Vec<String> {
 
 fn session_state_symbol(state: AgentSessionState) -> &'static str {
     match state {
-        AgentSessionState::Starting => "â€”‹",
+        AgentSessionState::Starting => "—‹",
         AgentSessionState::Working => "●",
         AgentSessionState::Processing => "—",
         AgentSessionState::Waiting => "!",

--- a/src/tui/cleanup.rs
+++ b/src/tui/cleanup.rs
@@ -57,7 +57,7 @@ impl CleanupTui {
         };
 
         if branch_statuses.is_empty() {
-            println!("âœ¨ No worktrees found that can be cleaned up!");
+            println!("✨ No worktrees found that can be cleaned up!");
             return Ok(vec![]);
         }
 
@@ -166,7 +166,7 @@ impl CleanupTui {
 
                 let selected_count = selected_branches.iter().filter(|&&x| x).count();
                 let footer_text = format!(
-                    "â†‘â†“/jk: Navigate | Space: Toggle | a: Toggle all | Enter: Confirm ({} selected) | q/Esc: Cancel",
+                    "↑↓/jk: Navigate | Space: Toggle | a: Toggle all | Enter: Confirm ({} selected) | q/Esc: Cancel",
                     selected_count
                 );
                 let footer = Paragraph::new(footer_text)

--- a/src/tui/config_editor.rs
+++ b/src/tui/config_editor.rs
@@ -259,9 +259,9 @@ pub struct ConfigStatusMsg {
 /// Outcome reported by `ConfigEditorModel::request_quit`.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ConfigQuitOutcome {
-    /// No unsaved changes â€” caller may exit immediately.
+    /// No unsaved changes — caller may exit immediately.
     Clean,
-    /// Working copy diverges from disk â€” caller must confirm discard.
+    /// Working copy diverges from disk — caller must confirm discard.
     NeedsConfirm,
 }
 
@@ -815,7 +815,7 @@ pub fn draw_config_editor(f: &mut Frame, model: &ConfigEditorModel, pending_quit
 
     let dirty_tag = if model.is_dirty() { " [unsaved]" } else { "" };
     let header_text = format!(
-        "Git-Warp config editor â€” {}{}",
+        "Git-Warp config editor — {}{}",
         model.config_path().display(),
         dirty_tag
     );
@@ -836,7 +836,7 @@ pub fn draw_config_editor(f: &mut Frame, model: &ConfigEditorModel, pending_quit
         .enumerate()
         .map(|(idx, section)| {
             let marker = if idx == model.section_idx() {
-                "â–¸ "
+                "▸ "
             } else {
                 "  "
             };
@@ -876,7 +876,7 @@ pub fn draw_config_editor(f: &mut Frame, model: &ConfigEditorModel, pending_quit
                 let buf = model.edit_buffer_value().unwrap_or("");
                 format!("> {} = {}_", field.label, buf)
             } else {
-                let cursor_mark = if idx == cursor { "â–¸" } else { " " };
+                let cursor_mark = if idx == cursor { "▸" } else { " " };
                 format!(
                     "{} {} = {}",
                     cursor_mark,
@@ -921,7 +921,7 @@ pub fn draw_config_editor(f: &mut Frame, model: &ConfigEditorModel, pending_quit
         status.text.clone()
     } else if !model.env_overrides().is_empty() {
         format!(
-            "Heads up: {} GIT_WARP_* env var(s) set â€” they shadow saved values at runtime.",
+            "Heads up: {} GIT_WARP_* env var(s) set — they shadow saved values at runtime.",
             model.env_overrides().len()
         )
     } else {
@@ -948,8 +948,7 @@ pub fn draw_config_editor(f: &mut Frame, model: &ConfigEditorModel, pending_quit
     } else if model.editing() {
         "Enter save field  Esc cancel  Backspace delete".to_string()
     } else {
-        "â†‘â†“/jk move  Tab section  Space toggle  Enter/e edit  s save  r revert  q quit"
-            .to_string()
+        "↑↓/jk move  Tab section  Space toggle  Enter/e edit  s save  r revert  q quit".to_string()
     };
     let footer = Paragraph::new(footer_text)
         .style(Style::default().fg(Color::Gray))

--- a/src/tui/switcher.rs
+++ b/src/tui/switcher.rs
@@ -456,7 +456,7 @@ fn draw_worktree_switcher(
     }
 
     let help = Paragraph::new(
-        "â†‘â†“/jk: Navigate | Space: Select | a: All | Enter: Switch | d/Del: Remove selected/current | q/Esc: Quit",
+        "↑↓/jk: Navigate | Space: Select | a: All | Enter: Switch | d/Del: Remove selected/current | q/Esc: Quit",
     )
         .style(Style::default().fg(Color::Gray))
         .alignment(Alignment::Center)
@@ -477,7 +477,7 @@ fn batch_removal_notice(batch: &WorktreeBatchRemoval) -> String {
         .map(|target| {
             if target.force {
                 format!(
-                    "{} ({}) [dirty â€” force]",
+                    "{} ({}) [dirty — force]",
                     target.branch,
                     target.path.display()
                 )

--- a/tests/unit/encoding_tests.rs
+++ b/tests/unit/encoding_tests.rs
@@ -1,0 +1,87 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use ignore::WalkBuilder;
+
+/// Scans tracked source and prose files for the byte sequence `0xC3 0xA2`,
+/// the leading bytes of every Windows-1252-mojibaked UTF-8 character (`U+00E2`
+/// followed by another high byte). That pattern is the fingerprint of UTF-8
+/// text once decoded as cp1252 and re-encoded as UTF-8 — what users see as
+/// scrambled sparkles, arrows, em-dashes, and triangles in the TUI. If
+/// anything matches, the test prints the offending file:line so the operator
+/// can fix the source bytes instead of relying on terminal rendering to
+/// surface the regression.
+#[test]
+fn source_tree_has_no_windows_1252_mojibake() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    // Restrict to source and prose paths that surface in the TUI or in
+    // docs the user reads. `tests/` is intentionally excluded — fixtures
+    // there legitimately exercise non-ASCII characters like `àáâãäå`.
+    let scan_roots = ["src", "docs", "README.md", "CHANGELOG.md"];
+
+    let mut hits = Vec::new();
+
+    for entry in scan_roots {
+        let path = root.join(entry);
+        if !path.exists() {
+            continue;
+        }
+        let walker = WalkBuilder::new(&path)
+            .hidden(false)
+            .git_ignore(true)
+            .build();
+        for result in walker {
+            let dent = match result {
+                Ok(d) => d,
+                Err(_) => continue,
+            };
+            if !dent.file_type().map(|t| t.is_file()).unwrap_or(false) {
+                continue;
+            }
+            scan_file(dent.path(), &root, &mut hits);
+        }
+    }
+
+    assert!(
+        hits.is_empty(),
+        "Windows-1252 mojibake detected (byte sequence C3 A2) at:\n  {}\n\
+         This is the leftover from a UTF-8 string that was once decoded as \
+         cp1252 and re-encoded as UTF-8. Re-save the file with the intended \
+         codepoints (em-dash, arrows, sparkles, etc.).",
+        hits.join("\n  ")
+    );
+}
+
+fn scan_file(path: &Path, root: &Path, hits: &mut Vec<String>) {
+    let bytes = match fs::read(path) {
+        Ok(b) => b,
+        Err(_) => return,
+    };
+    // Skip files that look binary: a NUL byte in the first 8 KiB is a strong
+    // hint and matches how `git diff` decides binary.
+    let head_len = bytes.len().min(8192);
+    if bytes[..head_len].contains(&0) {
+        return;
+    }
+
+    let mut line = 1usize;
+    let mut col = 1usize;
+    let mut i = 0;
+    while i + 1 < bytes.len() {
+        if bytes[i] == 0xC3 && bytes[i + 1] == 0xA2 {
+            let rel = path.strip_prefix(root).unwrap_or(path);
+            hits.push(format!("{}:{}:{}", rel.display(), line, col));
+            // Skip past this hit so a single bad string is reported once.
+            i += 2;
+            col += 2;
+            continue;
+        }
+        if bytes[i] == b'\n' {
+            line += 1;
+            col = 1;
+        } else {
+            col += 1;
+        }
+        i += 1;
+    }
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -2,6 +2,7 @@
 pub mod agents_tests;
 pub mod config_tests;
 pub mod cow_tests;
+pub mod encoding_tests;
 pub mod git_tests;
 pub mod manifest_tests;
 pub mod process_tests;


### PR DESCRIPTION
## Summary

`âœ¨`, `â†‘â†"`, `â€"`, `â–¸`, and `â†'` were UTF-8 strings once decoded as cp1252 and re-encoded as UTF-8. The damage lived in the source bytes, so every UTF-8-respecting terminal rendered the cleanup banner, switcher help line, agents header, config-editor markers, and the lockfile chain in `README.md` / `docs/user-guide.md` as scrambled glyphs.

- `src/tui/cleanup.rs`, `src/tui/switcher.rs`, `src/tui/agents.rs`, `src/tui/config_editor.rs`, `README.md`, and `docs/user-guide.md`: restore the intended codepoints in place — `✨`, `↑↓`, `→`, `—`, `▸`.
- `tests/unit/encoding_tests.rs`: new repo-level guard that scans `src`, `docs`, `README.md`, and `CHANGELOG.md` for the `0xC3 0xA2` byte fingerprint of the same cp1252-via-UTF-8 round-trip. `tests/` is skipped so legitimate non-ASCII fixtures like `àáâãäå` stay untouched. Wired through `tests/unit/mod.rs`, so `cargo test --locked` (and therefore `warp release-check`) fails fast if the regression returns.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` (222 passed; +1 over baseline for the new guard)
- `git diff --check`
- Negative test: temporarily reintroduced `âœ¨` into `src/tui/cleanup.rs`, ran `cargo test --locked unit::encoding_tests`, confirmed it failed with the file:line, then reverted.

Closes #171