### PR TITLE
fix(release): guard install.sh / uninstall.sh contents in release-check

### DIFF
--- a/src/release.rs
+++ b/src/release.rs
@@ -113,6 +113,7 @@ pub fn collect_metadata_checks(
     let install_doc = read_optional(repo_root.join("docs").join("install.md"))?;
     let install_script = read_optional(repo_root.join("install.sh"))?;
     let install_ps1 = read_optional(repo_root.join("install.ps1"))?;
+    let uninstall_script = read_optional(repo_root.join("uninstall.sh"))?;
     let uninstall_ps1 = read_optional(repo_root.join("uninstall.ps1"))?;
     let release_notes_path = repo_root
         .join("docs")
@@ -186,18 +187,19 @@ pub fn collect_metadata_checks(
         ));
     }
 
-    let has_env_override = install_script.contains("${GIT_WARP_VERSION:-");
-    let has_api_lookup = install_script.contains("api.github.com/repos/");
-
-    if has_env_override && has_api_lookup {
+    let install_sh_missing = install_sh_missing_parts(&install_script);
+    if install_sh_missing.is_empty() {
         checks.push(ReleaseCheck::pass(
             "install.sh",
-            "resolves GIT_WARP_VERSION dynamically from the GitHub releases API",
+            "resolves GIT_WARP_VERSION dynamically, verifies the archive checksum, and honors the skip env",
         ));
     } else {
         checks.push(ReleaseCheck::fail(
             "install.sh",
-            "install.sh must keep the ${GIT_WARP_VERSION:-...} override and call api.github.com/repos/.../releases/latest",
+            format!(
+                "install.sh must keep the ${{GIT_WARP_VERSION:-...}} override, call api.github.com/repos/.../releases/latest, run shasum -a 256 -c or sha256sum -c, and honor GIT_WARP_SKIP_CHECKSUM; missing: {}",
+                install_sh_missing.join(", ")
+            ),
         ));
     }
 
@@ -228,7 +230,35 @@ pub fn collect_metadata_checks(
         "uninstall.ps1 must keep the warp hooks-remove --level user invocation",
     ));
 
+    let uninstall_sh_requirements: &[(&str, &str)] = &[(
+        "hooks-remove --level user",
+        "the user-level hooks-remove call",
+    )];
+    checks.push(content_guard(
+        "uninstall.sh",
+        &uninstall_script,
+        uninstall_sh_requirements,
+        "uninstall.sh must keep the warp hooks-remove --level user invocation",
+    ));
+
     Ok(checks)
