### PR TITLE
fix(uninstall): honor -InstallRoot / GIT_WARP_INSTALL_ROOT (#218)

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -207,7 +207,7 @@ irm https://raw.githubusercontent.com/denysbutenko/git-warp/main/uninstall.ps1 |
 
 The PowerShell uninstaller mirrors the Bash one:
 - Removes agent hook entries from Claude/Codex settings using `warp.exe` before its deletion (opt out with `$env:GIT_WARP_KEEP_HOOKS = '1'`).
-- Removes `%LOCALAPPDATA%\Programs\git-warp\bin\warp.exe` (or `$env:GIT_WARP_INSTALL_DIR\warp.exe`). Drops the install directory if it ends up empty.
+- Removes `%LOCALAPPDATA%\Programs\git-warp\bin\warp.exe` (or `$env:GIT_WARP_INSTALL_DIR\warp.exe`). For a Cargo install with a custom root, pass `-InstallRoot` (or set `$env:GIT_WARP_INSTALL_ROOT`) to target `<root>\bin\warp.exe`. Drops the install directory if it ends up empty.
 - Scans the four `$PROFILE.*` PowerShell-profile paths for leftover `warp_cd` / `warp __complete` snippets and prints cleanup hints.
 - Lists any other detected `warp.exe` installs (Cargo, custom directories) without touching them.
 

--- a/src/release.rs
+++ b/src/release.rs
@@ -217,15 +217,21 @@ pub fn collect_metadata_checks(
         "install.ps1 must keep the GitHub releases lookup, $env:GIT_WARP_VERSION override, and Get-FileHash -Algorithm SHA256 verification",
     ));
 
-    let uninstall_ps1_requirements: &[(&str, &str)] = &[(
-        "hooks-remove --level user",
-        "the user-level hooks-remove call",
-    )];
+    let uninstall_ps1_requirements: &[(&str, &str)] = &[
+        (
+            "hooks-remove --level user",
+            "the user-level hooks-remove call",
+        ),
+        (
+            "GIT_WARP_INSTALL_ROOT",
+            "the GIT_WARP_INSTALL_ROOT / -InstallRoot handling",
+        ),
+    ];
     checks.push(content_guard(
         "uninstall.ps1",
         &uninstall_ps1,
         uninstall_ps1_requirements,
-        "uninstall.ps1 must keep the warp hooks-remove --level user invocation",
+        "uninstall.ps1 must keep the warp hooks-remove --level user invocation and honor -InstallRoot / GIT_WARP_INSTALL_ROOT",
     ));
 
     Ok(checks)

