### PR TITLE
fix(terminal): make warp --terminal current cross-platform on Windows (#172)

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -430,6 +430,18 @@ fn terminal_window_commands(path: &Path, options: &TerminalLaunchOptions, indent
     lines.join("\n")
 }
 
+fn build_init_lines(options: &TerminalLaunchOptions, path: &Path) -> Vec<String> {
+    let branch = options.branch.as_deref().unwrap_or("");
+    let repo = options.repo.as_deref().unwrap_or("");
+    let path_str = path.to_string_lossy();
+    options
+        .init_commands
+        .iter()
+        .map(|command| replace_placeholders(command, branch, repo, &path_str))
+        .collect()
+}
+
+#[cfg(unix)]
 fn enter_current_shell(path: &Path, options: &TerminalLaunchOptions) -> Result<()> {
     let shell = std::env::var("SHELL")
         .ok()
@@ -444,24 +456,16 @@ fn enter_current_shell(path: &Path, options: &TerminalLaunchOptions) -> Result<(
     let mut command = Command::new(&shell);
     command.current_dir(path);
 
-    if !options.init_commands.is_empty() {
-        let branch = options.branch.as_deref().unwrap_or("");
-        let repo = options.repo.as_deref().unwrap_or("");
-        let path_str = path.to_string_lossy();
-
-        let mut init_script = options
-            .init_commands
-            .iter()
-            .map(|command| replace_placeholders(command, branch, repo, &path_str))
-            .collect::<Vec<_>>()
-            .join("\n");
+    let lines = build_init_lines(options, path);
+    if !lines.is_empty() {
+        let mut init_script = lines.join("\n");
         init_script.push_str(&format!("\nexec {}", shell_quote(&shell)));
         command.args(["-lc", &init_script]);
     }
 
-    let status = command
-        .status()
-        .map_err(|e| anyhow::anyhow!("Failed to start current terminal shell: {}", e))?;
+    let status = command.status().map_err(|e| {
+        anyhow::anyhow!("Failed to start current terminal shell '{}': {}", shell, e)
+    })?;
 
     if !status.success() {
         return Err(anyhow::anyhow!(
@@ -471,6 +475,125 @@ fn enter_current_shell(path: &Path, options: &TerminalLaunchOptions) -> Result<(
     }
 
     Ok(())
+}
+
+#[cfg(windows)]
+fn enter_current_shell(path: &Path, options: &TerminalLaunchOptions) -> Result<()> {
+    println!(
+        "🐚 Starting shell in current terminal at: {}",
+        path.display()
+    );
+
+    let shell_env = std::env::var("SHELL").ok();
+    let ps_module_path = std::env::var("PSModulePath").ok();
+    let comspec = std::env::var("ComSpec").ok();
+    let path_env = std::env::var_os("PATH");
+
+    let lines = build_init_lines(options, path);
+    let spec = resolve_windows_current_shell(
+        shell_env.as_deref(),
+        ps_module_path.as_deref(),
+        comspec.as_deref(),
+        path_env.as_deref(),
+        &lines,
+    );
+
+    let status = Command::new(&spec.program)
+        .args(&spec.args)
+        .current_dir(path)
+        .status()
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to start current terminal shell '{}': {}",
+                spec.program.display(),
+                e
+            )
+        })?;
+
+    if !status.success() {
+        return Err(anyhow::anyhow!(
+            "Current terminal shell exited with status: {}",
+            status
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(any(windows, test))]
+#[derive(Debug)]
+struct WindowsShellSpec {
+    program: std::path::PathBuf,
+    args: Vec<std::ffi::OsString>,
+}
+
+#[cfg(any(windows, test))]
+fn find_on_path_with(env_path: Option<&std::ffi::OsStr>, name: &str) -> Option<std::path::PathBuf> {
+    let path = env_path?;
+    for dir in std::env::split_paths(path) {
+        let candidate = dir.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+#[cfg(any(windows, test))]
+fn resolve_windows_current_shell(
+    shell: Option<&str>,
+    ps_module_path: Option<&str>,
+    comspec: Option<&str>,
+    env_path: Option<&std::ffi::OsStr>,
+    init_lines: &[String],
+) -> WindowsShellSpec {
+    use std::ffi::OsString;
+    use std::path::PathBuf;
+
+    if let Some(shell) = shell.map(str::trim).filter(|s| !s.is_empty()) {
+        let mut args: Vec<OsString> = Vec::new();
+        if !init_lines.is_empty() {
+            let mut script = init_lines.join("\n");
+            script.push_str(&format!("\nexec {}", shell_quote(shell)));
+            args.push(OsString::from("-lc"));
+            args.push(OsString::from(script));
+        }
+        return WindowsShellSpec {
+            program: PathBuf::from(shell),
+            args,
+        };
+    }
+
+    if ps_module_path
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty())
+    {
+        let program = find_on_path_with(env_path, "pwsh.exe")
+            .or_else(|| find_on_path_with(env_path, "powershell.exe"))
+            .unwrap_or_else(|| PathBuf::from("pwsh.exe"));
+
+        let mut args: Vec<OsString> = vec![OsString::from("-NoExit")];
+        if !init_lines.is_empty() {
+            args.push(OsString::from("-Command"));
+            args.push(OsString::from(init_lines.join("; ")));
+        }
+        return WindowsShellSpec { program, args };
+    }
+
+    let program = comspec
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("cmd.exe"));
+
+    let mut args: Vec<OsString> = Vec::new();
+    if !init_lines.is_empty() {
+        args.push(OsString::from("/d"));
+        args.push(OsString::from("/k"));
+        args.push(OsString::from(init_lines.join(" & ")));
+    }
+
+    WindowsShellSpec { program, args }
 }
 
 pub struct TerminalManager;
@@ -668,5 +791,134 @@ mod tests {
             &TerminalLaunchOptions::default(),
         );
         assert!(result.is_ok(), "Echo must not require a GUI terminal");
+    }
+
+    #[test]
+    fn resolve_windows_current_shell_prefers_shell_env() {
+        let spec = resolve_windows_current_shell(
+            Some("/usr/bin/bash"),
+            Some("C:\\PSModules"),
+            Some("C:\\Windows\\System32\\cmd.exe"),
+            None,
+            &[],
+        );
+        assert_eq!(spec.program, std::path::PathBuf::from("/usr/bin/bash"));
+        assert!(spec.args.is_empty());
+    }
+
+    #[test]
+    fn resolve_windows_current_shell_shell_env_with_init_lines() {
+        let lines = vec!["echo first".to_string(), "echo second".to_string()];
+        let spec = resolve_windows_current_shell(Some("/usr/bin/bash"), None, None, None, &lines);
+        assert_eq!(spec.program, std::path::PathBuf::from("/usr/bin/bash"));
+        assert_eq!(spec.args.len(), 2);
+        assert_eq!(spec.args[0], "-lc");
+        let script = spec.args[1].to_str().expect("script is utf-8");
+        assert!(script.starts_with("echo first\necho second\nexec "));
+        assert!(script.ends_with("exec '/usr/bin/bash'"));
+    }
+
+    #[test]
+    fn resolve_windows_current_shell_prefers_pwsh_when_on_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("pwsh.exe"), b"").expect("write pwsh stub");
+        std::fs::write(dir.path().join("powershell.exe"), b"").expect("write powershell stub");
+        let path_env: std::ffi::OsString = dir.path().as_os_str().to_owned();
+
+        let spec = resolve_windows_current_shell(
+            None,
+            Some("C:\\PSModules"),
+            None,
+            Some(path_env.as_os_str()),
+            &[],
+        );
+
+        assert_eq!(spec.program.file_name().expect("file_name"), "pwsh.exe");
+        assert_eq!(spec.args, vec![std::ffi::OsString::from("-NoExit")]);
+    }
+
+    #[test]
+    fn resolve_windows_current_shell_falls_back_to_powershell() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("powershell.exe"), b"").expect("write powershell stub");
+        let path_env: std::ffi::OsString = dir.path().as_os_str().to_owned();
+
+        let spec = resolve_windows_current_shell(
+            None,
+            Some("C:\\PSModules"),
+            None,
+            Some(path_env.as_os_str()),
+            &[],
+        );
+
+        assert_eq!(
+            spec.program.file_name().expect("file_name"),
+            "powershell.exe"
+        );
+    }
+
+    #[test]
+    fn resolve_windows_current_shell_pwsh_with_init_uses_no_exit_command() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("pwsh.exe"), b"").expect("write pwsh stub");
+        let path_env: std::ffi::OsString = dir.path().as_os_str().to_owned();
+        let lines = vec![
+            "Set-Location C:\\Repo".to_string(),
+            "git status".to_string(),
+        ];
+
+        let spec = resolve_windows_current_shell(
+            None,
+            Some("C:\\PSModules"),
+            None,
+            Some(path_env.as_os_str()),
+            &lines,
+        );
+
+        assert_eq!(spec.args.len(), 3);
+        assert_eq!(spec.args[0], "-NoExit");
+        assert_eq!(spec.args[1], "-Command");
+        assert_eq!(spec.args[2], "Set-Location C:\\Repo; git status");
+    }
+
+    #[test]
+    fn resolve_windows_current_shell_pwsh_falls_back_to_literal_when_missing() {
+        let spec = resolve_windows_current_shell(None, Some("C:\\PSModules"), None, None, &[]);
+        assert_eq!(spec.program, std::path::PathBuf::from("pwsh.exe"));
+        assert_eq!(spec.args, vec![std::ffi::OsString::from("-NoExit")]);
+    }
+
+    #[test]
+    fn resolve_windows_current_shell_uses_comspec_when_no_shell_or_ps() {
+        let lines = vec!["dir".to_string(), "echo done".to_string()];
+        let spec = resolve_windows_current_shell(
+            None,
+            None,
+            Some("C:\\Windows\\System32\\cmd.exe"),
+            None,
+            &lines,
+        );
+        assert_eq!(
+            spec.program,
+            std::path::PathBuf::from("C:\\Windows\\System32\\cmd.exe")
+        );
+        assert_eq!(spec.args.len(), 3);
+        assert_eq!(spec.args[0], "/d");
+        assert_eq!(spec.args[1], "/k");
+        assert_eq!(spec.args[2], "dir & echo done");
+    }
+
+    #[test]
+    fn resolve_windows_current_shell_defaults_to_cmd_when_comspec_blank() {
+        let spec = resolve_windows_current_shell(None, None, Some("   "), None, &[]);
+        assert_eq!(spec.program, std::path::PathBuf::from("cmd.exe"));
+        assert!(spec.args.is_empty());
+    }
+
+    #[test]
+    fn resolve_windows_current_shell_defaults_to_cmd_when_no_env_set() {
+        let spec = resolve_windows_current_shell(None, None, None, None, &[]);
+        assert_eq!(spec.program, std::path::PathBuf::from("cmd.exe"));
+        assert!(spec.args.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

`enter_current_shell` in `src/terminal.rs` used to hard-code `/bin/sh` when `$SHELL` was unset and always pass `-lc <script>` for init commands, so `warp --terminal current` reliably failed under PowerShell, `cmd.exe`, or Windows Terminal without WSL — even though `README.md` lists `current` alongside the cross-platform `echo` and `inplace` modes that #149 wired up.

- `src/terminal.rs`: pull placeholder expansion into a shared `build_init_lines`. Wrap the previous body in `#[cfg(unix)]`. Add a `#[cfg(windows)]` sibling that delegates to a pure `resolve_windows_current_shell` helper picking a shell from env in this order:
  1. `SHELL` → POSIX-style spawn with `-lc <script>` (Git Bash / MSYS2 / WSL).
  2. `PSModulePath` set → `pwsh.exe` from `PATH`, falling back to `powershell.exe` then the literal `pwsh.exe`, invoked as `-NoExit -Command "<line>; <line>"`.
  3. `ComSpec` (or `cmd.exe` when blank) with `/d /k "<line> & <line>"`.
- Spawn errors now include the program name so a missing `pwsh.exe` surfaces which binary was tried instead of a generic message.
- Nine new unit tests cover every resolution branch — including pwsh vs. powershell PATH fallback — without spawning a real shell, so they run on the existing macOS / Linux / Windows CI matrix.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` (221 passed; +9 over baseline for the new resolver coverage)
- `git diff --check`

Closes #172