### PR TITLE
fix(cli): reject unknown warp hooks-install / hooks-remove --level (#179)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -144,8 +144,8 @@ pub enum Commands {
     /// Install agent hooks
     HooksInstall {
         /// Installation level: user, project, console
-        #[arg(long)]
-        level: Option<String>,
+        #[arg(long, value_enum)]
+        level: Option<crate::hooks::HookInstallLevel>,
         /// Runtime: claude, codex, all
         #[arg(long, default_value = "claude")]
         runtime: String,
@@ -154,8 +154,8 @@ pub enum Commands {
     /// Remove agent hooks
     HooksRemove {
         /// Installation level: user, project
-        #[arg(long)]
-        level: Option<String>,
+        #[arg(long, value_enum)]
+        level: Option<crate::hooks::HookRemoveLevel>,
         /// Runtime: claude, codex, all
         #[arg(long, default_value = "claude")]
         runtime: String,
@@ -443,12 +443,8 @@ impl Cli {
                 version: version.clone(),
                 metadata_only: *metadata_only,
             }),
-            Commands::HooksInstall { level, runtime } => {
-                self.handle_hooks_install(level.as_deref(), runtime)
-            }
-            Commands::HooksRemove { level, runtime } => {
-                self.handle_hooks_remove(level.as_deref(), runtime)
-            }
+            Commands::HooksInstall { level, runtime } => self.handle_hooks_install(*level, runtime),
+            Commands::HooksRemove { level, runtime } => self.handle_hooks_remove(*level, runtime),
             Commands::HooksStatus { runtime } => self.handle_hooks_status(runtime),
             Commands::ShellConfig { shell } => self.handle_shell_config(shell.as_deref()),
             Commands::Complete { target, prefix } => {
@@ -2366,40 +2362,50 @@ impl Cli {
         dashboard.run()
     }
 
-    fn handle_hooks_install(&self, level: Option<&str>, runtime: &str) -> Result<()> {
-        use crate::hooks::HooksManager;
+    fn handle_hooks_install(
+        &self,
+        level: Option<crate::hooks::HookInstallLevel>,
+        runtime: &str,
+    ) -> Result<()> {
+        use crate::hooks::{HookInstallLevel, HooksManager};
 
+        let resolved = level.unwrap_or(HookInstallLevel::Console);
         info!(
-            "Installing hooks at level: {:?}, runtime: {}",
-            level, runtime
+            "Installing hooks at level: {}, runtime: {}",
+            resolved, runtime
         );
         if self.dry_run {
             println!(
-                "Would install Git-Warp hooks at level: {:?}, runtime: {}",
-                level.unwrap_or("console"),
-                runtime
+                "Would install Git-Warp hooks at level: {}, runtime: {}",
+                resolved, runtime
             );
             return Ok(());
         }
 
-        HooksManager::install_hooks(level, runtime)
+        HooksManager::install_hooks(resolved, runtime)
     }
 
-    fn handle_hooks_remove(&self, level: Option<&str>, runtime: &str) -> Result<()> {
-        use crate::hooks::HooksManager;
+    fn handle_hooks_remove(
+        &self,
+        level: Option<crate::hooks::HookRemoveLevel>,
+        runtime: &str,
+    ) -> Result<()> {
+        use crate::hooks::{HookRemoveLevel, HooksManager};
 
-        info!("Removing hooks at level: {:?}, runtime: {}", level, runtime);
+        let resolved = level.unwrap_or(HookRemoveLevel::User);
+        info!(
+            "Removing hooks at level: {}, runtime: {}",
+            resolved, runtime
+        );
         if self.dry_run {
             println!(
-                "Would remove Git-Warp hooks at level: {:?}, runtime: {}",
-                level.unwrap_or("user"),
-                runtime
+                "Would remove Git-Warp hooks at level: {}, runtime: {}",
+                resolved, runtime
             );
             return Ok(());
         }
 
-        let level = level.unwrap_or("user");
-        HooksManager::remove_hooks(level, runtime)
+        HooksManager::remove_hooks(resolved, runtime)
     }
 
     fn handle_hooks_status(&self, runtime: &str) -> Result<()> {

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,9 +1,55 @@
 use crate::error::Result;
+use clap::ValueEnum;
 use serde_json::{Map, Value, json};
+use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 const GIT_WARP_HOOK_PREFIX: &str = "agent_status_";
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+pub enum HookInstallLevel {
+    User,
+    Project,
+    Console,
+}
+
+impl HookInstallLevel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            HookInstallLevel::User => "user",
+            HookInstallLevel::Project => "project",
+            HookInstallLevel::Console => "console",
+        }
+    }
+}
+
+impl fmt::Display for HookInstallLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+pub enum HookRemoveLevel {
+    User,
+    Project,
+}
+
+impl HookRemoveLevel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            HookRemoveLevel::User => "user",
+            HookRemoveLevel::Project => "project",
+        }
+    }
+}
+
+impl fmt::Display for HookRemoveLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 const EXPECTED_EVENTS: &[&str] = &[
     "SessionStart",
@@ -137,11 +183,11 @@ impl HookDiagnosis {
 pub struct HooksManager;
 
 impl HooksManager {
-    pub fn install_hooks(level: Option<&str>, runtime: &str) -> Result<()> {
+    pub fn install_hooks(level: HookInstallLevel, runtime: &str) -> Result<()> {
         let runtimes = HookRuntime::parse_many(runtime)?;
 
         match level {
-            Some("console") | None => {
+            HookInstallLevel::Console => {
                 for (index, runtime) in runtimes.iter().enumerate() {
                     if index > 0 {
                         println!();
@@ -154,45 +200,37 @@ impl HooksManager {
                 }
                 Ok(())
             }
-            Some("user") => {
+            HookInstallLevel::User => {
                 for runtime in runtimes {
                     let settings_path = runtime.user_settings_path()?;
                     Self::merge_hooks_into_settings(settings_path, runtime)?;
                 }
                 Ok(())
             }
-            Some("project") => {
+            HookInstallLevel::Project => {
                 for runtime in runtimes {
                     let settings_path = runtime.project_settings_path()?;
                     Self::merge_hooks_into_settings(settings_path, runtime)?;
                 }
                 Ok(())
             }
-            _ => {
-                println!("Invalid level. Use: user, project, or console");
-                Ok(())
-            }
         }
     }
 
-    pub fn remove_hooks(level: &str, runtime: &str) -> Result<()> {
+    pub fn remove_hooks(level: HookRemoveLevel, runtime: &str) -> Result<()> {
         let runtimes = HookRuntime::parse_many(runtime)?;
 
         match level {
-            "user" => {
+            HookRemoveLevel::User => {
                 for runtime in runtimes {
                     Self::remove_hooks_from_settings(runtime.user_settings_path()?, runtime)?;
                 }
                 Ok(())
             }
-            "project" => {
+            HookRemoveLevel::Project => {
                 for runtime in runtimes {
                     Self::remove_hooks_from_settings(runtime.project_settings_path()?, runtime)?;
                 }
-                Ok(())
-            }
-            _ => {
-                println!("Invalid level. Use: user or project");
                 Ok(())
             }
         }

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -1035,6 +1035,56 @@ fn test_cleanup_rejects_kill_and_no_kill_together() {
 }
 
 #[test]
+fn test_hooks_install_rejects_unknown_level() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+
+    let output = warp_command(repo_path)
+        .args(["hooks-install", "--level", "garbage", "--runtime", "claude"])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit when hooks-install --level is unknown; stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    for variant in ["user", "project", "console"] {
+        assert!(
+            stderr.contains(variant),
+            "stderr should mention valid level `{variant}`: {stderr}",
+        );
+    }
+}
+
+#[test]
+fn test_hooks_remove_rejects_unknown_level() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+
+    let output = warp_command(repo_path)
+        .args(["hooks-remove", "--level", "console", "--runtime", "claude"])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit when hooks-remove --level is unknown; stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    for variant in ["user", "project"] {
+        assert!(
+            stderr.contains(variant),
+            "stderr should mention valid level `{variant}`: {stderr}",
+        );
+    }
+}
+
+#[test]
 fn test_cleanup_dry_run_explains_candidates_and_skipped_reasons() {
     let temp_dir = setup_test_repo();
     let repo_path = temp_dir.path();


### PR DESCRIPTION
## Summary

- `Cli::HooksInstall.level` becomes `Option<HookInstallLevel>` and `Cli::HooksRemove.level` becomes `Option<HookRemoveLevel>`, both `clap::ValueEnum`. Typos like `--level usre` / `--level User` now fail at parse time with the supported list, matching the #154 (`--mode`) and #153 (`--terminal` / `terminal_mode`) precedent.
- The two enums live next to `HookRuntime` in `src/hooks.rs` since the rest of `crate::hooks` is the only consumer. `HooksManager::install_hooks` and `HooksManager::remove_hooks` take them directly, so the unreachable `_ => println!(...); Ok(())` arms that swallowed bad input and exited 0 are gone.
- `handle_hooks_install` / `handle_hooks_remove` resolve a missing `--level` to `Console` / `User` respectively, so the existing CLI defaults (no `--level` for `hooks-install` prints the config snippet, no `--level` for `hooks-remove` strips user-level hooks) are unchanged.
- Two new tests in `tests/integration/cli_surface_tests.rs`:
  - `test_hooks_install_rejects_unknown_level` asserts `--level garbage` exits non-zero and stderr names `user`, `project`, and `console`.
  - `test_hooks_remove_rejects_unknown_level` asserts `--level console` exits non-zero and stderr names `user` and `project` (since `Console` is not a valid remove scope).

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` (90 + 93 + 224 passed; +2 over baseline)
- `git diff --check`

Closes #179