### PR TITLE
fix(doctor): make warp doctor Windows-aware (#178)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -214,6 +214,8 @@ enum DoctorShell {
         name: &'static str,
         rc_path: PathBuf,
     },
+    #[cfg_attr(not(windows), allow(dead_code))]
+    PowerShell,
     Unknown {
         value: Option<String>,
     },
@@ -1944,6 +1946,12 @@ impl Cli {
                 "Install",
                 "no warp binary found in PATH or known install dirs",
             );
+            #[cfg(windows)]
+            next_steps.push(
+                "Reinstall with `irm https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.ps1 | iex`."
+                    .to_string(),
+            );
+            #[cfg(not(windows))]
             next_steps.push(
                 "Reinstall with `curl -fsSL https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.sh | sh`."
                     .to_string(),
@@ -2004,7 +2012,10 @@ impl Cli {
             (None, Some(dir)) => {
                 Self::doctor_warn(
                     "Shell PATH",
-                    format!("no warp on PATH (expected {}/warp)", dir.display()),
+                    format!(
+                        "no warp on PATH (expected {})",
+                        dir.join(Self::warp_executable_name()).display()
+                    ),
                 );
                 next_steps.push(format!(
                     "Add `{}` to PATH (e.g. `export PATH=\"{}:$PATH\"`).",
@@ -2029,7 +2040,7 @@ impl Cli {
                     dir.display()
                 ));
             } else if let Some(active_path) = &active {
-                let installed = dir.join("warp");
+                let installed = dir.join(Self::warp_executable_name());
                 if installed.is_file() && !Self::same_path(active_path, &installed) {
                     Self::doctor_warn(
                         "Default install path",
@@ -2083,6 +2094,25 @@ impl Cli {
                     ));
                 }
             }
+            DoctorShell::PowerShell => {
+                Self::doctor_warn(
+                    "Shell integration",
+                    "PowerShell integration is not yet shipped",
+                );
+                if let Some(dir) = &default_dir {
+                    next_steps.push(format!(
+                        "Add `{}` to $env:PATH (e.g. `$env:Path = \"{};$env:Path\"`) so installed {} is found.",
+                        dir.display(),
+                        dir.display(),
+                        Self::warp_executable_name(),
+                    ));
+                } else {
+                    next_steps.push(
+                        "Install Git-Warp via `irm https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.ps1 | iex` and add the install directory to $env:PATH."
+                            .to_string(),
+                    );
+                }
+            }
             DoctorShell::Unknown { value } => {
                 let detail = match value {
                     Some(v) => format!("unsupported shell `{v}`; supported: bash, zsh, fish"),
@@ -2096,6 +2126,10 @@ impl Cli {
         }
     }
 
+    fn warp_executable_name() -> String {
+        format!("warp{}", std::env::consts::EXE_SUFFIX)
+    }
+
     fn doctor_default_install_dir() -> Option<PathBuf> {
         if let Some(value) = std::env::var_os("GIT_WARP_DEFAULT_INSTALL_DIR") {
             let path = PathBuf::from(value);
@@ -2103,7 +2137,23 @@ impl Cli {
                 return Some(path);
             }
         }
-        dirs::home_dir().map(|h| h.join(".local").join("bin"))
+        #[cfg(windows)]
+        {
+            if let Some(local) = dirs::data_local_dir() {
+                return Some(local.join("Programs").join("git-warp").join("bin"));
+            }
+            return dirs::home_dir().map(|h| {
+                h.join("AppData")
+                    .join("Local")
+                    .join("Programs")
+                    .join("git-warp")
+                    .join("bin")
+            });
+        }
+        #[cfg(not(windows))]
+        {
+            dirs::home_dir().map(|h| h.join(".local").join("bin"))
+        }
     }
 
     fn path_dirs() -> Vec<PathBuf> {
@@ -2130,7 +2180,7 @@ impl Cli {
 
         let home = match dirs::home_dir() {
             Some(h) => h,
-            None => return DoctorShell::Unknown { value: raw },
+            None => return Self::fallback_shell(raw),
         };
 
         match basename.as_deref() {
@@ -2146,8 +2196,19 @@ impl Cli {
                 name: "fish",
                 rc_path: home.join(".config").join("fish").join("config.fish"),
             },
-            _ => DoctorShell::Unknown { value: raw },
+            _ => Self::fallback_shell(raw),
         }
+    }
+
+    fn fallback_shell(raw: Option<String>) -> DoctorShell {
+        #[cfg(windows)]
+        {
+            if std::env::var_os("PSModulePath").is_some() {
+                let _ = raw;
+                return DoctorShell::PowerShell;
+            }
+        }
+        DoctorShell::Unknown { value: raw }
     }
 
     fn shell_rc_has_warp_integration(rc_path: &Path) -> bool {
@@ -2164,7 +2225,7 @@ impl Cli {
         }
 
         for dir in Self::doctor_install_probe_dirs() {
-            let candidate = dir.join("warp");
+            let candidate = dir.join(Self::warp_executable_name());
             if candidate.is_file() {
                 paths.push((candidate, false));
             }
@@ -2197,20 +2258,34 @@ impl Cli {
         if let Some(override_value) = std::env::var_os("GIT_WARP_DOCTOR_PROBE_DIRS") {
             return std::env::split_paths(&override_value).collect();
         }
+        #[allow(unused_mut)]
         let mut dirs = Vec::new();
-        if let Some(home) = dirs::home_dir() {
-            dirs.push(home.join(".local").join("bin"));
-            dirs.push(home.join(".cargo").join("bin"));
+        #[cfg(windows)]
+        {
+            if let Some(local) = dirs::data_local_dir() {
+                dirs.push(local.join("Programs").join("git-warp").join("bin"));
+            }
+            if let Some(home) = dirs::home_dir() {
+                dirs.push(home.join(".cargo").join("bin"));
+            }
         }
-        dirs.push(PathBuf::from("/usr/local/bin"));
-        dirs.push(PathBuf::from("/opt/homebrew/bin"));
+        #[cfg(not(windows))]
+        {
+            if let Some(home) = dirs::home_dir() {
+                dirs.push(home.join(".local").join("bin"));
+                dirs.push(home.join(".cargo").join("bin"));
+            }
+            dirs.push(PathBuf::from("/usr/local/bin"));
+            dirs.push(PathBuf::from("/opt/homebrew/bin"));
+        }
         dirs
     }
 
     fn resolve_warp_on_path() -> Option<PathBuf> {
         let path = std::env::var_os("PATH")?;
+        let name = Self::warp_executable_name();
         for dir in std::env::split_paths(&path) {
-            let candidate = dir.join("warp");
+            let candidate = dir.join(&name);
             if candidate.is_file() && Self::is_executable(&candidate) {
                 return Some(candidate);
             }

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -1242,10 +1242,21 @@ fn uninstall_script_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("uninstall.sh")
 }
 
-#[cfg(unix)]
+fn warp_bin_name() -> String {
+    format!("warp{}", std::env::consts::EXE_SUFFIX)
+}
+
 fn write_fake_warp_binary(path: &Path, version_label: &str) {
     fs::create_dir_all(path.parent().unwrap()).unwrap();
-    write_executable(path, &format!("#!/bin/sh\necho \"{version_label}\"\n"));
+    #[cfg(unix)]
+    {
+        write_executable(path, &format!("#!/bin/sh\necho \"{version_label}\"\n"));
+    }
+    #[cfg(windows)]
+    {
+        let _ = version_label;
+        fs::write(path, b"").unwrap();
+    }
 }
 
 #[cfg(unix)]
@@ -1537,7 +1548,6 @@ fn test_uninstaller_reports_when_no_default_install_exists() {
     );
 }
 
-#[cfg(unix)]
 #[test]
 fn test_doctor_install_check_warns_on_multiple_warp_binaries() {
     let temp_dir = tempdir().unwrap();
@@ -1545,22 +1555,24 @@ fn test_doctor_install_check_warns_on_multiple_warp_binaries() {
     let probe_a = tempdir().unwrap();
     let probe_b = tempdir().unwrap();
 
-    write_fake_warp_binary(&probe_a.path().join("warp"), "warp 0.1.0");
-    write_fake_warp_binary(&probe_b.path().join("warp"), "warp 0.2.0");
+    write_fake_warp_binary(&probe_a.path().join(warp_bin_name()), "warp 0.1.0");
+    write_fake_warp_binary(&probe_b.path().join(warp_bin_name()), "warp 0.2.0");
 
+    let probe_dirs = std::env::join_paths([probe_a.path(), probe_b.path()]).unwrap();
     let output = warp_command(temp_dir.path())
         .env("HOME", home_dir.path())
         .env("XDG_CONFIG_HOME", home_dir.path().join(".config"))
         .env("PATH", probe_a.path())
-        .env(
-            "GIT_WARP_DOCTOR_PROBE_DIRS",
-            format!("{}:{}", probe_a.path().display(), probe_b.path().display()),
-        )
+        .env("GIT_WARP_DOCTOR_PROBE_DIRS", probe_dirs)
+        .env_remove("PSModulePath")
         .arg("doctor")
         .output()
         .unwrap();
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
+
+    let active_path = probe_a.path().join(warp_bin_name());
+    let inactive_path = probe_b.path().join(warp_bin_name());
 
     assert!(output.status.success(), "{stdout}{stderr}");
     assert!(stdout.contains("Install:"), "{stdout}");
@@ -1569,40 +1581,42 @@ fn test_doctor_install_check_warns_on_multiple_warp_binaries() {
         "{stdout}"
     );
     assert!(
-        stdout.contains(&format!("{}/warp (active)", probe_a.path().display())),
+        stdout.contains(&format!("{} (active)", active_path.display())),
         "{stdout}"
     );
     assert!(
-        stdout.contains(&format!("{}/warp", probe_b.path().display())),
+        stdout.contains(&inactive_path.display().to_string()),
         "{stdout}"
     );
     assert!(stdout.contains("Resolve install conflicts"), "{stdout}");
 }
 
-#[cfg(unix)]
 #[test]
 fn test_doctor_install_check_passes_with_single_active_binary() {
     let temp_dir = tempdir().unwrap();
     let home_dir = tempdir().unwrap();
     let probe = tempdir().unwrap();
 
-    write_fake_warp_binary(&probe.path().join("warp"), "warp 0.3.0");
+    write_fake_warp_binary(&probe.path().join(warp_bin_name()), "warp 0.3.0");
 
     let output = warp_command(temp_dir.path())
         .env("HOME", home_dir.path())
         .env("XDG_CONFIG_HOME", home_dir.path().join(".config"))
         .env("PATH", probe.path())
         .env("GIT_WARP_DOCTOR_PROBE_DIRS", probe.path())
+        .env_remove("PSModulePath")
         .arg("doctor")
         .output()
         .unwrap();
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
 
+    let active_path = probe.path().join(warp_bin_name());
+
     assert!(output.status.success(), "{stdout}{stderr}");
     assert!(stdout.contains("Install:"), "{stdout}");
     assert!(
-        stdout.contains(&format!("{}/warp (active)", probe.path().display())),
+        stdout.contains(&format!("{} (active)", active_path.display())),
         "{stdout}"
     );
     assert!(
@@ -1611,19 +1625,20 @@ fn test_doctor_install_check_passes_with_single_active_binary() {
     );
 }
 
-#[cfg(unix)]
 #[test]
 fn test_doctor_shell_check_warns_when_install_dir_not_in_path() {
     let temp_dir = tempdir().unwrap();
     let home_dir = tempdir().unwrap();
     let other_dir = tempdir().unwrap();
+    let install_dir = home_dir.path().join("install-bin");
 
-    let install_dir = home_dir.path().join(".local").join("bin");
     let output = warp_command(temp_dir.path())
         .env("HOME", home_dir.path())
         .env("XDG_CONFIG_HOME", home_dir.path().join(".config"))
         .env("PATH", other_dir.path())
         .env("GIT_WARP_DOCTOR_PROBE_DIRS", other_dir.path())
+        .env("GIT_WARP_DEFAULT_INSTALL_DIR", &install_dir)
+        .env_remove("PSModulePath")
         .arg("doctor")
         .output()
         .unwrap();
@@ -1637,58 +1652,62 @@ fn test_doctor_shell_check_warns_when_install_dir_not_in_path() {
         "{stdout}"
     );
     assert!(
-        stdout.contains(&format!("export PATH=\"{}:$PATH\"", install_dir.display())),
+        stdout.contains(&format!("Add `{}` to PATH", install_dir.display())),
         "{stdout}"
     );
 }
 
-#[cfg(unix)]
 #[test]
 fn test_doctor_shell_check_passes_when_install_dir_in_path() {
     let temp_dir = tempdir().unwrap();
     let home_dir = tempdir().unwrap();
-    let install_dir = home_dir.path().join(".local").join("bin");
+    let install_dir = home_dir.path().join("install-bin");
     fs::create_dir_all(&install_dir).unwrap();
-    write_fake_warp_binary(&install_dir.join("warp"), "warp 0.4.0");
+    write_fake_warp_binary(&install_dir.join(warp_bin_name()), "warp 0.4.0");
 
     let output = warp_command(temp_dir.path())
         .env("HOME", home_dir.path())
         .env("XDG_CONFIG_HOME", home_dir.path().join(".config"))
         .env("PATH", &install_dir)
         .env("GIT_WARP_DOCTOR_PROBE_DIRS", &install_dir)
+        .env("GIT_WARP_DEFAULT_INSTALL_DIR", &install_dir)
+        .env_remove("PSModulePath")
         .arg("doctor")
         .output()
         .unwrap();
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
 
+    let active_path = install_dir.join(warp_bin_name());
+
     assert!(output.status.success(), "{stdout}{stderr}");
     assert!(stdout.contains("Shell PATH"), "{stdout}");
     assert!(
-        stdout.contains(&format!("active warp at {}/warp", install_dir.display())),
+        stdout.contains(&format!("active warp at {}", active_path.display())),
         "{stdout}"
     );
     assert!(!stdout.contains("is not in PATH"), "{stdout}");
 }
 
-#[cfg(unix)]
 #[test]
 fn test_doctor_shell_check_warns_when_path_shadows_install_dir() {
     let temp_dir = tempdir().unwrap();
     let home_dir = tempdir().unwrap();
-    let install_dir = home_dir.path().join(".local").join("bin");
+    let install_dir = home_dir.path().join("install-bin");
     fs::create_dir_all(&install_dir).unwrap();
-    write_fake_warp_binary(&install_dir.join("warp"), "warp 0.4.0");
+    write_fake_warp_binary(&install_dir.join(warp_bin_name()), "warp 0.4.0");
 
     let other_dir = tempdir().unwrap();
-    write_fake_warp_binary(&other_dir.path().join("warp"), "warp 0.1.0");
+    write_fake_warp_binary(&other_dir.path().join(warp_bin_name()), "warp 0.1.0");
 
-    let path_value = format!("{}:{}", other_dir.path().display(), install_dir.display());
+    let path_value = std::env::join_paths([other_dir.path(), install_dir.as_path()]).unwrap();
     let output = warp_command(temp_dir.path())
         .env("HOME", home_dir.path())
         .env("XDG_CONFIG_HOME", home_dir.path().join(".config"))
         .env("PATH", &path_value)
         .env("GIT_WARP_DOCTOR_PROBE_DIRS", &path_value)
+        .env("GIT_WARP_DEFAULT_INSTALL_DIR", &install_dir)
+        .env_remove("PSModulePath")
         .arg("doctor")
         .output()
         .unwrap();
@@ -1807,6 +1826,76 @@ fn test_doctor_shell_check_handles_unknown_shell() {
         "{stdout}"
     );
     assert!(stdout.contains("supported: bash, zsh, fish"), "{stdout}");
+}
+
+#[cfg(windows)]
+#[test]
+fn test_doctor_shell_check_recognizes_powershell() {
+    let temp_dir = tempdir().unwrap();
+    let home_dir = tempdir().unwrap();
+    let install_dir = home_dir
+        .path()
+        .join("Programs")
+        .join("git-warp")
+        .join("bin");
+    fs::create_dir_all(&install_dir).unwrap();
+    write_fake_warp_binary(&install_dir.join(warp_bin_name()), "warp 0.4.0");
+
+    let output = warp_command(temp_dir.path())
+        .env("HOME", home_dir.path())
+        .env("XDG_CONFIG_HOME", home_dir.path().join(".config"))
+        .env("PATH", &install_dir)
+        .env("GIT_WARP_DOCTOR_PROBE_DIRS", &install_dir)
+        .env("GIT_WARP_DEFAULT_INSTALL_DIR", &install_dir)
+        .env("PSModulePath", "C:\\fake\\Modules")
+        .env_remove("SHELL")
+        .arg("doctor")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "{stdout}{stderr}");
+    assert!(
+        stdout.contains("PowerShell integration is not yet shipped"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains(&format!("Add `{}` to $env:PATH", install_dir.display())),
+        "{stdout}"
+    );
+    assert!(
+        !stdout.contains("Set SHELL to bash, zsh, or fish"),
+        "{stdout}"
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn test_doctor_install_check_recommends_install_ps1_when_missing() {
+    let temp_dir = tempdir().unwrap();
+    let home_dir = tempdir().unwrap();
+    let empty_probe = tempdir().unwrap();
+    let empty_path = tempdir().unwrap();
+
+    let output = warp_command(temp_dir.path())
+        .env("HOME", home_dir.path())
+        .env("XDG_CONFIG_HOME", home_dir.path().join(".config"))
+        .env("PATH", empty_path.path())
+        .env("GIT_WARP_DOCTOR_PROBE_DIRS", empty_probe.path())
+        .env_remove("SHELL")
+        .arg("doctor")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "{stdout}{stderr}");
+    assert!(
+        stdout.contains("no warp binary found in PATH or known install dirs"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("install.ps1 | iex"), "{stdout}");
 }
 
 fn setup_repo_with_origin() -> (tempfile::TempDir, tempfile::TempDir) {


### PR DESCRIPTION
## Summary

- Probes join `warp{EXE_SUFFIX}` everywhere, so `warp.exe` from `install.ps1` is no longer "missing" on Windows.
- `doctor_default_install_dir` and `doctor_install_probe_dirs` branch on `cfg(windows)` to `%LOCALAPPDATA%\Programs\git-warp\bin` (the `install.ps1` default) and `%USERPROFILE%\.cargo\bin`.
- `DoctorShell` gains a `PowerShell` variant, picked up via `PSModulePath`. The shell-integration check then emits a `$env:PATH` next step instead of the "Set SHELL to bash, zsh, or fish" nonsense.
- Empty-installs reinstall hint is now `irm ... install.ps1 | iex` on Windows. The previous `curl | sh` line wasn't usable.
- Five doctor install/shell tests dropped `#[cfg(unix)]`. They use `warp_bin_name()`, `env::join_paths`, and `GIT_WARP_DEFAULT_INSTALL_DIR` to stay deterministic. Two new `#[cfg(windows)]` tests cover the PowerShell branch and the `install.ps1` reinstall hint.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` — 222 passed on macOS (same baseline; new tests are Windows-only).
- `git diff --check`

`windows-latest` in the existing CI matrix exercises the new code paths and the two new tests.

Closes #178