### PR TITLE
fix(uninstall): detect .git file inside linked git worktrees

### DIFF
--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -1574,6 +1574,43 @@ fn test_uninstaller_dry_run_keeps_default_install() {
 
 #[cfg(unix)]
 #[test]
+fn test_uninstaller_dry_run_lists_project_hooks_inside_linked_worktree() {
+    let primary = setup_test_repo();
+    let worktree_path = create_worktree(primary.path(), "feature-203");
+
+    assert!(
+        worktree_path.join(".git").is_file(),
+        ".git in a linked worktree should be a file, not a directory"
+    );
+
+    let home_dir = tempdir().unwrap();
+    let install_dir = tempdir().unwrap();
+    let target = install_dir.path().join("warp");
+    write_fake_warp_binary(&target, "warp 9.9.9");
+
+    let output = Command::new("/bin/sh")
+        .arg(uninstall_script_path())
+        .arg("--dry-run")
+        .current_dir(&worktree_path)
+        .env("HOME", home_dir.path())
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("GIT_WARP_INSTALL_DIR", install_dir.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "{stdout}{stderr}");
+    assert!(stdout.contains("Would remove user hooks with:"), "{stdout}");
+    assert!(
+        stdout.contains("Would remove project hooks with:"),
+        "{stdout}"
+    );
+    assert!(target.exists());
+}
+
+#[cfg(unix)]
+#[test]
 fn test_uninstaller_reports_when_no_default_install_exists() {
     let home_dir = tempdir().unwrap();
     let install_dir = tempdir().unwrap();

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -71,13 +71,13 @@ remove_hooks() {
 
   if [ "$dry_run" -eq 1 ]; then
     echo "Would remove user hooks with: $target hooks-remove --level user --runtime all"
-    if [ -d .git ]; then
+    if [ -e .git ]; then
       echo "Would remove project hooks with: $target hooks-remove --level project --runtime all"
     fi
   else
     echo "Removing agent hooks..."
     "$target" hooks-remove --level user --runtime all >/dev/null 2>&1 || echo "warning: failed to remove user hooks"
-    if [ -d .git ]; then
+    if [ -e .git ]; then
       "$target" hooks-remove --level project --runtime all >/dev/null 2>&1 || echo "warning: failed to remove project hooks"
     fi
   fi


### PR DESCRIPTION
## Summary

`uninstall.sh` gated the project-level `hooks-remove` call on `[ -d .git ]`. In a linked git worktree `.git` is a regular file containing a `gitdir:` pointer, not a directory, so the test failed and `<worktree>/.claude/settings.json` (or `.codex/hooks.json`) silently kept its git-warp hook stanza. Running the uninstaller from a secondary worktree therefore left the per-project hook entries intact.

- Switch both gates in `remove_hooks` from `[ -d .git ]` to `[ -e .git ]`, covering both a `.git` directory (primary checkout) and a `.git` file (linked worktree). Mirrors the existing `uninstall.ps1` `Test-Path -LiteralPath '.git'` behavior.
- Adds `test_uninstaller_dry_run_lists_project_hooks_inside_linked_worktree` in `tests/integration/cli_surface_tests.rs`: creates a real linked worktree via `git worktree add`, asserts `.git` is a file there, and runs `uninstall.sh --dry-run` from inside it — the dry-run now prints both the user-hooks and project-hooks lines.

## Verification

Ran in the `203-uninstall-worktree` worktree:

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --all-targets --locked -- -D warnings` — clean.
- `cargo test --locked` — 226 passed, 0 failed.
- `git diff --check` — clean.

Closes #203