### PR TITLE
fix(process): honor kill_timeout on Windows via handle-based wait (#212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+
+- `warp cleanup --kill` on Windows now honors `[process].kill_timeout`. The
+  Windows branch of `ProcessManager::terminate_single_process` fires a single
+  `taskkill /T` for the graceful attempt, waits on the process handle via
+  `WaitForSingleObject(kill_timeout)`, then falls back to `TerminateProcess`
+  through the same handle instead of a second `taskkill /F` spawn. (#212)
+
 ## v0.4.0 - 2026-07-02
 
 Third public Git-Warp release. Highlights: Windows support (prebuilt binary,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,6 +834,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml 0.9.6",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,12 @@ dirs = "6.0.0"
 chrono = "0.4.38"
 tempfile = "3.10.1"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.60", features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+] }
+
 [dev-dependencies]
 criterion = "0.8"
 rand = "0.10"

--- a/src/process.rs
+++ b/src/process.rs
@@ -5,6 +5,9 @@ use std::time::Duration;
 use std::time::Instant;
 use sysinfo::{ProcessesToUpdate, System};
 
+#[cfg(windows)]
+const WINDOWS_FORCE_WAIT_MS: u32 = 5_000;
+
 #[derive(Debug, Clone)]
 pub struct ProcessInfo {
     pub pid: u32,
@@ -233,16 +236,69 @@ impl ProcessManager {
 
         #[cfg(windows)]
         {
-            let _ = kill_timeout; // taskkill is immediate; timeout unused on Windows.
             use std::process::Command;
+            use windows_sys::Win32::Foundation::{
+                CloseHandle, ERROR_INVALID_PARAMETER, GetLastError, WAIT_OBJECT_0, WAIT_TIMEOUT,
+            };
+            use windows_sys::Win32::System::Threading::{
+                OpenProcess, PROCESS_TERMINATE, SYNCHRONIZE, TerminateProcess, WaitForSingleObject,
+            };
 
-            let result = Command::new("taskkill")
+            // SYNCHRONIZE lets us wait on the process handle for graceful exit;
+            // PROCESS_TERMINATE is the fallback if the grace window elapses.
+            let handle = unsafe { OpenProcess(SYNCHRONIZE | PROCESS_TERMINATE, 0, pid) };
+            if handle.is_null() {
+                let err = unsafe { GetLastError() };
+                if err == ERROR_INVALID_PARAMETER {
+                    // Windows returns ERROR_INVALID_PARAMETER when the PID no
+                    // longer exists — mirror the Unix ESRCH branch and report
+                    // success.
+                    return true;
+                }
+                log::warn!("OpenProcess({pid}) failed: {err}");
+                return false;
+            }
+
+            // Fire the graceful attempt via taskkill without /F. This sends
+            // WM_CLOSE to top-level windows and CTRL+BREAK to console apps in
+            // the target's tree, without disturbing our own console state the
+            // way GenerateConsoleCtrlEvent from this process would. Failure
+            // just means we fall through to the timeout + TerminateProcess
+            // path.
+            let _ = Command::new("taskkill")
                 .arg("/PID")
                 .arg(pid.to_string())
-                .arg("/F")
+                .arg("/T")
                 .output();
 
-            result.map(|o| o.status.success()).unwrap_or(false)
+            let grace_ms = u32::try_from(kill_timeout.as_millis()).unwrap_or(u32::MAX);
+            let wait = unsafe { WaitForSingleObject(handle, grace_ms) };
+
+            let result = if wait == WAIT_OBJECT_0 {
+                true
+            } else if wait == WAIT_TIMEOUT {
+                let terminated = unsafe { TerminateProcess(handle, 1) };
+                if terminated == 0 {
+                    let err = unsafe { GetLastError() };
+                    log::warn!("TerminateProcess({pid}) failed: {err}");
+                    false
+                } else {
+                    // Wait briefly for the kernel to finish tearing the
+                    // process down so a caller-side sysinfo refresh sees it
+                    // gone.
+                    let _ = unsafe { WaitForSingleObject(handle, WINDOWS_FORCE_WAIT_MS) };
+                    true
+                }
+            } else {
+                let err = unsafe { GetLastError() };
+                log::warn!("WaitForSingleObject({pid}) returned {wait:#x}: {err}");
+                false
+            };
+
+            unsafe {
+                CloseHandle(handle);
+            }
+            result
         }
 
         #[cfg(not(any(unix, windows)))]
@@ -399,6 +455,58 @@ mod tests {
         let ok = manager.terminate_single_process(pid, Duration::from_millis(200));
 
         assert!(ok, "ESRCH should be treated as success");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn terminate_single_process_handles_missing_pid() {
+        use std::process::Command as StdCommand;
+
+        // Spawn cmd /C exit 0, wait for it to exit, then let Rust reap it.
+        // OpenProcess on the recycled PID must fail with ERROR_INVALID_PARAMETER,
+        // which the Windows branch treats as success (mirrors the Unix ESRCH
+        // path).
+        let mut child = StdCommand::new("cmd")
+            .args(["/C", "exit"])
+            .spawn()
+            .expect("spawn cmd exit");
+        let pid = child.id();
+        let _ = child.wait();
+
+        let manager = ProcessManager::new();
+        let ok = manager.terminate_single_process(pid, Duration::from_millis(200));
+
+        assert!(ok, "vanished PID should be treated as success on Windows");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn terminate_single_process_respects_kill_timeout() {
+        use std::process::Command as StdCommand;
+        use std::time::Instant;
+
+        // powershell sleep for 30s; taskkill without /F won't touch it, so the
+        // TerminateProcess fallback path must fire after the kill_timeout
+        // elapses. Total wall time stays well below the 30s sleep.
+        let mut child = StdCommand::new("powershell")
+            .args(["-NoProfile", "-Command", "Start-Sleep -Seconds 30"])
+            .spawn()
+            .expect("spawn powershell sleep");
+        let pid = child.id();
+
+        let manager = ProcessManager::new();
+        let start = Instant::now();
+        let ok = manager.terminate_single_process(pid, Duration::from_millis(200));
+        let elapsed = start.elapsed();
+
+        assert!(ok, "terminate_single_process should report success");
+        assert!(
+            elapsed < Duration::from_secs(15),
+            "expected fast TerminateProcess fallback, took {:?}",
+            elapsed
+        );
+
+        let _ = child.wait();
     }
 
     #[cfg(unix)]

--- a/src/process.rs
+++ b/src/process.rs
@@ -241,11 +241,15 @@ impl ProcessManager {
                 CloseHandle, ERROR_INVALID_PARAMETER, GetLastError, WAIT_OBJECT_0, WAIT_TIMEOUT,
             };
             use windows_sys::Win32::System::Threading::{
-                OpenProcess, PROCESS_TERMINATE, SYNCHRONIZE, TerminateProcess, WaitForSingleObject,
+                OpenProcess, PROCESS_TERMINATE, TerminateProcess, WaitForSingleObject,
             };
 
-            // SYNCHRONIZE lets us wait on the process handle for graceful exit;
+            // SYNCHRONIZE (0x0010_0000) is the standard access right that lets
+            // us wait on the process handle for graceful exit. windows-sys only
+            // re-exports the constant behind Win32_Storage_FileSystem, so define
+            // it locally to avoid pulling in that feature just for one value.
             // PROCESS_TERMINATE is the fallback if the grace window elapses.
+            const SYNCHRONIZE: u32 = 0x0010_0000;
             let handle = unsafe { OpenProcess(SYNCHRONIZE | PROCESS_TERMINATE, 0, pid) };
             if handle.is_null() {
                 let err = unsafe { GetLastError() };


### PR DESCRIPTION
## Summary
- `warp cleanup --kill` on Windows now honors `[process].kill_timeout` (#212). The Windows branch of `ProcessManager::terminate_single_process` was a plain `taskkill /F` shell-out that ignored the configured grace window.
- New sequence: `OpenProcess(SYNCHRONIZE | PROCESS_TERMINATE)`, one graceful `taskkill /PID <n> /T` (no `/F`), `WaitForSingleObject(handle, kill_timeout_ms)`, then `TerminateProcess` through the same handle on timeout. Handle closed via `CloseHandle` on every exit.
- Vanished-PID guard mirrors the Unix ESRCH path: `OpenProcess` failing with `ERROR_INVALID_PARAMETER` returns success.
- Adds `windows-sys` as a `cfg(windows)` dep with `Win32_Foundation` and `Win32_System_Threading`.
- Two new `#[cfg(windows)]` unit tests match the Unix ones: a vanished PID, and a 30s `Start-Sleep` child that ignores graceful signals to exercise the timeout fallback.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --lib process::` (Unix only; Windows compile and tests run in CI on `ubuntu-latest`, `macos-14`, `windows-latest`)
- `git diff --check`

Closes #212.