### PR TITLE
ci(deps): add Dependabot config for cargo and github-actions (#184)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      cargo-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

- New `.github/dependabot.yml` enables Dependabot v2 for two ecosystems: `cargo` (root `Cargo.toml`) and `github-actions` (workflow files under `.github/workflows/`).
- Both ecosystems run on a weekly schedule with `open-pull-requests-limit: 5` to cap dashboard noise per the issue guidance.
- Minor + patch updates are grouped into a single PR per ecosystem (`cargo-minor-and-patch`, `actions-minor-and-patch`); major bumps still arrive individually so SemVer-breaking changes get isolated review.
- No `allow`/`ignore` block — the issue notes the slot is useful but currently empty.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` — config parses as valid YAML with `version: 2` and both ecosystems present.
- `git diff --check` — clean.

Closes #184