### PR TITLE
feat(shell-config): ship PowerShell shell-config emitter (#219)

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,12 @@ warp shell-config zsh >> ~/.zshrc
 warp shell-config fish >> ~/.config/fish/config.fish
 ```
 
+For Windows PowerShell, append the snippet to your profile:
+
+```powershell
+warp shell-config powershell | Add-Content -Path $PROFILE.CurrentUserAllHosts
+```
+
 ## Development
 
 ```bash

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -170,7 +170,7 @@ pub enum Commands {
 
     /// Generate shell configuration
     ShellConfig {
-        /// Shell type: bash, zsh, fish
+        /// Shell type: bash, zsh, fish, powershell
         shell: Option<String>,
     },
 
@@ -2129,10 +2129,24 @@ impl Cli {
                 }
             }
             DoctorShell::PowerShell => {
-                Self::doctor_warn(
-                    "Shell integration",
-                    "PowerShell integration is not yet shipped",
-                );
+                let profile_paths = Self::powershell_profile_paths();
+                let integrated = profile_paths
+                    .iter()
+                    .any(|path| Self::shell_rc_has_warp_integration(path));
+                if integrated {
+                    Self::doctor_ok(
+                        "Shell integration",
+                        "warp_cd helper detected in a PowerShell profile",
+                    );
+                } else {
+                    Self::doctor_warn(
+                        "Shell integration",
+                        "PowerShell warp_cd helper is not installed",
+                    );
+                    next_steps.push(
+                        "Run `warp shell-config powershell` and append the output to $PROFILE.CurrentUserAllHosts to enable `warp_cd` and completions.".to_string(),
+                    );
+                }
                 if let Some(dir) = &default_dir {
                     next_steps.push(format!(
                         "Add `{}` to $env:PATH (e.g. `$env:Path = \"{};$env:Path\"`) so installed {} is found.",
@@ -2245,6 +2259,23 @@ impl Cli {
         std::fs::read_to_string(rc_path)
             .map(|content| content.contains("warp_cd") || content.contains("warp __complete"))
             .unwrap_or(false)
+    }
+
+    fn powershell_profile_paths() -> Vec<PathBuf> {
+        let mut paths = Vec::new();
+        let Some(home) = dirs::home_dir() else {
+            return paths;
+        };
+        let documents = home.join("Documents");
+        for host in ["PowerShell", "WindowsPowerShell"] {
+            paths.push(documents.join(host).join("profile.ps1"));
+            paths.push(
+                documents
+                    .join(host)
+                    .join("Microsoft.PowerShell_profile.ps1"),
+            );
+        }
+        paths
     }
 
     fn doctor_install_candidates() -> Vec<DoctorInstallEntry> {
@@ -2537,6 +2568,13 @@ impl Cli {
                         .filter(|value| !value.is_empty())
                 })
             })
+            .or_else(|| {
+                if cfg!(windows) && std::env::var_os("PSModulePath").is_some() {
+                    Some("powershell".to_string())
+                } else {
+                    None
+                }
+            })
             .unwrap_or_else(|| "bash".to_string());
 
         let commands = public_subcommand_names().join(" ");
@@ -2598,9 +2636,41 @@ complete -c warp -n '__fish_use_subcommand' -f -a '(warp __complete branches (co
 complete -c warp -n '__fish_seen_subcommand_from switch' -f -a '(warp __complete branches (commandline -ct) 2>/dev/null)'"
                 );
             }
+            "powershell" | "pwsh" => {
+                let ps_subcommands = public_subcommand_names()
+                    .iter()
+                    .map(|name| format!("'{name}'"))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                println!("# Add to $PROFILE.CurrentUserAllHosts");
+                println!("function warp_cd {{");
+                println!("    $script = (warp --terminal echo @args) -join \"`n\"");
+                println!("    if ($script) {{ Invoke-Expression $script }}");
+                println!("}}");
+                println!(
+                    "Register-ArgumentCompleter -CommandName warp -Native -ScriptBlock {{
+    param($wordToComplete, $commandAst, $cursorPosition)
+    $subcommands = @({ps_subcommands})
+    $elements = $commandAst.CommandElements
+    $subcommand = if ($elements.Count -ge 2) {{ $elements[1].Extent.Text }} else {{ '' }}
+    if ($subcommand -eq 'switch' -or $elements.Count -le 2) {{
+        foreach ($branch in @(warp __complete branches $wordToComplete 2>$null)) {{
+            [System.Management.Automation.CompletionResult]::new($branch, $branch, 'ParameterValue', $branch)
+        }}
+    }}
+    if ($elements.Count -le 2) {{
+        foreach ($cmd in $subcommands) {{
+            if ($cmd.StartsWith($wordToComplete)) {{
+                [System.Management.Automation.CompletionResult]::new($cmd, $cmd, 'ParameterValue', $cmd)
+            }}
+        }}
+    }}
+}}"
+                );
+            }
             other => {
                 return Err(anyhow::anyhow!(
-                    "Unsupported shell '{other}'. Supported shells: bash, zsh, fish"
+                    "Unsupported shell '{other}'. Supported shells: bash, zsh, fish, powershell"
                 ));
             }
         }

