### PR TITLE
fix(cli): drop needless return in windows install-dir resolver

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2163,13 +2163,13 @@ impl Cli {
             if let Some(local) = dirs::data_local_dir() {
                 return Some(local.join("Programs").join("git-warp").join("bin"));
             }
-            return dirs::home_dir().map(|h| {
+            dirs::home_dir().map(|h| {
                 h.join("AppData")
                     .join("Local")
                     .join("Programs")
                     .join("git-warp")
                     .join("bin")
-            });
+            })
         }
         #[cfg(not(windows))]
         {


### PR DESCRIPTION
The windows branch of `doctor_default_install_dir` ended with an explicit `return` on its tail expression, which clippy's `needless_return` rejects. This was failing `cargo clippy (windows-latest)` and blocking all CI on that runner (including the open Dependabot PRs).

Make it a tail expression. No behavior change.