### PR TITLE
feat(install): ship uninstall.ps1 for Windows (#177)

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -169,6 +169,8 @@ active one, and warns when more than one exists.
 
 ## Uninstall
 
+### macOS / Linux
+
 Remove the default install with the bundled uninstaller:
 
 ```bash
@@ -182,6 +184,26 @@ The uninstaller:
 - Lists any other detected `warp` installs without touching them.
 
 Use `--dry-run` to preview the changes without modifying your system.
+
+### Windows (PowerShell)
+
+```powershell
+irm https://raw.githubusercontent.com/denysbutenko/git-warp/main/uninstall.ps1 | iex
+```
+
+The PowerShell uninstaller mirrors the Bash one:
+- Removes agent hook entries from Claude/Codex settings using `warp.exe` before its deletion (opt out with `$env:GIT_WARP_KEEP_HOOKS = '1'`).
+- Removes `%LOCALAPPDATA%\Programs\git-warp\bin\warp.exe` (or `$env:GIT_WARP_INSTALL_DIR\warp.exe`). Drops the install directory if it ends up empty.
+- Scans the four `$PROFILE.*` PowerShell-profile paths for leftover `warp_cd` / `warp __complete` snippets and prints cleanup hints.
+- Lists any other detected `warp.exe` installs (Cargo, custom directories) without touching them.
+
+Preview the actions without modifying anything:
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/denysbutenko/git-warp/main/uninstall.ps1))) -DryRun
+```
+
+### Cargo
 
 If you installed Git-Warp with Cargo, also run:
 

--- a/src/release.rs
+++ b/src/release.rs
@@ -193,6 +193,21 @@ pub fn collect_metadata_checks(
         ));
     }
 
+    for label in ["install.ps1", "uninstall.ps1"] {
+        let path = repo_root.join(label);
+        if path.is_file() {
+            checks.push(ReleaseCheck::pass(
+                label,
+                format!("{label} is present at the repo root"),
+            ));
+        } else {
+            checks.push(ReleaseCheck::fail(
+                label,
+                format!("{label} is missing from the repo root"),
+            ));
+        }
+    }
+
     Ok(checks)
 }
 

--- a/tests/unit/release_tests.rs
+++ b/tests/unit/release_tests.rs
@@ -90,9 +90,13 @@ fn test_collect_metadata_checks_all_pass() {
     )
     .unwrap();
 
+    // 5. install.ps1 + uninstall.ps1 presence
+    fs::write(temp.path().join("install.ps1"), "param()").unwrap();
+    fs::write(temp.path().join("uninstall.ps1"), "param()").unwrap();
+
     let checks = collect_metadata_checks(temp.path(), &expected, version).unwrap();
 
-    assert_eq!(checks.len(), 5);
+    assert_eq!(checks.len(), 7);
     for check in &checks {
         assert!(check.ok, "check failed: {} - {}", check.label, check.detail);
     }
@@ -109,7 +113,7 @@ fn test_collect_metadata_checks_failures() {
     // All files missing or mismatched
     let checks = collect_metadata_checks(temp.path(), &expected, "0.2.0").unwrap();
 
-    assert_eq!(checks.len(), 5);
+    assert_eq!(checks.len(), 7);
     for check in &checks {
         assert!(!check.ok, "check should have failed: {}", check.label);
     }
@@ -136,6 +140,10 @@ fn test_collect_metadata_checks_failures() {
             .detail
             .contains("api.github.com/repos/.../releases/latest")
     );
+    assert_eq!(checks[5].label, "install.ps1");
+    assert!(checks[5].detail.contains("install.ps1 is missing"));
+    assert_eq!(checks[6].label, "uninstall.ps1");
+    assert!(checks[6].detail.contains("uninstall.ps1 is missing"));
 }
 
 #[test]
@@ -159,6 +167,27 @@ fn test_install_script_partial_lookup_fails() {
         "install.sh missing API lookup should fail the check"
     );
     assert_eq!(checks[4].label, "install.sh");
