### PR TITLE
ci: add cargo audit workflow for RUSTSEC advisories (#183)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,38 @@
+name: Audit
+
+on:
+  pull_request:
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - .github/workflows/audit.yml
+  push:
+    branches:
+      - main
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - .github/workflows/audit.yml
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: cargo audit
+        uses: rustsec/audit-check@v2
+        continue-on-error: true
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- New `.github/workflows/audit.yml` runs `rustsec/audit-check@v2` against the dependency tree on every PR that changes `Cargo.toml` / `Cargo.lock`, on pushes to `main` with the same path filter, on a daily `0 6 * * *` cron, and via `workflow_dispatch`.
- `continue-on-error: true` keeps the job non-gating, per the issue's guidance — findings appear in the Checks tab without blocking merges.
- Permissions narrowed to `contents: read` plus `issues: write` (the official action can open advisory issues on scheduled runs).
- Concurrency group mirrors `ci.yml` so cron + push runs do not pile up.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/audit.yml'))"` — YAML parses cleanly.
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #183