### PR TITLE
fix(release): guard install.ps1 / uninstall.ps1 contents in release-check

### DIFF
--- a/src/release.rs
+++ b/src/release.rs
@@ -106,6 +106,8 @@ pub fn collect_metadata_checks(
     let changelog = read_optional(repo_root.join("CHANGELOG.md"))?;
     let install_doc = read_optional(repo_root.join("docs").join("install.md"))?;
     let install_script = read_optional(repo_root.join("install.sh"))?;
+    let install_ps1 = read_optional(repo_root.join("install.ps1"))?;
+    let uninstall_ps1 = read_optional(repo_root.join("uninstall.ps1"))?;
     let release_notes_path = repo_root
         .join("docs")
         .join("releases")
@@ -193,22 +195,56 @@ pub fn collect_metadata_checks(
         ));
     }
 
-    for label in ["install.ps1", "uninstall.ps1"] {
-        let path = repo_root.join(label);
-        if path.is_file() {
-            checks.push(ReleaseCheck::pass(
-                label,
-                format!("{label} is present at the repo root"),
-            ));
-        } else {
-            checks.push(ReleaseCheck::fail(
-                label,
-                format!("{label} is missing from the repo root"),
-            ));
-        }
-    }
+    let install_ps1_requirements: &[(&str, &str)] = &[
+        ("api.github.com/repos/", "the GitHub releases API lookup"),
+        (
+            "$env:GIT_WARP_VERSION",
+            "the $env:GIT_WARP_VERSION override",
+        ),
+        ("Get-FileHash", "the Get-FileHash checksum step"),
+        ("-Algorithm SHA256", "the SHA256 algorithm flag"),
+    ];
+    checks.push(content_guard(
+        "install.ps1",
+        &install_ps1,
+        install_ps1_requirements,
+        "install.ps1 must keep the GitHub releases lookup, $env:GIT_WARP_VERSION override, and Get-FileHash -Algorithm SHA256 verification",
+    ));
+
+    let uninstall_ps1_requirements: &[(&str, &str)] = &[(
+        "hooks-remove --level user",
+        "the user-level hooks-remove call",
+    )];
+    checks.push(content_guard(
+        "uninstall.ps1",
+        &uninstall_ps1,
+        uninstall_ps1_requirements,
+        "uninstall.ps1 must keep the warp hooks-remove --level user invocation",
+    ));
 
     Ok(checks)
+}
+
+fn content_guard(
+    label: &'static str,
+    content: &str,
+    requirements: &[(&str, &str)],
+    fail_summary: &str,
+) -> ReleaseCheck {
+    let missing: Vec<&str> = requirements
+        .iter()
+        .filter(|(needle, _)| !content.contains(needle))
+        .map(|(_, description)| *description)
+        .collect();
+
+    if missing.is_empty() {
+        ReleaseCheck::pass(label, format!("{label} keeps its release-critical logic"))
+    } else {
+        ReleaseCheck::fail(
+            label,
+            format!("{fail_summary}; missing: {}", missing.join(", ")),
+        )
+    }
 }
 
 fn read_optional(path: PathBuf) -> Result<String> {

--- a/tests/unit/release_tests.rs
+++ b/tests/unit/release_tests.rs
@@ -90,9 +90,20 @@ fn test_collect_metadata_checks_all_pass() {
     )
     .unwrap();
 
-    // 5. install.ps1 + uninstall.ps1 presence
-    fs::write(temp.path().join("install.ps1"), "param()").unwrap();
-    fs::write(temp.path().join("uninstall.ps1"), "param()").unwrap();
+    // 5. install.ps1 + uninstall.ps1 with release-critical content
+    fs::write(
+        temp.path().join("install.ps1"),
+        "$api = \"https://api.github.com/repos/denysbutenko/git-warp/releases/latest\"\n\
+         $envVersion = [Environment]::GetEnvironmentVariable('GIT_WARP_VERSION')\n\
+         if ($envVersion) { $tag = $env:GIT_WARP_VERSION }\n\
+         $hash = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash\n",
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("uninstall.ps1"),
+        "& $Target hooks-remove --level user --runtime all *> $null\n",
+    )
+    .unwrap();
 
     let checks = collect_metadata_checks(temp.path(), &expected, version).unwrap();
 
@@ -141,9 +152,18 @@ fn test_collect_metadata_checks_failures() {
             .contains("api.github.com/repos/.../releases/latest")
     );
     assert_eq!(checks[5].label, "install.ps1");
-    assert!(checks[5].detail.contains("install.ps1 is missing"));
+    assert!(
+        checks[5]
+            .detail
+            .contains("Get-FileHash -Algorithm SHA256 verification")
+    );
+    assert!(checks[5].detail.contains("missing: "));
     assert_eq!(checks[6].label, "uninstall.ps1");
-    assert!(checks[6].detail.contains("uninstall.ps1 is missing"));
+    assert!(
+        checks[6]
+            .detail
+            .contains("warp hooks-remove --level user invocation")
+    );
 }
 
 #[test]
