### PR TITLE
fix(install): install.ps1 cargo path honors -InstallDir / -InstallRoot

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -76,6 +76,20 @@ piping):
 & ([scriptblock]::Create((irm https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.ps1))) -InstallDir 'C:\tools\git-warp'
 ```
 
+For `-Method cargo`, `cargo install` writes to `<root>\bin\warp.exe`, so the
+relevant override is the cargo root. Pass `-InstallRoot` (or set
+`$env:GIT_WARP_INSTALL_ROOT`) — this mirrors `GIT_WARP_INSTALL_ROOT` in
+`install.sh`:
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.ps1))) -Method cargo -InstallRoot 'C:\tools\git-warp'
+```
+
+When `-InstallDir` ends in `\bin` (and `-InstallRoot` is not set), the
+installer derives the cargo root as the parent directory so a single
+`-InstallDir 'C:\tools\git-warp\bin'` works for both methods. For any other
+`-InstallDir` shape, pass `-InstallRoot` explicitly on the cargo path.
+
 ## Checksum Verification
 
 `install.sh` downloads the release archive's companion `.sha256` file from the

--- a/install.ps1
+++ b/install.ps1
@@ -10,15 +10,21 @@
     $env:GIT_WARP_VERSION. Default install directory is
     "$env:LOCALAPPDATA\Programs\git-warp\bin"; override with -InstallDir or
     $env:GIT_WARP_INSTALL_DIR.
+
+    For -Method cargo, override the cargo install root with -InstallRoot or
+    $env:GIT_WARP_INSTALL_ROOT (cargo writes to <root>\bin\warp.exe).
 .EXAMPLE
     irm https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.ps1 | iex
 .EXAMPLE
     & ([scriptblock]::Create((irm https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.ps1))) -InstallDir 'C:\tools\git-warp'