+}
+
+fn install_sh_missing_parts(script: &str) -> Vec<&'static str> {
+    let mut missing = Vec::new();
+    if !script.contains("${GIT_WARP_VERSION:-") {
+        missing.push("the ${GIT_WARP_VERSION:-...} override");
+    }
+    if !script.contains("api.github.com/repos/") {
+        missing.push("the GitHub releases API lookup");
+    }
+    if !script.contains("shasum -a 256 -c") && !script.contains("sha256sum -c") {
+        missing.push("the shasum -a 256 -c or sha256sum -c checksum verification");
+    }
+    if !script.contains("GIT_WARP_SKIP_CHECKSUM") {
+        missing.push("the GIT_WARP_SKIP_CHECKSUM opt-out guard");
+    }
+    missing
 }
 
 fn content_guard(

--- a/tests/unit/release_tests.rs
+++ b/tests/unit/release_tests.rs
@@ -93,15 +93,16 @@ fn test_collect_metadata_checks_all_pass() {
     )
     .unwrap();
 
-    // 4. install.sh with env override + GitHub API lookup
+    // 4. install.sh with env override + GitHub API lookup + checksum guards
     fs::write(
         temp.path().join("install.sh"),
         "version=\"${GIT_WARP_VERSION:-}\"\n\
-         api_url=\"https://api.github.com/repos/denysbutenko/git-warp/releases/latest\"\n",
+         api_url=\"https://api.github.com/repos/denysbutenko/git-warp/releases/latest\"\n\
+         if [ \"${GIT_WARP_SKIP_CHECKSUM:-0}\" != \"1\" ]; then sha256sum -c \"$sums\"; fi\n",
     )
     .unwrap();
 
-    // 5. install.ps1 + uninstall.ps1 with release-critical content
+    // 5. install.ps1 + uninstall.ps1 + uninstall.sh with release-critical content
     fs::write(
         temp.path().join("install.ps1"),
         "$api = \"https://api.github.com/repos/denysbutenko/git-warp/releases/latest\"\n\
@@ -115,10 +116,15 @@ fn test_collect_metadata_checks_all_pass() {
         "& $Target hooks-remove --level user --runtime all *> $null\n",
     )
     .unwrap();
+    fs::write(
+        temp.path().join("uninstall.sh"),
+        "\"$target\" hooks-remove --level user --runtime all >/dev/null 2>&1\n",
+    )
+    .unwrap();
 
     let checks = collect_metadata_checks(temp.path(), &expected, version).unwrap();
 
-    assert_eq!(checks.len(), 7);
+    assert_eq!(checks.len(), 8);
     for check in &checks {
         assert!(check.ok, "check failed: {} - {}", check.label, check.detail);
     }
@@ -135,7 +141,7 @@ fn test_collect_metadata_checks_failures() {
     // All files missing or mismatched
     let checks = collect_metadata_checks(temp.path(), &expected, "0.2.0").unwrap();
 
-    assert_eq!(checks.len(), 7);
+    assert_eq!(checks.len(), 8);
     for check in &checks {
         assert!(!check.ok, "check should have failed: {}", check.label);
     }
@@ -157,10 +163,21 @@ fn test_collect_metadata_checks_failures() {
             .detail
             .contains("docs/install.md does not mention GIT_WARP_VERSION=v0.3.0")
     );
+    assert_eq!(checks[4].label, "install.sh");
     assert!(
         checks[4]
             .detail
             .contains("api.github.com/repos/.../releases/latest")
+    );
+    assert!(
+        checks[4]
+            .detail
+            .contains("shasum -a 256 -c or sha256sum -c checksum verification")
+    );
+    assert!(
+        checks[4]
+            .detail
+            .contains("GIT_WARP_SKIP_CHECKSUM opt-out guard")
     );
     assert_eq!(checks[5].label, "install.ps1");
     assert!(
@@ -172,6 +189,12 @@ fn test_collect_metadata_checks_failures() {
     assert_eq!(checks[6].label, "uninstall.ps1");
     assert!(
         checks[6]
+            .detail
+            .contains("warp hooks-remove --level user invocation")
+    );
+    assert_eq!(checks[7].label, "uninstall.sh");
+    assert!(
+        checks[7]
             .detail
             .contains("warp hooks-remove --level user invocation")
     );
@@ -330,7 +353,7 @@ fn test_collect_metadata_checks_partial_success() {
     // All other files are missing.
     let checks = collect_metadata_checks(temp.path(), &expected, version).unwrap();
 
-    assert_eq!(checks.len(), 7);
+    assert_eq!(checks.len(), 8);
     assert!(checks[0].ok, "Cargo.toml check should pass");
     assert!(!checks[1].ok, "CHANGELOG.md check should fail");
     assert!(!checks[2].ok, "release notes check should fail");
@@ -338,4 +361,119 @@ fn test_collect_metadata_checks_partial_success() {
     assert!(!checks[4].ok, "install.sh check should fail");
     assert!(!checks[5].ok, "install.ps1 check should fail");
     assert!(!checks[6].ok, "uninstall.ps1 check should fail");
+    assert!(!checks[7].ok, "uninstall.sh check should fail");
+}
+
+#[test]
+fn test_install_script_missing_checksum_verifier_fails() {
+    let temp = tempdir().unwrap();
+    let expected = ReleaseVersion {
+        number: "0.3.0".to_string(),
+        tag: "v0.3.0".to_string(),
+    };
+
+    // install.sh keeps env override + API lookup + skip env, but lost the shasum/sha256sum call.
+    fs::write(
+        temp.path().join("install.sh"),
+        "version=\"${GIT_WARP_VERSION:-}\"\n\
+         api_url=\"https://api.github.com/repos/denysbutenko/git-warp/releases/latest\"\n\
+         if [ \"${GIT_WARP_SKIP_CHECKSUM:-0}\" != \"1\" ]; then :; fi\n",
+    )
+    .unwrap();
+
+    let checks = collect_metadata_checks(temp.path(), &expected, "0.3.0").unwrap();
+
+    assert_eq!(checks[4].label, "install.sh");
+    assert!(
+        !checks[4].ok,
+        "install.sh without shasum/sha256sum should fail"
+    );
+    assert!(
+        checks[4]
+            .detail
+            .contains("shasum -a 256 -c or sha256sum -c checksum verification"),
+        "fail detail should call out the missing checksum verifier, got: {}",
+        checks[4].detail
+    );
+}
+
+#[test]
+fn test_install_script_missing_skip_env_fails() {
+    let temp = tempdir().unwrap();
+    let expected = ReleaseVersion {
+        number: "0.3.0".to_string(),
+        tag: "v0.3.0".to_string(),
+    };
+
+    // install.sh keeps env override + API lookup + sha256sum -c, but lost the skip env guard.
+    fs::write(
+        temp.path().join("install.sh"),
+        "version=\"${GIT_WARP_VERSION:-}\"\n\
+         api_url=\"https://api.github.com/repos/denysbutenko/git-warp/releases/latest\"\n\
+         sha256sum -c \"$sums\"\n",
+    )
+    .unwrap();
+
+    let checks = collect_metadata_checks(temp.path(), &expected, "0.3.0").unwrap();
+
+    assert_eq!(checks[4].label, "install.sh");
+    assert!(
+        !checks[4].ok,
+        "install.sh without GIT_WARP_SKIP_CHECKSUM should fail"
+    );
+    assert!(
+        checks[4]
+            .detail
+            .contains("GIT_WARP_SKIP_CHECKSUM opt-out guard"),
+        "fail detail should call out the missing skip env, got: {}",
+        checks[4].detail
+    );
+}
+
+#[test]
+fn test_uninstall_script_missing_hooks_remove_fails() {
+    let temp = tempdir().unwrap();
+    let expected = ReleaseVersion {
+        number: "0.3.0".to_string(),
+        tag: "v0.3.0".to_string(),
+    };
+
+    // install.sh + install.ps1 + uninstall.ps1 satisfy their guards.
+    fs::write(
+        temp.path().join("install.sh"),
+        "version=\"${GIT_WARP_VERSION:-}\"\n\
+         api_url=\"https://api.github.com/repos/denysbutenko/git-warp/releases/latest\"\n\
+         if [ \"${GIT_WARP_SKIP_CHECKSUM:-0}\" != \"1\" ]; then sha256sum -c \"$sums\"; fi\n",
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("install.ps1"),
+        "$api = \"https://api.github.com/repos/denysbutenko/git-warp/releases/latest\"\n\
+         $tag = $env:GIT_WARP_VERSION\n\
+         $hash = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash\n",
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("uninstall.ps1"),
+        "& $Target hooks-remove --level user --runtime all *> $null\n",
+    )
+    .unwrap();
+    // uninstall.sh forgot the hooks-remove call.
+    fs::write(temp.path().join("uninstall.sh"), "rm -f \"$target\"\n").unwrap();
+
+    let checks = collect_metadata_checks(temp.path(), &expected, "0.3.0").unwrap();
+
+    assert!(checks[4].ok, "install.sh guard should pass");
+    assert!(checks[5].ok, "install.ps1 guard should pass");
+    assert!(checks[6].ok, "uninstall.ps1 guard should pass");
+    assert_eq!(checks[7].label, "uninstall.sh");
+    assert!(
+        !checks[7].ok,
+        "uninstall.sh without hooks-remove should fail"
+    );
+    assert!(
+        checks[7].detail.contains("user-level hooks-remove call"),
+        "fail detail should call out the missing hooks-remove, got: {}",
+        checks[7].detail
+    );
 }


### PR DESCRIPTION
## Summary
- `release-check` now fails when `install.sh` drops either the `shasum -a 256 -c` / `sha256sum -c` step or the `GIT_WARP_SKIP_CHECKSUM` opt-out.
- Adds an `uninstall.sh` guard for the user-level `hooks-remove` call.
- Same idea as the `.ps1` guards in #208, applied on the `.sh` side.

## Verification
- `cargo test --test mod release` (17 tests pass)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- `cargo run --quiet -- release-check --metadata-only` on the real repo files, all 8 metadata checks pass.

Closes #213