--- a/src/release.rs
+++ b/src/release.rs
@@ -114,6 +114,7 @@ pub fn collect_metadata_checks(
     let install_script = read_optional(repo_root.join("install.sh"))?;
     let install_ps1 = read_optional(repo_root.join("install.ps1"))?;
     let uninstall_ps1 = read_optional(repo_root.join("uninstall.ps1"))?;
+    let cli_rs = read_optional(repo_root.join("src").join("cli.rs"))?;
     let release_notes_path = repo_root
         .join("docs")
         .join("releases")
@@ -226,6 +227,20 @@ pub fn collect_metadata_checks(
         &uninstall_ps1,
         uninstall_ps1_requirements,
         "uninstall.ps1 must keep the warp hooks-remove --level user invocation",
+    ));
+
+    let cli_ps_requirements: &[(&str, &str)] = &[
+        ("function warp_cd", "the PowerShell warp_cd function"),
+        (
+            "Register-ArgumentCompleter -CommandName warp",
+            "the Register-ArgumentCompleter block",
+        ),
+    ];
+    checks.push(content_guard(
+        "src/cli.rs",
+        &cli_rs,
+        cli_ps_requirements,
+        "src/cli.rs must keep the PowerShell shell-config emitter (warp_cd + Register-ArgumentCompleter)",
     ));
 
     Ok(checks)

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -1245,6 +1245,39 @@ fn test_shell_config_fish_outputs_branch_completion_for_root_and_switch() {
     assert!(stdout.contains("warp __complete branches (commandline -ct)"));
 }
 