--- a/tests/unit/release_tests.rs
+++ b/tests/unit/release_tests.rs
@@ -112,7 +112,8 @@ fn test_collect_metadata_checks_all_pass() {
     .unwrap();
     fs::write(
         temp.path().join("uninstall.ps1"),
-        "& $Target hooks-remove --level user --runtime all *> $null\n",
+        "$installRoot = Coalesce $InstallRoot 'GIT_WARP_INSTALL_ROOT' $null\n\
+         & $Target hooks-remove --level user --runtime all *> $null\n",
     )
     .unwrap();
 
@@ -217,7 +218,8 @@ fn test_install_ps1_missing_checksum_fails() {
     .unwrap();
     fs::write(
         temp.path().join("uninstall.ps1"),
-        "& $Target hooks-remove --level user --runtime all *> $null\n",
+        "$installRoot = Coalesce $InstallRoot 'GIT_WARP_INSTALL_ROOT' $null\n\
+         & $Target hooks-remove --level user --runtime all *> $null\n",
     )
     .unwrap();
 
@@ -259,7 +261,8 @@ fn test_uninstall_ps1_missing_hooks_remove_fails() {
     // uninstall.ps1 forgot the hooks-remove call.
     fs::write(
         temp.path().join("uninstall.ps1"),
-        "Remove-Item -LiteralPath $target -Force\n",
+        "$installRoot = Coalesce $InstallRoot 'GIT_WARP_INSTALL_ROOT' $null\n\
+         Remove-Item -LiteralPath $target -Force\n",
     )
     .unwrap();
 
@@ -274,6 +277,45 @@ fn test_uninstall_ps1_missing_hooks_remove_fails() {
     assert!(
         checks[6].detail.contains("user-level hooks-remove call"),
         "fail detail should call out the missing hooks-remove, got: {}",
+        checks[6].detail
+    );
+}
+
+#[test]
+fn test_uninstall_ps1_missing_installroot_fails() {
+    let temp = tempdir().unwrap();
+    let expected = ReleaseVersion {
+        number: "0.3.0".to_string(),
+        tag: "v0.3.0".to_string(),
+    };
+
+    fs::write(
+        temp.path().join("install.ps1"),
+        "$api = \"https://api.github.com/repos/denysbutenko/git-warp/releases/latest\"\n\
+         $tag = $env:GIT_WARP_VERSION\n\
+         $hash = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash\n",
+    )
+    .unwrap();
+    // uninstall.ps1 keeps hooks-remove but lost the InstallRoot handling.
+    fs::write(
+        temp.path().join("uninstall.ps1"),
+        "& $Target hooks-remove --level user --runtime all *> $null\n",
+    )
+    .unwrap();
+
+    let checks = collect_metadata_checks(temp.path(), &expected, "0.3.0").unwrap();
+
+    assert!(checks[5].ok, "install.ps1 guard should pass");
+    assert_eq!(checks[6].label, "uninstall.ps1");
+    assert!(
+        !checks[6].ok,
+        "uninstall.ps1 without InstallRoot handling should fail"
+    );
+    assert!(
+        checks[6]
+            .detail
+            .contains("GIT_WARP_INSTALL_ROOT / -InstallRoot handling"),
+        "fail detail should call out the missing InstallRoot handling, got: {}",
         checks[6].detail
     );
 }

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -10,10 +10,17 @@
     Defaults to "$env:LOCALAPPDATA\Programs\git-warp\bin" (the install.ps1
     default). Override with -InstallDir or $env:GIT_WARP_INSTALL_DIR.
 
+    For a Cargo install with a custom root, pass -InstallRoot or
+    $env:GIT_WARP_INSTALL_ROOT (mirrors install.ps1). The uninstaller then
+    targets "<root>\bin\warp.exe".
+
     Other detected warp.exe installs (Cargo, custom directories) are listed
     but not touched.
 .PARAMETER InstallDir
     Directory containing warp.exe. Defaults to the install.ps1 location.
+.PARAMETER InstallRoot
+    Cargo install root that owns "<root>\bin\warp.exe". Overrides -InstallDir
+    when set. Mirrors install.ps1 -InstallRoot / $env:GIT_WARP_INSTALL_ROOT.
 .PARAMETER DryRun
     Print the actions that would run without modifying the system.
 .EXAMPLE
@@ -27,6 +34,7 @@
 [CmdletBinding()]
 param(
     [string]$InstallDir,
+    [string]$InstallRoot,
     [switch]$DryRun
 )
 
@@ -167,7 +175,7 @@ function Show-ProfileLeftovers {
 }
 
 function Show-OtherInstalls {
-    param([string]$Target)
+    param([string]$Target, [string]$InstallRoot)
 
     $candidates = @()
     if ($env:GIT_WARP_INSTALL_DIR) {
@@ -175,6 +183,12 @@ function Show-OtherInstalls {
     }
     if ($env:LOCALAPPDATA) {
         $candidates += (Join-Path $env:LOCALAPPDATA 'Programs\git-warp\bin\warp.exe')
+    }
+    if ($env:GIT_WARP_INSTALL_ROOT) {
+        $candidates += (Join-Path $env:GIT_WARP_INSTALL_ROOT 'bin\warp.exe')
+    }
+    if ($InstallRoot) {
+        $candidates += (Join-Path $InstallRoot 'bin\warp.exe')
     }
     if ($env:USERPROFILE) {
         $candidates += (Join-Path $env:USERPROFILE '.cargo\bin\warp.exe')
@@ -224,10 +238,14 @@ function Show-PathLeftover {
 
 $defaultDir = Join-Path $env:LOCALAPPDATA 'Programs\git-warp\bin'
 $installDir = Coalesce $InstallDir 'GIT_WARP_INSTALL_DIR' $defaultDir
+$installRoot = Coalesce $InstallRoot 'GIT_WARP_INSTALL_ROOT' $null
+if ($installRoot) {
+    $installDir = Join-Path $installRoot 'bin'
+}
 $target = Join-Path $installDir 'warp.exe'
 
 Remove-Hooks -Target $target -Preview $DryRun.IsPresent
 Remove-Binary -Target $target -Dir $installDir -Preview $DryRun.IsPresent
 Show-ProfileLeftovers
-Show-OtherInstalls -Target $target
+Show-OtherInstalls -Target $target -InstallRoot $installRoot
 Show-PathLeftover -Target $target


### PR DESCRIPTION
## Summary
- `uninstall.ps1` now accepts `-InstallRoot` and `$env:GIT_WARP_INSTALL_ROOT`, mirroring `install.ps1`. When set, it targets `<root>\bin\warp.exe` so cargo-root installs (`install.ps1 -Method cargo -InstallRoot ...`) uninstall symmetrically instead of reporting "nothing to remove" against the LOCALAPPDATA default.
- `Show-OtherInstalls` probes both `$env:GIT_WARP_INSTALL_ROOT\bin\warp.exe` and the resolved `-InstallRoot\bin\warp.exe` so a cargo root install is at least surfaced when uninstall runs against a different target.
- `src/release.rs` `content_guard` on `uninstall.ps1` now also requires `GIT_WARP_INSTALL_ROOT`, keeping it in lockstep with the `install.ps1` guard.
- `docs/install.md` Windows uninstall section documents the new override.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked --test mod unit::release` (12 passed, incl. new `test_uninstall_ps1_missing_installroot_fails`)
- `git diff --check`

Closes #218.