### PR TITLE
chore(deps): bump anyhow to 1.0.103 (RUSTSEC-2026-0190)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"


### PR DESCRIPTION
## Summary
- Bumps `anyhow` 1.0.102 → 1.0.103 in `Cargo.lock` to clear RUSTSEC-2026-0190 (unsound `Error::downcast_mut` when combined with `Error::context`).
- `Cargo.toml` requirement stays at `anyhow = "1.0.86"`; the caret picks up 1.0.103 automatically.
- No source changes; lockfile only.

## Verification
- `cargo audit` — no advisories
- `cargo build --all-targets` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --all` — 228 passed, 0 failed
- `git diff --check` — clean

Closes #210