### PR TITLE
docs(cow): describe Linux CoW via FICLONE ioctl, not cp --reflink

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ Fast, safety-focused Git worktree management with terminal handoff, cleanup
 helpers, and optional Claude/Codex session visibility.
 
 Git-Warp is a Rust CLI for creating, switching, listing, and cleaning Git
-worktrees. On macOS/APFS it can use Copy-on-Write cloning for faster worktree
-creation, and it falls back to normal `git worktree` creation when CoW is not
-available.
+worktrees. On macOS/APFS and Linux filesystems that implement the FICLONE
+ioctl (btrfs, xfs with `reflink=1`, bcachefs, OCFS2, etc.) it can use
+Copy-on-Write cloning for faster worktree creation, and it falls back to
+normal `git worktree` creation when CoW is not available.
 
 ## What It Does Today
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -113,7 +113,7 @@ Git-Warp uses Copy-on-Write (CoW) to create worktrees almost instantaneously. Th
 feature is supported on:
 
 - **macOS**: APFS filesystems.
-- **Linux**: Btrfs, XFS, and OCFS2 filesystems (via `cp --reflink=always`).
+- **Linux**: Filesystems that implement the FICLONE ioctl (btrfs, xfs with `reflink=1`, bcachefs, OCFS2, etc.).
 
 Git-Warp automatically detects CoW support. If your filesystem does not support
 it, Git-Warp falls back to traditional Git worktree creation. Run `warp doctor`

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -199,7 +199,7 @@ fn clone_directory_apfs<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dest: Q) -> Resu
 
 #[cfg(target_os = "linux")]
 fn clone_directory_reflink<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dest: Q) -> Result<()> {
-    // ... use cp --reflink=always for Linux
+    // ... use FICLONE ioctl for Linux
 }
 ```
 


### PR DESCRIPTION
## Summary

`src/cow.rs` has cloned reflinks via the FICLONE ioctl on opened file
descriptors since PR #170 closed #167. The shell-out to
`cp --reflink=always` no longer exists, but several user-facing docs
still described it that way and listed an outdated, narrower filesystem
set.

- `docs/install.md`: replace the `cp --reflink=always` parenthetical
  with the FICLONE ioctl, and widen the filesystem list to anything
  that implements FICLONE (btrfs, xfs with `reflink=1`, bcachefs,
  OCFS2, etc.) instead of just Btrfs/XFS/OCFS2.
- `docs/technical-overview.md`: fix the stale `// ... use cp
  --reflink=always for Linux` comment in the illustrative code sample
  so it points at the FICLONE ioctl.
- `README.md`: mention Linux CoW alongside macOS/APFS in the opening
  paragraph so the README matches `docs/user-guide.md` and
  `docs/technical-overview.md`, which already cover Linux.

## Verification

- `git diff --check`

Docs-only change; no Rust sources touched, so no `cargo` runs were
needed.

Closes #202