+}
+
+#[test]
+fn test_powershell_scripts_partial_presence_fails() {
+    let temp = tempdir().unwrap();
+    let expected = ReleaseVersion {
+        number: "0.3.0".to_string(),
+        tag: "v0.3.0".to_string(),
+    };
+
+    // install.ps1 present, uninstall.ps1 missing — release must fail.
+    fs::write(temp.path().join("install.ps1"), "param()").unwrap();
+
+    let checks = collect_metadata_checks(temp.path(), &expected, "0.3.0").unwrap();
+
+    assert_eq!(checks.len(), 7);
+    assert_eq!(checks[5].label, "install.ps1");
+    assert!(checks[5].ok, "install.ps1 presence check should pass");
+    assert_eq!(checks[6].label, "uninstall.ps1");
+    assert!(!checks[6].ok, "uninstall.ps1 absence should fail the check");
+    assert!(checks[6].detail.contains("uninstall.ps1 is missing"));
 }
 
 #[test]
@@ -213,10 +242,12 @@ fn test_collect_metadata_checks_partial_success() {
     // All other files are missing.
     let checks = collect_metadata_checks(temp.path(), &expected, version).unwrap();
 
-    assert_eq!(checks.len(), 5);
+    assert_eq!(checks.len(), 7);
     assert!(checks[0].ok, "Cargo.toml check should pass");
     assert!(!checks[1].ok, "CHANGELOG.md check should fail");
     assert!(!checks[2].ok, "release notes check should fail");
     assert!(!checks[3].ok, "docs/install.md check should fail");
     assert!(!checks[4].ok, "install.sh check should fail");
+    assert!(!checks[5].ok, "install.ps1 check should fail");
+    assert!(!checks[6].ok, "uninstall.ps1 check should fail");
 }

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -1,0 +1,233 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+    Uninstall Git-Warp on Windows.
+.DESCRIPTION
+    Removes the Git-Warp binary installed by install.ps1, strips Claude/Codex
+    hook entries before deletion, and prints cleanup hints for leftover
+    PowerShell-profile snippets.
+
+    Defaults to "$env:LOCALAPPDATA\Programs\git-warp\bin" (the install.ps1
+    default). Override with -InstallDir or $env:GIT_WARP_INSTALL_DIR.
+
+    Other detected warp.exe installs (Cargo, custom directories) are listed
+    but not touched.
+.PARAMETER InstallDir
+    Directory containing warp.exe. Defaults to the install.ps1 location.
+.PARAMETER DryRun
+    Print the actions that would run without modifying the system.
+.EXAMPLE
+    irm https://raw.githubusercontent.com/denysbutenko/git-warp/main/uninstall.ps1 | iex
+.EXAMPLE
+    & ([scriptblock]::Create((irm https://raw.githubusercontent.com/denysbutenko/git-warp/main/uninstall.ps1))) -DryRun
+.EXAMPLE
+    $env:GIT_WARP_KEEP_HOOKS = '1'
+    & .\uninstall.ps1
+#>
+[CmdletBinding()]
+param(
+    [string]$InstallDir,
+    [switch]$DryRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Coalesce {
+    param([string]$Explicit, [string]$EnvName, [string]$Default)
+    if ($Explicit) { return $Explicit }
+    $envValue = [Environment]::GetEnvironmentVariable($EnvName)
+    if ($envValue) { return $envValue }
+    return $Default
+}
+
+function Write-Warn {
+    param([string]$Message)
+    [Console]::Error.WriteLine("warning: $Message")
+}
+
+function Write-Err {
+    param([string]$Message)
+    [Console]::Error.WriteLine("error: $Message")
+}
+
+function Get-BinaryVersion {
+    param([string]$Path)
+    try {
+        $line = & $Path --version 2>$null | Select-Object -First 1
+        if ($line) { return $line.ToString().Trim() }
+    } catch {
+        # binary refused to run; treat as no version
+    }
+    return $null
+}
+
+function Remove-Hooks {
+    param([string]$Target, [bool]$Preview)
+
+    if (-not (Test-Path -LiteralPath $Target)) { return }
+    if ([Environment]::GetEnvironmentVariable('GIT_WARP_KEEP_HOOKS') -eq '1') { return }
+
+    $hasGit = Test-Path -LiteralPath '.git'
+
+    if ($Preview) {
+        Write-Host "Would remove user hooks with: $Target hooks-remove --level user --runtime all"
+        if ($hasGit) {
+            Write-Host "Would remove project hooks with: $Target hooks-remove --level project --runtime all"
+        }
+        return
+    }
+
+    Write-Host "Removing agent hooks..."
+    try {
+        & $Target hooks-remove --level user --runtime all *> $null
+        if ($LASTEXITCODE -ne 0) { Write-Warn "failed to remove user hooks" }
+    } catch {
+        Write-Warn "failed to remove user hooks ($($_.Exception.Message))"
+    }
+
+    if ($hasGit) {
+        try {
+            & $Target hooks-remove --level project --runtime all *> $null
+            if ($LASTEXITCODE -ne 0) { Write-Warn "failed to remove project hooks" }
+        } catch {
+            Write-Warn "failed to remove project hooks ($($_.Exception.Message))"
+        }
+    }
+}
+
+function Remove-Binary {
+    param([string]$Target, [string]$Dir, [bool]$Preview)
+
+    if (-not (Test-Path -LiteralPath $Target)) {
+        Write-Host "No Git-Warp binary found at $Target; nothing to remove."
+        return
+    }
+
+    if ($Preview) {
+        Write-Host "Would remove $Target"
+        return
+    }
+
+    try {
+        Remove-Item -LiteralPath $Target -Force
+    } catch {
+        Write-Err "failed to remove $Target ($($_.Exception.Message))"
+        throw
+    }
+    Write-Host "Removed $Target"
+
+    if (Test-Path -LiteralPath $Dir) {
+        $remaining = Get-ChildItem -LiteralPath $Dir -Force -ErrorAction SilentlyContinue
+        if (-not $remaining) {
+            try {
+                Remove-Item -LiteralPath $Dir -Force
+                Write-Host "Removed empty install directory $Dir"
+            } catch {
+                # leave directory in place if removal fails
+            }
+        }
+    }
+}
+
+function Test-ProfileSnippet {
+    param([string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) { return $false }
+    try {
+        $content = Get-Content -LiteralPath $Path -Raw -ErrorAction Stop
+    } catch {
+        return $false
+    }
+    if (-not $content) { return $false }
+    return ($content -match 'warp_cd' -or $content -match 'warp __complete')
+}
+
+function Show-ProfileLeftovers {
+    $candidates = @()
+    if ($PROFILE -is [string]) {
+        $candidates += $PROFILE
+    } else {
+        foreach ($name in 'AllUsersAllHosts', 'AllUsersCurrentHost', 'CurrentUserAllHosts', 'CurrentUserCurrentHost') {
+            $value = $PROFILE.$name
+            if ($value) { $candidates += $value }
+        }
+    }
+
+    $found = @()
+    foreach ($path in ($candidates | Select-Object -Unique)) {
+        if (Test-ProfileSnippet -Path $path) { $found += $path }
+    }
+
+    if ($found.Count -eq 0) { return }
+
+    Write-Host ""
+    Write-Host "Leftover PowerShell-profile snippets detected:"
+    foreach ($path in $found) { Write-Host "  - $path" }
+    Write-Host "Remove lines containing 'warp_cd' or 'warp __complete' from these files."
+}
+
+function Show-OtherInstalls {
+    param([string]$Target)
+
+    $candidates = @()
+    if ($env:GIT_WARP_INSTALL_DIR) {
+        $candidates += (Join-Path $env:GIT_WARP_INSTALL_DIR 'warp.exe')
+    }
+    if ($env:LOCALAPPDATA) {
+        $candidates += (Join-Path $env:LOCALAPPDATA 'Programs\git-warp\bin\warp.exe')
+    }
+    if ($env:USERPROFILE) {
+        $candidates += (Join-Path $env:USERPROFILE '.cargo\bin\warp.exe')
+    }
+
+    $targetNorm = $Target.ToLowerInvariant()
+    $printed = New-Object 'System.Collections.Generic.HashSet[string]'
+    $lines = @()
+    foreach ($path in $candidates) {
+        if (-not $path) { continue }
+        $norm = $path.ToLowerInvariant()
+        if ($norm -eq $targetNorm) { continue }
+        if (-not $printed.Add($norm)) { continue }
+        if (-not (Test-Path -LiteralPath $path)) { continue }
+        $version = Get-BinaryVersion -Path $path
+        if ($version) {
+            $lines += "  - $path ($version)"
+        } else {
+            $lines += "  - $path"
+        }
+    }
+
+    if ($lines.Count -eq 0) { return }
+
+    Write-Host ""
+    Write-Host "Other Git-Warp installs detected (not removed):"
+    foreach ($line in $lines) { Write-Host $line }
+    Write-Host "Remove them manually, or with the matching tool:"
+    Write-Host "  Cargo install:    cargo uninstall git-warp"
+    Write-Host "  Other directory:  Remove-Item <path>"
+}
+
+function Show-PathLeftover {
+    param([string]$Target)
+
+    $active = Get-Command warp -ErrorAction SilentlyContinue
+    if (-not $active) { return }
+
+    $activePath = $active.Source
+    if (-not $activePath) { return }
+    if ($activePath.ToLowerInvariant() -eq $Target.ToLowerInvariant()) { return }
+
+    Write-Host ""
+    Write-Host "'warp' is still on PATH at $activePath."
+    Write-Host "Remove it or adjust PATH if you intended a complete uninstall."
+}
+
+$defaultDir = Join-Path $env:LOCALAPPDATA 'Programs\git-warp\bin'
+$installDir = Coalesce $InstallDir 'GIT_WARP_INSTALL_DIR' $defaultDir
+$target = Join-Path $installDir 'warp.exe'
+
+Remove-Hooks -Target $target -Preview $DryRun.IsPresent
+Remove-Binary -Target $target -Dir $installDir -Preview $DryRun.IsPresent
+Show-ProfileLeftovers
+Show-OtherInstalls -Target $target
+Show-PathLeftover -Target $target


### PR DESCRIPTION
## Summary

`uninstall.ps1` is the Windows counterpart to `uninstall.sh`. It removes `warp.exe` from the `install.ps1` location, runs `hooks-remove --level user --runtime all` first (and `--level project` when invoked inside a Git repo) so Claude/Codex settings aren't left with dangling hook entries, scans the four `$PROFILE.*` paths for `warp_cd` / `warp __complete` snippets, and lists other detected `warp.exe` installs without touching them.

Surface lines up with the Bash uninstaller and `install.ps1`: `-DryRun`, `-InstallDir`, `$env:GIT_WARP_INSTALL_DIR`, `$env:GIT_WARP_KEEP_HOOKS = '1'`.

`docs/install.md` Uninstall section now has a PowerShell subsection with the `irm | iex` invocation and the new flags. `src/release.rs::collect_metadata_checks` asserts both `install.ps1` and `uninstall.ps1` exist at the repo root, so a Windows install can't ship without the matching uninstall. Existing `tests/unit/release_tests.rs` cases updated for the new check count; one new case covers the partial-presence failure (install present, uninstall missing).

## Verification

- \`cargo fmt --all -- --check\`
- \`cargo clippy --all-targets --locked -- -D warnings\`
- \`cargo test --locked\` — 223 passed (+1 vs baseline)
- \`git diff --check\`

No PowerShell interpreter on this dev host, so the script itself wasn't end-to-end smoke-tested; CI on \`windows-latest\` will exercise the release-check guardrail.

Closes #177