### PR TITLE
fix(release): honor .exe suffix in release-check binary smoke steps

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2035,7 +2035,7 @@ impl Cli {
                     "Shell PATH",
                     format!(
                         "no warp on PATH (expected {})",
-                        dir.join(Self::warp_executable_name()).display()
+                        dir.join(crate::release::warp_executable_name()).display()
                     ),
                 );
                 next_steps.push(format!(
@@ -2061,7 +2061,7 @@ impl Cli {
                     dir.display()
                 ));
             } else if let Some(active_path) = &active {
-                let installed = dir.join(Self::warp_executable_name());
+                let installed = dir.join(crate::release::warp_executable_name());
                 if installed.is_file() && !Self::same_path(active_path, &installed) {
                     Self::doctor_warn(
                         "Default install path",
@@ -2125,7 +2125,7 @@ impl Cli {
                         "Add `{}` to $env:PATH (e.g. `$env:Path = \"{};$env:Path\"`) so installed {} is found.",
                         dir.display(),
                         dir.display(),
-                        Self::warp_executable_name(),
+                        crate::release::warp_executable_name(),
                     ));
                 } else {
                     next_steps.push(
@@ -2145,10 +2145,6 @@ impl Cli {
                 );
             }
         }
-    }
-
-    fn warp_executable_name() -> String {
-        format!("warp{}", std::env::consts::EXE_SUFFIX)
     }
 
     fn doctor_default_install_dir() -> Option<PathBuf> {
@@ -2246,7 +2242,7 @@ impl Cli {
         }
 
         for dir in Self::doctor_install_probe_dirs() {
-            let candidate = dir.join(Self::warp_executable_name());
+            let candidate = dir.join(crate::release::warp_executable_name());
             if candidate.is_file() {
                 paths.push((candidate, false));
             }
@@ -2304,7 +2300,7 @@ impl Cli {
 
     fn resolve_warp_on_path() -> Option<PathBuf> {
         let path = std::env::var_os("PATH")?;
-        let name = Self::warp_executable_name();
+        let name = crate::release::warp_executable_name();
         for dir in std::env::split_paths(&path) {
             let candidate = dir.join(&name);
             if candidate.is_file() && Self::is_executable(&candidate) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,3 +18,4 @@ pub mod terminal;
 pub mod tui;
 
 pub use error::{GitWarpError, Result};
+pub use release::warp_executable_name;

--- a/src/release.rs
+++ b/src/release.rs
@@ -3,6 +3,12 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+/// Filename of the `warp` binary on the current platform (`warp.exe` on Windows,
+/// `warp` elsewhere).
+pub fn warp_executable_name() -> String {
+    format!("warp{}", std::env::consts::EXE_SUFFIX)
+}
+
 pub struct ReleaseCheckOptions {
     pub version: Option<String>,
     pub metadata_only: bool,
@@ -229,8 +235,10 @@ fn print_metadata_checks(checks: &[ReleaseCheck]) {
 }
 
 fn run_release_commands(repo_root: &Path, expected: &ReleaseVersion) -> Result<()> {
-    let release_binary = repo_root.join("target").join("release").join("warp");
+    let binary_name = warp_executable_name();
+    let release_binary = repo_root.join("target").join("release").join(&binary_name);
     let release_binary = release_binary.to_string_lossy().into_owned();
+    let warp_label = format!("./target/release/{binary_name}");
 
     let steps = [
         ReleaseCommand::new(
@@ -258,27 +266,27 @@ fn run_release_commands(repo_root: &Path, expected: &ReleaseVersion) -> Result<(
             &["build", "--release", "--bin", "warp"],
         ),
         ReleaseCommand::new(
-            "./target/release/warp --version",
+            format!("{warp_label} --version"),
             release_binary.as_str(),
             &["--version"],
         ),
         ReleaseCommand::new(
-            "./target/release/warp --help",
+            format!("{warp_label} --help"),
             release_binary.as_str(),
             &["--help"],
         ),
         ReleaseCommand::new(
-            "./target/release/warp switch --help",
+            format!("{warp_label} switch --help"),
             release_binary.as_str(),
             &["switch", "--help"],
         ),
         ReleaseCommand::new(
-            "./target/release/warp cleanup --help",
+            format!("{warp_label} cleanup --help"),
             release_binary.as_str(),
             &["cleanup", "--help"],
         ),
         ReleaseCommand::new(
-            "./target/release/warp doctor",
+            format!("{warp_label} doctor"),
             release_binary.as_str(),
             &["doctor"],
         ),
@@ -295,15 +303,15 @@ fn run_release_commands(repo_root: &Path, expected: &ReleaseVersion) -> Result<(
 }
 
 struct ReleaseCommand<'a> {
-    label: &'static str,
+    label: String,
     program: &'a str,
     args: &'a [&'a str],
 }
 
 impl<'a> ReleaseCommand<'a> {
-    fn new(label: &'static str, program: &'a str, args: &'a [&'a str]) -> Self {
+    fn new(label: impl Into<String>, program: &'a str, args: &'a [&'a str]) -> Self {
         Self {
-            label,
+            label: label.into(),
             program,
             args,
         }

--- a/tests/unit/release_tests.rs
+++ b/tests/unit/release_tests.rs
@@ -1,8 +1,19 @@
 use git_warp::release::{
     ReleaseVersion, collect_metadata_checks, read_package_version, resolve_version,
 };
+use git_warp::warp_executable_name;
 use std::fs;
 use tempfile::tempdir;
+
+#[test]
+fn test_warp_executable_name_matches_platform() {
+    let name = warp_executable_name();
+    if cfg!(windows) {
+        assert_eq!(name, "warp.exe");
+    } else {
+        assert_eq!(name, "warp");
+    }
+}
 
 #[test]
 fn test_resolve_version() {


### PR DESCRIPTION
## Summary

`run_release_commands` in `src/release.rs` hardcoded `./target/release/warp` for
the five binary smoke steps (`--version`, `--help`, `switch --help`, `cleanup
--help`, `doctor`). On Windows `cargo build --release --bin warp` produces
`warp.exe`, so every spawn failed with \"the system cannot find the file
specified\" even when the build itself succeeded.

- Extract `warp_executable_name()` as a free function in `src/release.rs` and
  re-export it from `src/lib.rs` so both the library (`release-check`) and the
  binary crate (`cli` doctor probes) reach the same helper.
- Build `release_binary` from that helper and derive each smoke step's label
  from the same name, so the printed `$ ./target/release/<bin> ...` line
  matches what was actually spawned (`warp.exe` on Windows, `warp` elsewhere).
- Drop the now-redundant `Cli::warp_executable_name()` and route the six
  callers in `src/cli.rs` through `crate::release::warp_executable_name()`.
- Add a `test_warp_executable_name_matches_platform` unit test that asserts
  `warp` on Unix and `warp.exe` on Windows.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` (226 tests pass, includes the new helper test)
- `git diff --check`

Closes #190