@@ -170,24 +190,81 @@ fn test_install_script_partial_lookup_fails() {
 }
 
 #[test]
-fn test_powershell_scripts_partial_presence_fails() {
+fn test_install_ps1_missing_checksum_fails() {
     let temp = tempdir().unwrap();
     let expected = ReleaseVersion {
         number: "0.3.0".to_string(),
         tag: "v0.3.0".to_string(),
     };
 
-    // install.ps1 present, uninstall.ps1 missing — release must fail.
-    fs::write(temp.path().join("install.ps1"), "param()").unwrap();
+    // install.ps1 keeps env override + API lookup but lost the checksum step.
+    fs::write(
+        temp.path().join("install.ps1"),
+        "$api = \"https://api.github.com/repos/denysbutenko/git-warp/releases/latest\"\n\
+         $tag = $env:GIT_WARP_VERSION\n",
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("uninstall.ps1"),
+        "& $Target hooks-remove --level user --runtime all *> $null\n",
+    )
+    .unwrap();
 
     let checks = collect_metadata_checks(temp.path(), &expected, "0.3.0").unwrap();
 
-    assert_eq!(checks.len(), 7);
     assert_eq!(checks[5].label, "install.ps1");
-    assert!(checks[5].ok, "install.ps1 presence check should pass");
+    assert!(
+        !checks[5].ok,
+        "install.ps1 without checksum guard should fail the check"
+    );
+    assert!(
+        checks[5].detail.contains("Get-FileHash checksum step"),
+        "fail detail should call out the missing checksum, got: {}",
+        checks[5].detail
+    );
+    assert!(
+        checks[5].detail.contains("SHA256 algorithm flag"),
+        "fail detail should call out the missing SHA256 flag, got: {}",
+        checks[5].detail
+    );
+    assert!(checks[6].ok, "uninstall.ps1 guard should still pass");
+}
+
+#[test]
+fn test_uninstall_ps1_missing_hooks_remove_fails() {
+    let temp = tempdir().unwrap();
+    let expected = ReleaseVersion {
+        number: "0.3.0".to_string(),
+        tag: "v0.3.0".to_string(),
+    };
+
+    fs::write(
+        temp.path().join("install.ps1"),
+        "$api = \"https://api.github.com/repos/denysbutenko/git-warp/releases/latest\"\n\
+         $tag = $env:GIT_WARP_VERSION\n\
+         $hash = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash\n",
+    )
+    .unwrap();
+    // uninstall.ps1 forgot the hooks-remove call.
+    fs::write(
+        temp.path().join("uninstall.ps1"),
+        "Remove-Item -LiteralPath $target -Force\n",
+    )
+    .unwrap();
+
+    let checks = collect_metadata_checks(temp.path(), &expected, "0.3.0").unwrap();
+
+    assert!(checks[5].ok, "install.ps1 guard should pass");
     assert_eq!(checks[6].label, "uninstall.ps1");
-    assert!(!checks[6].ok, "uninstall.ps1 absence should fail the check");
-    assert!(checks[6].detail.contains("uninstall.ps1 is missing"));
+    assert!(
+        !checks[6].ok,
+        "uninstall.ps1 without hooks-remove should fail"
+    );
+    assert!(
+        checks[6].detail.contains("user-level hooks-remove call"),
+        "fail detail should call out the missing hooks-remove, got: {}",
+        checks[6].detail
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`collect_metadata_checks` only checked that `install.ps1` and `uninstall.ps1` existed at the repo root, while `install.sh` already had to keep `${GIT_WARP_VERSION:-...}` plus the `api.github.com/repos/.../releases/latest` lookup to pass. A refactor that quietly dropped `Resolve-LatestTag`, `$env:GIT_WARP_VERSION`, or the SHA256 step from `install.ps1` — or `hooks-remove --level user` from `uninstall.ps1` — still passed `warp release-check`.

- `install.ps1` now must contain `api.github.com/repos/`, `$env:GIT_WARP_VERSION`, `Get-FileHash`, and `-Algorithm SHA256`.
- `uninstall.ps1` now must contain `hooks-remove --level user`.
- The failure detail enumerates the missing pieces by name, so the release-check output points straight at the regression.

Refreshed `tests/unit/release_tests.rs` to cover the new pass/fail paths in the same shape as the install.sh tests (full pass, all-missing failure, install.ps1 partial failure, uninstall.ps1 partial failure).

## Verification

Ran in the `204-release-check-ps1` worktree:

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --all-targets --locked -- -D warnings` — clean.
- `cargo test --locked` — 226 passed.
- `git diff --check` — clean.

Closes #204