+#[test]
+fn test_shell_config_powershell_outputs_reusable_function() {
+    let output = Command::new(env!("CARGO_BIN_EXE_warp"))
+        .args(["shell-config", "powershell"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{stdout}");
+    assert!(stdout.contains("function warp_cd"));
+    assert!(stdout.contains("warp --terminal echo @args"));
+    assert!(stdout.contains("Invoke-Expression"));
+    assert!(stdout.contains("Register-ArgumentCompleter -CommandName warp -Native"));
+    assert!(stdout.contains("warp __complete branches $wordToComplete"));
+    assert!(stdout.contains("$commandAst.CommandElements"));
+}
+
+#[test]
+fn test_shell_config_pwsh_alias_matches_powershell() {
+    let ps = Command::new(env!("CARGO_BIN_EXE_warp"))
+        .args(["shell-config", "powershell"])
+        .output()
+        .unwrap();
+    let pwsh = Command::new(env!("CARGO_BIN_EXE_warp"))
+        .args(["shell-config", "pwsh"])
+        .output()
+        .unwrap();
+
+    assert!(ps.status.success());
+    assert!(pwsh.status.success());
+    assert_eq!(ps.stdout, pwsh.stdout);
+}
+
 // Keep in sync with the public variants of `Commands` in src/cli.rs.
 // The binary builds the live list dynamically via clap::CommandFactory, so
 // adding a new public subcommand updates the rendered snippet automatically;
@@ -1267,7 +1300,7 @@ const PUBLIC_SUBCOMMAND_NAMES: &[&str] = &[
 
 #[test]
 fn test_shell_config_lists_every_public_subcommand() {
-    for shell in ["bash", "zsh", "fish"] {
+    for shell in ["bash", "zsh", "fish", "powershell"] {
         let output = Command::new(env!("CARGO_BIN_EXE_warp"))
             .args(["shell-config", shell])
             .output()

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -1977,7 +1977,7 @@ fn test_doctor_shell_check_recognizes_powershell() {
 
     assert!(output.status.success(), "{stdout}{stderr}");
     assert!(
-        stdout.contains("PowerShell integration is not yet shipped"),
+        stdout.contains("Run `warp shell-config powershell`"),
         "{stdout}"
     );
     assert!(

--- a/tests/unit/release_tests.rs
+++ b/tests/unit/release_tests.rs
@@ -116,9 +116,19 @@ fn test_collect_metadata_checks_all_pass() {
     )
     .unwrap();
 
+    // 6. src/cli.rs with the PowerShell shell-config emitter
+    let src_dir = temp.path().join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::write(
+        src_dir.join("cli.rs"),
+        "// function warp_cd emitter\n\
+         // Register-ArgumentCompleter -CommandName warp -Native\n",
+    )
+    .unwrap();
+
     let checks = collect_metadata_checks(temp.path(), &expected, version).unwrap();
 
-    assert_eq!(checks.len(), 7);
+    assert_eq!(checks.len(), 8);
     for check in &checks {
         assert!(check.ok, "check failed: {} - {}", check.label, check.detail);
     }
@@ -135,7 +145,7 @@ fn test_collect_metadata_checks_failures() {
     // All files missing or mismatched
     let checks = collect_metadata_checks(temp.path(), &expected, "0.2.0").unwrap();
 
-    assert_eq!(checks.len(), 7);
+    assert_eq!(checks.len(), 8);
     for check in &checks {
         assert!(!check.ok, "check should have failed: {}", check.label);
     }
@@ -175,6 +185,8 @@ fn test_collect_metadata_checks_failures() {
             .detail
             .contains("warp hooks-remove --level user invocation")
     );
+    assert_eq!(checks[7].label, "src/cli.rs");
+    assert!(checks[7].detail.contains("PowerShell shell-config emitter"));
 }
 
 #[test]
@@ -279,6 +291,39 @@ fn test_uninstall_ps1_missing_hooks_remove_fails() {
 }
 
 #[test]
+fn test_cli_rs_missing_powershell_emitter_fails() {
+    let temp = tempdir().unwrap();
+    let expected = ReleaseVersion {
+        number: "0.3.0".to_string(),
+        tag: "v0.3.0".to_string(),
+    };
+
+    // src/cli.rs kept warp_cd but lost the Register-ArgumentCompleter line.
+    let src_dir = temp.path().join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::write(
+        src_dir.join("cli.rs"),
+        "fn handle_shell_config() { println!(\"function warp_cd\"); }\n",
+    )
+    .unwrap();
+
+    let checks = collect_metadata_checks(temp.path(), &expected, "0.3.0").unwrap();
+
+    assert_eq!(checks[7].label, "src/cli.rs");
+    assert!(
+        !checks[7].ok,
+        "src/cli.rs without Register-ArgumentCompleter should fail"
+    );
+    assert!(
+        checks[7]
+            .detail
+            .contains("Register-ArgumentCompleter block"),
+        "fail detail should call out the missing completer, got: {}",
+        checks[7].detail
+    );
+}
+
+#[test]
 fn test_changelog_heading_variants() {
     let temp = tempdir().unwrap();
     let expected = ReleaseVersion {
@@ -330,7 +375,7 @@ fn test_collect_metadata_checks_partial_success() {
     // All other files are missing.
     let checks = collect_metadata_checks(temp.path(), &expected, version).unwrap();
 
-    assert_eq!(checks.len(), 7);
+    assert_eq!(checks.len(), 8);
     assert!(checks[0].ok, "Cargo.toml check should pass");
     assert!(!checks[1].ok, "CHANGELOG.md check should fail");
     assert!(!checks[2].ok, "release notes check should fail");
@@ -338,4 +383,5 @@ fn test_collect_metadata_checks_partial_success() {
     assert!(!checks[4].ok, "install.sh check should fail");
     assert!(!checks[5].ok, "install.ps1 check should fail");
     assert!(!checks[6].ok, "uninstall.ps1 check should fail");
+    assert!(!checks[7].ok, "src/cli.rs check should fail");
 }


### PR DESCRIPTION
## Summary

- `warp shell-config powershell` (with `pwsh` as an alias) emits a `warp_cd`
  function plus a `Register-ArgumentCompleter -Native` block suitable for
  `$PROFILE.CurrentUserAllHosts`, mirroring the existing bash/zsh/fish snippets.
  The completer offers branches after `warp switch` and at the first positional,
  and offers subcommand names at the first positional — matching the bash flow.
- `warp doctor` on PowerShell now probes the four standard `$PROFILE.*` paths
  (`Documents/{PowerShell,WindowsPowerShell}/{profile,Microsoft.PowerShell_profile}.ps1`)
  for the `warp_cd` / `warp __complete` substrings that `uninstall.ps1` already
  scans for, and points at `warp shell-config powershell` when the snippet is
  missing instead of the previous "not yet shipped" line.
- Bare `warp shell-config` on Windows (no `SHELL` env var, `PSModulePath`
  present) now falls back to the PowerShell emitter instead of defaulting to
  bash.
- `release-check` guards `src/cli.rs` for the two anchor substrings
  (`function warp_cd` and `Register-ArgumentCompleter -CommandName warp`) so a
  future refactor that drops the emitter fails validation.

Closes #219.

## Verification

```bash
cargo fmt --check
cargo clippy --all-targets -- -D warnings
cargo test --test mod cli_surface_tests
cargo test --test mod release_tests
cargo run -- shell-config powershell
cargo run -- shell-config pwsh    # verified byte-identical to powershell
cargo run -- release-check --metadata-only
git diff --check
```

## Test plan

- [ ] On Windows PowerShell: `warp shell-config powershell | Add-Content -Path $PROFILE.CurrentUserAllHosts`, open a fresh session, then `warp <TAB>` offers branch names and `warp switch <TAB>` completes branches.
- [ ] On Windows PowerShell after installing the snippet: `warp doctor` reports "warp_cd helper detected in a PowerShell profile" instead of the missing-integration warning.
- [ ] `warp shell-config nonsense` still errors with the updated supported-shells list including `powershell`.