### PR TITLE
docs: link v0.4.0 release notes and bump release-check examples (#220)

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ git diff --check
 Before tagging a release, run the release validation flow:
 
 ```bash
-warp release-check --version v0.3.0
+warp release-check --version v0.4.0
 ```
 
 Useful manual checks:
@@ -254,6 +254,7 @@ cargo run -- --dry-run cleanup --mode merged
 - [Technical Overview](docs/technical-overview.md)
 - [Documentation Index](docs/README.md)
 - [Changelog](CHANGELOG.md)
+- [Release Notes (v0.4.0)](docs/releases/v0.4.0.md)
 - [Release Notes (v0.3.0)](docs/releases/v0.3.0.md)
 - [Release Notes (v0.2.0)](docs/releases/v0.2.0.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,8 @@ planning material for Git-Warp.
 - [Technical Overview](technical-overview.md): architecture, modules, and
   implementation notes.
 - [Changelog](../CHANGELOG.md): release notes and verification commands.
+- [Release Notes (v0.4.0)](releases/v0.4.0.md): pasteable notes for the
+  `v0.4.0` GitHub release.
 - [Release Notes (v0.3.0)](releases/v0.3.0.md): pasteable notes for the
   `v0.3.0` GitHub release.
 - [Release Notes (v0.2.0)](releases/v0.2.0.md): pasteable notes for the

--- a/docs/release-check.md
+++ b/docs/release-check.md
@@ -3,7 +3,7 @@
 Run the release check before tagging a Git-Warp release.
 
 ```bash
-warp release-check --version v0.3.0
+warp release-check --version v0.4.0
 ```
 
 The command validates release metadata first, then runs the release verification
@@ -11,12 +11,12 @@ commands. It stops at the first failing command.
 
 ## Metadata Checks
 
-`warp release-check --version v0.3.0` verifies that:
+`warp release-check --version v0.4.0` verifies that:
 
-- `Cargo.toml` has package version `0.3.0`.
-- `CHANGELOG.md` has a `v0.3.0` release heading.
-- `docs/releases/v0.3.0.md` exists.
-- `docs/install.md` mentions `GIT_WARP_VERSION=v0.3.0`.
+- `Cargo.toml` has package version `0.4.0`.
+- `CHANGELOG.md` has a `v0.4.0` release heading.
+- `docs/releases/v0.4.0.md` exists.
+- `docs/install.md` mentions `GIT_WARP_VERSION=v0.4.0`.
 - `install.sh` keeps the `${GIT_WARP_VERSION:-...}` env override and resolves
   the latest tag via `api.github.com/repos/.../releases/latest`. This is a
   shape check, independent of the prepared tag.
@@ -24,7 +24,7 @@ commands. It stops at the first failing command.
 Use the fast metadata-only mode while preparing notes:
 
 ```bash
-warp release-check --metadata-only --version v0.3.0
+warp release-check --metadata-only --version v0.4.0
 ```
 
 ## Full Verification


### PR DESCRIPTION
## Summary

- Add a `Release Notes (v0.4.0)` entry above the v0.3.0 link in `README.md` and `docs/README.md` so users landing on either index see the shipped v0.4.0 notes.
- Bump the `warp release-check --version` example in `README.md` and every v0.3.0 reference in `docs/release-check.md` to `v0.4.0` so the copy-paste flow matches the current tag.

Closes #220.

## Verification

- `git diff --check`
- `grep -n "v0.3.0" README.md docs/README.md docs/release-check.md` — remaining hits are the intentional v0.3.0 release-note links.
- `grep -rn "release-check --version v0" README.md docs/` — every example now uses `v0.4.0`.