+.EXAMPLE
+    & ([scriptblock]::Create((irm https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.ps1))) -Method cargo -InstallRoot 'C:\tools\git-warp'
 #>
 [CmdletBinding()]
 param(
     [string]$Version,
     [string]$InstallDir,
+    [string]$InstallRoot,
     [string]$RepoUrl,
     [string]$DownloadBase,
     [ValidateSet('binary', 'cargo')]
@@ -171,8 +177,11 @@ function Show-ExistingInstalls {
 }
 
 function Resolve-InstalledBinary {
-    param([string]$Method, [string]$InstallDir)
+    param([string]$Method, [string]$InstallDir, [string]$InstallRoot)
     if ($Method -eq 'cargo') {
+        if ($InstallRoot) {
+            return Join-Path $InstallRoot 'bin\warp.exe'
+        }
         $cargoHome = [Environment]::GetEnvironmentVariable('CARGO_HOME')
         if ($cargoHome) {
             $cargoBin = Join-Path $cargoHome 'bin'
@@ -267,7 +276,8 @@ function Install-Binary {
 function Install-Cargo {
     param(
         [string]$Repo,
-        [string]$Tag
+        [string]$Tag,
+        [string]$InstallRoot
     )
 
     $cargo = Get-Command cargo -ErrorAction SilentlyContinue
@@ -275,8 +285,16 @@ function Install-Cargo {
         Fail "cargo is required for the cargo install method" $Repo
     }
 
-    Write-Host "Installing Git-Warp $Tag from $Repo with Cargo"
-    & cargo install --locked --force --git $Repo --tag $Tag --bin warp git-warp
+    $cargoArgs = @('install', '--locked', '--force', '--git', $Repo, '--tag', $Tag, '--bin', 'warp')
+    if ($InstallRoot) {
+        $cargoArgs += @('--root', $InstallRoot)
+        Write-Host "Installing Git-Warp $Tag from $Repo with Cargo into $InstallRoot\bin"
+    } else {
+        Write-Host "Installing Git-Warp $Tag from $Repo with Cargo"
+    }
+    $cargoArgs += 'git-warp'
+
+    & cargo @cargoArgs
     if ($LASTEXITCODE -ne 0) {
         Fail "Cargo install failed for Git-Warp $Tag" $Repo
     }
@@ -293,6 +311,13 @@ if (-not $skipChecksum) {
 
 $defaultDir = Join-Path $env:LOCALAPPDATA 'Programs\git-warp\bin'
 $installDir = Coalesce $InstallDir 'GIT_WARP_INSTALL_DIR' $defaultDir
+$installRoot = Coalesce $InstallRoot 'GIT_WARP_INSTALL_ROOT' $null
+if (-not $installRoot -and $installDir -ne $defaultDir) {
+    $trimmed = $installDir.TrimEnd('\')
+    if ($trimmed.ToLowerInvariant().EndsWith('\bin')) {
+        $installRoot = Split-Path -Parent $trimmed
+    }
+}
 
 if ($Version) {
     $tag = $Version
@@ -312,25 +337,26 @@ Show-ExistingInstalls -Primary $installDir -Repo $repoUrl
 
 switch ($method) {
     'binary' { Install-Binary -Repo $repoUrl -Tag $tag -Dir $installDir -Base $downloadBase -Skip $skipChecksum }
-    'cargo'  { Install-Cargo -Repo $repoUrl -Tag $tag }
+    'cargo'  { Install-Cargo -Repo $repoUrl -Tag $tag -InstallRoot $installRoot }
     default  { Fail "unsupported install method: $method; use 'binary' or 'cargo'" $repoUrl }
 }
 
 Write-Host ""
 
-$installedPath = Resolve-InstalledBinary -Method $method -InstallDir $installDir
+$installedPath = Resolve-InstalledBinary -Method $method -InstallDir $installDir -InstallRoot $installRoot
 if ($installedPath -and (Test-Path -LiteralPath $installedPath)) {
     & $installedPath --version
 } else {
     Write-Host "Git-Warp installed, but 'warp.exe' was not found at $installedPath."
 }
 
-if (-not (Test-OnPath -Dir $installDir)) {
+$pathDir = if ($installedPath) { Split-Path -Parent $installedPath } else { $installDir }
+if (-not (Test-OnPath -Dir $pathDir)) {
     Write-Host ""
-    Write-Host "Add $installDir to PATH so your shell can find 'warp':"
-    Write-Host "  `$env:PATH = '$installDir;' + `$env:PATH"
+    Write-Host "Add $pathDir to PATH so your shell can find 'warp':"
+    Write-Host "  `$env:PATH = '$pathDir;' + `$env:PATH"
     Write-Host "Persist it across sessions with:"
-    Write-Host "  [Environment]::SetEnvironmentVariable('Path', `"$installDir;`" + [Environment]::GetEnvironmentVariable('Path', 'User'), 'User')"
+    Write-Host "  [Environment]::SetEnvironmentVariable('Path', `"$pathDir;`" + [Environment]::GetEnvironmentVariable('Path', 'User'), 'User')"
     Write-Host "Open a new terminal or run 'warp doctor' after updating PATH."
 }
 


### PR DESCRIPTION
## Summary

`install.ps1` only forwarded `-InstallDir` / `$env:GIT_WARP_INSTALL_DIR` to
the `binary` branch. The `cargo` branch ran `cargo install ... --git --tag
--bin warp git-warp` with no `--root`, so the binary landed in
`%USERPROFILE%\.cargo\bin\warp.exe`, while the post-install probe kept
looking at `Join-Path $installDir 'warp.exe'` and reported the install as
not-found.

`install.sh` already exposes `GIT_WARP_INSTALL_ROOT` and forwards it as
`--root` on the cargo path (`install.sh:262-263`); `install.ps1` had no
equivalent.

- Adds `-InstallRoot` parameter and `$env:GIT_WARP_INSTALL_ROOT` lookup to
  `install.ps1`, mirroring `install.sh`.
- When `-InstallDir` ends in `\bin` and `-InstallRoot` is not set, derives
  the cargo root as its parent so a single `-InstallDir
  'C:\tools\git-warp\bin'` works for both methods.
- `Install-Cargo` appends `--root <root>` to the cargo invocation and prints
  the resolved `<root>\bin` path.
- `Resolve-InstalledBinary` returns `<root>\bin\warp.exe` for the cargo
  branch when `-InstallRoot` is set; the PATH-not-on-PATH hint now points at
  the directory that actually holds the binary instead of `$installDir`.
- Documents the new flag and the binary/cargo distinction in
  `docs/install.md`.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` (225 passed)
- `git diff --check`

PowerShell parsing was not run locally (no `pwsh` on the build host); the
existing Windows CI matrix exercises `install.ps1` indirectly via the
release pipeline.

Closes #191