### PR TITLE
ci(audit): fail PRs on new RUSTSEC advisories (#211)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -33,6 +33,6 @@ jobs:
       - uses: actions/checkout@v7
       - name: cargo audit
         uses: rustsec/audit-check@v2
-        continue-on-error: true
+        continue-on-error: ${{ github.event_name != 'pull_request' }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Flip the `rustsec/audit-check` step from `continue-on-error: true` to `continue-on-error: ${{ github.event_name != 'pull_request' }}`, so PRs that change `Cargo.toml` / `Cargo.lock` / `audit.yml` and pull in a new RUSTSEC advisory fail the check.
- Scheduled cron, `workflow_dispatch`, and `push` runs keep the existing non-blocking behavior — they still surface advisories without turning `main` red or firing red nightly notifications.

## Verification
- `git diff --stat` — one file, +1 −1.
- `git diff --check` — no whitespace errors.
- `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/audit.yml"))'` — parses.

Refs #211.
