### PR TITLE
fix(switch): overlay untracked files instead of cloning the whole tree

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -355,6 +355,81 @@ impl Cli {
             })
     }
 
+    /// CoW-overlay the primary worktree's untracked & ignored files onto a
+    /// freshly created linked worktree at `dest`.
+    ///
+    /// Copies only what `git worktree add` cannot reproduce — build output and
+    /// local files such as `node_modules`, `.env`, and caches — and never
+    /// touches `.git`, tracked files, the worktree-storage directory, or names
+    /// listed in `exclude`. Absolute paths baked into the copied files are
+    /// rewritten to point at `dest`. Best-effort: a failure leaves the worktree
+    /// usable, just without the overlaid files.
+    fn cow_overlay_untracked(
+        git_repo: &crate::git::GitRepository,
+        dest: &Path,
+        exclude: &[String],
+    ) -> Result<()> {
+        use crate::cow;
+        use crate::rewrite::PathRewriter;
+
+        let worktrees = git_repo.list_worktrees()?;
+        let Some(primary) = worktrees.iter().find(|wt| wt.is_primary) else {
+            return Ok(());
+        };
+        let primary_path = primary.path.clone();
+
+        let entries = crate::git::list_untracked_and_ignored(&primary_path)?;
+        if entries.is_empty() {
+            return Ok(());
+        }
+
+        // The worktree-storage directory is the destination's parent: in a
+        // nested layout (`worktrees_path` inside the repo) every sibling
+        // worktree lives under it. Skipping any entry that resolves to the
+        // destination's ancestors *or* into that storage directory keeps whole
+        // worktrees from being copied back into `dest`. In the default sibling
+        // layout the storage dir lives outside the primary, so nothing matches.
+        let dest_canon = dest.canonicalize().unwrap_or_else(|_| dest.to_path_buf());
+        let storage = dest_canon.parent().map(std::path::Path::to_path_buf);
+
+        let mut copied = Vec::new();
+        for rel in entries {
+            if !cow::should_overlay_entry(&rel, exclude) {
+                continue;
+            }
+            let src = primary_path.join(&rel);
+            // `symlink_metadata`, not `exists`: keep dangling untracked symlinks
+            // (e.g. `.env` -> a not-yet-present target) that the worktree wants.
+            if std::fs::symlink_metadata(&src).is_err() {
+                continue;
+            }
+            let src_canon = src.canonicalize().unwrap_or_else(|_| src.clone());
+            if dest_canon.starts_with(&src_canon)
+                || storage
+                    .as_deref()
+                    .is_some_and(|base| src_canon.starts_with(base))
+            {
+                continue;
+            }
+            // `overlay_into` skips paths git already checked out and returns the
+            // freshly created paths (for scoped rewriting), cleaning up on a
+            // partial clone so no stale, un-rewritten copy is left behind.
+            match cow::overlay_into(&src, &dest.join(&rel)) {
+                Ok(mut created) => copied.append(&mut created),
+                Err(e) => log::warn!("CoW overlay of {} failed: {}", rel.display(), e),
+            }
+        }
+
+        if !copied.is_empty() {
+            let rewriter = PathRewriter::new(&primary_path, dest);
+            if let Err(e) = rewriter.rewrite_paths_under(&copied) {
+                log::warn!("Path rewriting failed: {}", e);
+            }
+        }
+
+        Ok(())
+    }
+
     fn source_announcement(branch: &str, source: &crate::git::BranchSource) -> String {
         match source {
             crate::git::BranchSource::ExistingWorktree { path } => format!(
@@ -765,7 +840,6 @@ impl Cli {
         use crate::cow;
         use crate::git::GitRepository;
         use crate::post_create::{PostCreateSetupStatus, run_post_create_setup};
-        use crate::rewrite::PathRewriter;
 
         // Find the Git repository
         let git_repo = GitRepository::find().map_err(|_| Self::not_in_git_repo_error())?;
@@ -811,7 +885,9 @@ impl Cli {
 
         let mut report = SwitchOutcomeReport::new(worktree_path.clone());
         let mut worktree_created = false;
-        let mut checkout_warning = None;
+        // The CoW path no longer re-checks-out the branch (the linked worktree is
+        // created on the right branch up front), so no checkout warning arises.
+        let checkout_warning: Option<String> = None;
 
         // Check if worktree already exists
         if worktree_path.exists() {
@@ -825,9 +901,11 @@ impl Cli {
                 !no_cow && config.use_cow && cow::is_cow_supported(&worktree_path).unwrap_or(false);
 
             if use_cow {
-                println!("⚡ Using Copy-on-Write for instant creation...");
+                println!("⚡ Using Copy-on-Write for instant setup...");
 
-                // Create worktree using traditional method first
+                // Create the real linked worktree first. `git worktree add`
+                // produces the correct `.git` gitfile and checks out the branch;
+                // CoW only needs to add the files git can't reproduce.
                 Self::create_worktree_for_source_with_recovery(
                     &git_repo,
                     &branch,
@@ -835,44 +913,14 @@ impl Cli {
                     &branch_source,
                 )?;
 
-                // If we have existing worktrees, try CoW enhancement
-                let worktrees = git_repo.list_worktrees()?;
-                if let Some(main_worktree) = worktrees.iter().find(|wt| wt.is_primary) {
-                    // Remove the traditionally created worktree files
-                    if worktree_path.exists() {
-                        std::fs::remove_dir_all(&worktree_path)?;
-                    }
-
-                    // Clone using CoW
-                    if let Err(e) = cow::clone_directory(&main_worktree.path, &worktree_path) {
-                        log::warn!("CoW failed, falling back to traditional method: {}", e);
-                        // Recreate using traditional method
-                        Self::create_worktree_for_source_with_recovery(
-                            &git_repo,
-                            &branch,
-                            &worktree_path,
-                            &branch_source,
-                        )?;
-                    } else {
-                        // Rewrite paths in the CoW copy
-                        let rewriter = PathRewriter::new(&main_worktree.path, &worktree_path);
-                        if let Err(e) = rewriter.rewrite_paths() {
-                            log::warn!("Path rewriting failed: {}", e);
-                        }
-
-                        // Switch to the correct branch
-                        let output = Command::new("git")
-                            .args(["checkout", branch.as_str()])
-                            .current_dir(&worktree_path)
-                            .output()?;
-
-                        if !output.status.success() {
-                            let error = String::from_utf8_lossy(&output.stderr);
-                            let error = error.trim().to_string();
-                            log::warn!("Failed to checkout branch in CoW worktree: {}", error);
-                            checkout_warning = Some(error);
-                        }
-                    }
+                // Overlay the primary worktree's untracked & ignored files
+                // (node_modules, .env, local caches) via CoW — never `.git` or
+                // tracked files. If the overlay does nothing the worktree is
+                // still a fully valid linked worktree.
+                if let Err(e) =
+                    Self::cow_overlay_untracked(&git_repo, &worktree_path, &config.cow.exclude)
+                {
+                    log::warn!("CoW overlay skipped ({e}); worktree is still usable");
                 }
             } else {
                 println!("📦 Using traditional Git worktree creation...");

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,22 @@ pub struct Config {
     /// Post-create setup settings
     #[serde(default)]
     pub post_create: PostCreateConfig,
+
+    /// Copy-on-Write overlay settings
+    #[serde(default)]
+    pub cow: CowConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CowConfig {
+    /// Directory/file names to skip when CoW-overlaying a new worktree with the
+    /// primary's untracked & ignored files. Matched against any path component,
+    /// so `target` also skips `crates/foo/target`. `.git` and tracked files are
+    /// always skipped regardless of this list. Defaults to regeneratable build
+    /// and cache output (`node_modules` is intentionally kept, since cloning it
+    /// is the point). Set to `[]` to overlay everything untracked.
+    #[serde(default = "default_cow_exclude")]
+    pub exclude: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -152,6 +168,28 @@ fn default_max_activities() -> usize {
     100
 }
 
+fn default_cow_exclude() -> Vec<String> {
+    [
+        "target",
+        "dist",
+        "build",
+        "out",
+        "coverage",
+        ".next",
+        ".nuxt",
+        ".svelte-kit",
+        ".turbo",
+        ".parcel-cache",
+        "__pycache__",
+        ".pytest_cache",
+        ".mypy_cache",
+        ".gradle",
+    ]
+    .iter()
+    .map(|entry| entry.to_string())
+    .collect()
+}
+
 // Default implementations
 impl Default for Config {
     fn default() -> Self {
@@ -165,6 +203,15 @@ impl Default for Config {
             terminal: TerminalConfig::default(),
             agent: AgentConfig::default(),
             post_create: PostCreateConfig::default(),
+            cow: CowConfig::default(),
+        }
+    }
+}
+
+impl Default for CowConfig {
+    fn default() -> Self {
+        Self {
+            exclude: default_cow_exclude(),
         }
     }
 }
@@ -285,6 +332,12 @@ refresh_rate = {}
 
 # Maximum activities to track
 max_activities = {}
+
+[cow]
+# Names to skip when copying the primary worktree's untracked & ignored files
+# into a new worktree. Matched per path component. `.git` and tracked files are
+# never copied. `node_modules` is kept on purpose. Set to [] to copy everything.
+exclude = {:?}
 "#,
             config.terminal_mode,
             config.use_cow,
@@ -302,6 +355,7 @@ max_activities = {}
             config.agent.enabled,
             config.agent.refresh_rate,
             config.agent.max_activities,
+            config.cow.exclude,
         )
     }
 }
@@ -453,12 +507,42 @@ mod tests {
         assert!(sample.contains("[agent]"));
         assert!(sample.contains("[post_create]"));
         assert!(sample.contains("auto_install"));
+        assert!(sample.contains("[cow]"));
+        assert!(sample.contains("exclude"));
     }
 
     #[test]
     fn test_post_create_defaults() {
         let config = Config::default();
         assert!(config.post_create.auto_install);
+    }
+
+    #[test]
+    fn test_cow_exclude_defaults_skip_build_output_keep_node_modules() {
+        let config = Config::default();
+        assert!(config.cow.exclude.contains(&"target".to_string()));
+        assert!(config.cow.exclude.contains(&"dist".to_string()));
+        assert!(
+            !config.cow.exclude.contains(&"node_modules".to_string()),
+            "node_modules must stay copyable by default"
+        );
+    }
+
+    #[test]
+    fn test_cow_config_serialization_roundtrip() {
+        let mut config = Config::default();
+        config.cow.exclude = vec!["target".to_string(), "custom-cache".to_string()];
+        let toml_str = toml::to_string(&config).unwrap();
+        let parsed: Config = toml::from_str(&toml_str).unwrap();
+        assert_eq!(parsed.cow.exclude, config.cow.exclude);
+    }
+
+    #[test]
+    fn test_cow_config_defaults_when_absent_from_file() {
+        // A config file written before the [cow] section existed must still load,
+        // falling back to the default exclude list.
+        let parsed: Config = toml::from_str("terminal_mode = \"tab\"\n").unwrap();
+        assert!(parsed.cow.exclude.contains(&"target".to_string()));
     }
 
     #[test]

--- a/src/cow.rs
+++ b/src/cow.rs
@@ -46,6 +46,9 @@ fn nearest_existing_ancestor(path: &Path) -> PathBuf {
 /// Returns `None` when `dest` is not inside `src` (the default git-warp layout,
 /// where worktrees live in a sibling `../worktrees` directory), so the fast
 /// whole-tree clone path is preserved.
+// Part of the whole-tree `clone_directory` API, which the `warp` bin no longer
+// calls (it uses the untracked overlay); still exercised by tests/benches.
+#[allow(dead_code)]
 fn nested_dest_exclusion(src: &Path, dest: &Path) -> Option<PathBuf> {
     use std::path::Component;
 
@@ -61,6 +64,7 @@ fn nested_dest_exclusion(src: &Path, dest: &Path) -> Option<PathBuf> {
 /// Resolve `path` to an absolute, symlink-free form for containment checks,
 /// tolerating a not-yet-created leaf by canonicalizing the nearest existing
 /// ancestor and re-appending the missing tail components.
+#[allow(dead_code)] // Whole-tree clone helper; bin uses the untracked overlay.
 fn resolve_for_containment(path: &Path) -> PathBuf {
     let ancestor = nearest_existing_ancestor(path);
     let base = ancestor.canonicalize().unwrap_or(ancestor.clone());
@@ -70,7 +74,12 @@ fn resolve_for_containment(path: &Path) -> PathBuf {
     }
 }
 
-/// Clone a directory using Copy-on-Write
+/// Clone an entire directory tree using Copy-on-Write.
+///
+/// The `warp` bin creates worktrees via `git worktree add` plus [`clone_entry`]
+/// overlay and no longer calls this; it remains part of the public library
+/// surface and is exercised by the integration tests and benchmarks.
+#[allow(dead_code)]
 pub fn clone_directory<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dest: Q) -> Result<()> {
     let src = src.as_ref();
     let dest = dest.as_ref();
@@ -102,6 +111,120 @@ pub fn clone_directory<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dest: Q) -> Resul
     {
         let _ = (dest, exclude);
         Err(GitWarpError::CoWNotSupported.into())
+    }
+}
+
+/// Whether a relative untracked/ignored entry should be CoW-overlaid onto a
+/// freshly created worktree. Always skips `.git`, and skips any entry whose
+/// path contains a component listed in `exclude` (so `target` also drops
+/// `crates/foo/target`). Matching is name-based; callers list bare directory
+/// or file names, not globs.
+pub fn should_overlay_entry(rel: &Path, exclude: &[String]) -> bool {
+    use std::path::Component;
+
+    for component in rel.components() {
+        if let Component::Normal(name) = component {
+            let name = name.to_string_lossy();
+            if name == ".git" {
+                return false;
+            }
+            if exclude.iter().any(|token| token.trim_matches('/') == name) {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// CoW-clone a single filesystem entry (regular file, directory, or symlink)
+/// from `src` to `dst`, creating `dst`'s parent directories as needed.
+///
+/// Unlike [`clone_directory`], this overlays into an existing tree: it never
+/// removes `dst`'s siblings, so it is safe to layer untracked/ignored files on
+/// top of a worktree that `git worktree add` already populated.
+pub fn clone_entry(src: &Path, dst: &Path) -> Result<()> {
+    // `symlink_metadata` (not `exists`) so a *dangling* symlink still counts as
+    // present — both backends recreate the link verbatim without resolving it.
+    if std::fs::symlink_metadata(src).is_err() {
+        return Err(GitWarpError::WorktreeNotFound {
+            path: src.display().to_string(),
+        }
+        .into());
+    }
+
+    if let Some(parent) = dst.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| anyhow::anyhow!("Failed to create {}: {}", parent.display(), e))?;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        cp_clone(src, dst)
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        linux::clone_entry(src, dst)
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        let _ = dst;
+        Err(GitWarpError::CoWNotSupported.into())
+    }
+}
+
+/// Overlay `src` onto `dst`, copying only paths that do not already exist in
+/// `dst`, and return the freshly created destination paths (so callers can
+/// scope path-rewriting to exactly what was added).
+///
+/// - `dst` absent → the whole entry is CoW-cloned in one shot ([`clone_entry`]).
+/// - both directories → children are merged recursively, so a directory that is
+///   fully untracked on the primary's branch (reported by git as one collapsed
+///   entry) but partly *tracked* on the new branch still contributes its
+///   untracked children instead of being skipped wholesale.
+/// - `dst` already a file/symlink → left untouched (never clobber a checkout).
+///
+/// On a clone failure the partially written destination is removed, so a failed
+/// overlay leaves the worktree *without* those files rather than with a stale,
+/// half-written, un-rewritten copy.
+pub fn overlay_into(src: &Path, dst: &Path) -> Result<Vec<PathBuf>> {
+    let src_meta = std::fs::symlink_metadata(src)
+        .map_err(|e| anyhow::anyhow!("Failed to stat {}: {}", src.display(), e))?;
+
+    match std::fs::symlink_metadata(dst) {
+        // Nothing there yet: clone the whole entry, cleaning up on failure.
+        Err(_) => match clone_entry(src, dst) {
+            Ok(()) => Ok(vec![dst.to_path_buf()]),
+            Err(e) => {
+                let _ = remove_path(dst);
+                Err(e)
+            }
+        },
+        // Directory-into-directory: merge only the missing children.
+        Ok(dst_meta) if src_meta.is_dir() && dst_meta.is_dir() => {
+            let mut created = Vec::new();
+            for entry in std::fs::read_dir(src)
+                .map_err(|e| anyhow::anyhow!("Failed to read {}: {}", src.display(), e))?
+            {
+                let entry = entry.map_err(|e| {
+                    anyhow::anyhow!("Failed to read entry in {}: {}", src.display(), e)
+                })?;
+                created.extend(overlay_into(&entry.path(), &dst.join(entry.file_name()))?);
+            }
+            Ok(created)
+        }
+        // `dst` already exists as a tracked file/symlink: leave it be.
+        Ok(_) => Ok(Vec::new()),
+    }
+}
+
+/// Best-effort recursive removal of whatever kind of node `path` is.
+fn remove_path(path: &Path) -> std::io::Result<()> {
+    match std::fs::symlink_metadata(path) {
+        Ok(meta) if meta.is_dir() => std::fs::remove_dir_all(path),
+        Ok(_) => std::fs::remove_file(path),
+        Err(_) => Ok(()),
     }
 }
 
@@ -189,6 +312,16 @@ mod linux {
         unsafe { ficlone(dst.as_raw_fd(), src.as_raw_fd() as nix::libc::c_ulong) }
     }
 
+    /// Overlay a single entry (file, dir, or symlink) from `src` to `dst`
+    /// without touching `dst`'s siblings. `dst` must not already exist; its
+    /// parent is created by the caller.
+    pub(super) fn clone_entry(src: &Path, dst: &Path) -> Result<()> {
+        clone_tree(src, dst, None)
+    }
+
+    // Whole-tree reflink clone; reached only through the lib's `clone_directory`
+    // (tests/benches), not the `warp` bin, which overlays untracked files.
+    #[allow(dead_code)]
     pub(super) fn clone_directory(src: &Path, dst: &Path, exclude: Option<&Path>) -> Result<()> {
         if dst.exists() {
             fs::remove_dir_all(dst)?;
@@ -285,6 +418,7 @@ mod linux {
 }
 
 #[cfg(target_os = "macos")]
+#[allow(dead_code)] // Whole-tree clone path; bin overlays untracked files instead.
 fn clone_directory_apfs(src: &Path, dest: &Path, exclude: Option<&Path>) -> Result<()> {
     // Ensure we're on APFS
     if !is_apfs(src)? {
@@ -352,6 +486,7 @@ fn cp_clone(from: &Path, to: &Path) -> Result<()> {
 }
 
 #[cfg(target_os = "linux")]
+#[allow(dead_code)] // Whole-tree clone path; bin overlays untracked files instead.
 fn clone_directory_reflink(src: &Path, dest: &Path, exclude: Option<&Path>) -> Result<()> {
     linux::clone_directory(src, dest, exclude)
 }
@@ -366,6 +501,155 @@ mod tests {
     fn test_cow_support_check() {
         let result = is_cow_supported(".");
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn should_overlay_entry_always_skips_dot_git() {
+        assert!(!should_overlay_entry(Path::new(".git"), &[]));
+        assert!(!should_overlay_entry(Path::new(".git/config"), &[]));
+    }
+
+    #[test]
+    fn should_overlay_entry_honors_exclude_by_component() {
+        let exclude = vec!["target".to_string(), ".next".to_string()];
+        assert!(!should_overlay_entry(Path::new("target"), &exclude));
+        assert!(!should_overlay_entry(
+            Path::new("target/debug/foo"),
+            &exclude
+        ));
+        // nested build dir with the same leaf name is also skipped
+        assert!(!should_overlay_entry(
+            Path::new("crates/inner/target"),
+            &exclude
+        ));
+        assert!(!should_overlay_entry(Path::new(".next/cache"), &exclude));
+        // trailing-slash tokens still match
+        let exclude_slash = vec!["dist/".to_string()];
+        assert!(!should_overlay_entry(Path::new("dist"), &exclude_slash));
+    }
+
+    #[test]
+    fn should_overlay_entry_keeps_normal_untracked() {
+        let exclude = vec!["target".to_string()];
+        assert!(should_overlay_entry(Path::new("node_modules"), &exclude));
+        assert!(should_overlay_entry(Path::new(".env"), &exclude));
+        assert!(should_overlay_entry(
+            Path::new("node_modules/lodash/index.js"),
+            &exclude
+        ));
+    }
+
+    #[test]
+    fn overlay_into_merges_missing_children_without_clobbering_tracked() {
+        let tmp = tempdir().unwrap();
+        let src = tmp.path().join("primary");
+        let dest = tmp.path().join("worktree");
+        // Primary's `assets/` is fully untracked here (git would collapse it to
+        // one entry): a local note plus generated data.
+        fs::create_dir_all(src.join("assets")).unwrap();
+        fs::write(src.join("assets/logo.png"), b"local-logo").unwrap();
+        fs::write(src.join("assets/notes.txt"), b"local-notes").unwrap();
+        // On the NEW branch `assets/` is tracked, so `git worktree add` already
+        // laid down a checked-out file there.
+        fs::create_dir_all(dest.join("assets")).unwrap();
+        fs::write(dest.join("assets/style.css"), b"tracked").unwrap();
+
+        if !is_cow_supported(&src).unwrap_or(false) {
+            return;
+        }
+
+        let created = overlay_into(&src.join("assets"), &dest.join("assets")).unwrap();
+
+        // Untracked children were overlaid...
+        assert_eq!(
+            fs::read(dest.join("assets/logo.png")).unwrap(),
+            b"local-logo"
+        );
+        assert_eq!(
+            fs::read(dest.join("assets/notes.txt")).unwrap(),
+            b"local-notes"
+        );
+        // ...the tracked checkout survived untouched...
+        assert_eq!(fs::read(dest.join("assets/style.css")).unwrap(), b"tracked");
+        // ...and only the freshly created paths are returned for rewriting.
+        assert!(created.iter().any(|p| p.ends_with("assets/logo.png")));
+        assert!(created.iter().any(|p| p.ends_with("assets/notes.txt")));
+        assert!(!created.iter().any(|p| p.ends_with("assets/style.css")));
+    }
+
+    #[test]
+    fn overlay_into_clones_whole_entry_when_dest_absent() {
+        let tmp = tempdir().unwrap();
+        let src = tmp.path().join("primary");
+        let dest = tmp.path().join("worktree");
+        fs::create_dir_all(src.join("node_modules/pkg")).unwrap();
+        fs::write(src.join("node_modules/pkg/i.js"), b"dep").unwrap();
+        fs::create_dir_all(&dest).unwrap();
+
+        if !is_cow_supported(&src).unwrap_or(false) {
+            return;
+        }
+
+        let created = overlay_into(&src.join("node_modules"), &dest.join("node_modules")).unwrap();
+        assert_eq!(
+            fs::read(dest.join("node_modules/pkg/i.js")).unwrap(),
+            b"dep"
+        );
+        assert_eq!(created, vec![dest.join("node_modules")]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn overlay_into_recreates_dangling_symlink() {
+        let tmp = tempdir().unwrap();
+        let src = tmp.path().join("primary");
+        let dest = tmp.path().join("worktree");
+        fs::create_dir_all(&src).unwrap();
+        fs::create_dir_all(&dest).unwrap();
+        // A symlink whose target does not exist — `Path::exists()` would say no.
+        std::os::unix::fs::symlink("/nonexistent/target", src.join("link")).unwrap();
+
+        if !is_cow_supported(&src).unwrap_or(false) {
+            return;
+        }
+
+        overlay_into(&src.join("link"), &dest.join("link")).unwrap();
+        let meta = fs::symlink_metadata(dest.join("link")).unwrap();
+        assert!(
+            meta.file_type().is_symlink(),
+            "dangling symlink must survive"
+        );
+        assert_eq!(
+            fs::read_link(dest.join("link")).unwrap(),
+            Path::new("/nonexistent/target")
+        );
+    }
+
+    #[test]
+    fn clone_entry_overlays_without_touching_siblings() {
+        let tmp = tempdir().unwrap();
+        let src = tmp.path().join("primary");
+        let dest = tmp.path().join("worktree");
+        fs::create_dir_all(src.join("node_modules/pkg")).unwrap();
+        fs::write(src.join("node_modules/pkg/index.js"), b"module").unwrap();
+        // `dest` already exists (as if `git worktree add` created it) and has a
+        // sibling that must survive the overlay.
+        fs::create_dir_all(&dest).unwrap();
+        fs::write(dest.join("tracked.txt"), b"checked out").unwrap();
+
+        if !is_cow_supported(&src).unwrap_or(false) {
+            return;
+        }
+
+        clone_entry(&src.join("node_modules"), &dest.join("node_modules"))
+            .expect("overlay must succeed");
+
+        assert_eq!(
+            fs::read(dest.join("node_modules/pkg/index.js")).unwrap(),
+            b"module"
+        );
+        // The pre-existing tracked file is untouched.
+        assert_eq!(fs::read(dest.join("tracked.txt")).unwrap(), b"checked out");
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,9 +10,11 @@ pub enum GitWarpError {
     #[error("Worktree '{path}' not found")]
     WorktreeNotFound { path: String },
 
-    // Constructed only on the macOS APFS path and the non-CoW fallback; never
-    // on Linux, where the reflink probe reports support via a bool instead.
-    #[cfg_attr(target_os = "linux", allow(dead_code))]
+    // Constructed by the lib's whole-tree `clone_directory` (APFS path) and the
+    // non-CoW fallback, exercised through tests/benches. The `warp` bin reaches
+    // CoW only via the untracked overlay, which never constructs this, so the
+    // bin build would otherwise flag it as unconstructed.
+    #[allow(dead_code)]
     #[error("Copy-on-Write is not supported on this filesystem")]
     CoWNotSupported,
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -1016,11 +1016,135 @@ impl GitRepository {
     }
 }
 
+/// List a worktree's untracked and ignored entries as paths relative to
+/// `repo_dir`, with whole untracked/ignored directories collapsed to a single
+/// entry (git's default reporting granularity).
+///
+/// This drives the CoW overlay: `git worktree add` reproduces tracked files but
+/// not the build output and local files (`node_modules`, `.env`, caches, venvs)
+/// that make a worktree usable, so those are the only entries worth cloning.
+/// `.git` is never reported by `git status`, so it is inherently excluded.
+pub fn list_untracked_and_ignored(repo_dir: &Path) -> Result<Vec<PathBuf>> {
+    let output = Command::new("git")
+        .args(["status", "--porcelain", "-z", "--ignored"])
+        .current_dir(repo_dir)
+        .output()
+        .map_err(|e| anyhow::anyhow!("Failed to list untracked files: {}", e))?;
+
+    if !output.status.success() {
+        return Ok(Vec::new());
+    }
+
+    // Porcelain v1 records are `XY <path>`; `-z` NUL-separates records and
+    // leaves paths *unquoted, as raw bytes*. Parse on the byte stream and
+    // rebuild each path via the OS encoding so non-UTF-8 filenames (legal on
+    // Linux) survive intact rather than being mangled by lossy UTF-8 decoding.
+    let mut entries = Vec::new();
+    for record in output.stdout.split(|&byte| byte == 0) {
+        // Shortest meaningful record is `?? x` (2 status bytes, a space, ≥1 path
+        // byte). `XY` is always ASCII.
+        if record.len() < 4 {
+            continue;
+        }
+        let is_untracked = record[0] == b'?' && record[1] == b'?';
+        let is_ignored = record[0] == b'!' && record[1] == b'!';
+        if !is_untracked && !is_ignored {
+            continue;
+        }
+        let mut path_bytes = &record[3..];
+        // git appends a trailing '/' to collapsed directory entries.
+        if path_bytes.last() == Some(&b'/') {
+            path_bytes = &path_bytes[..path_bytes.len() - 1];
+        }
+        if path_bytes.is_empty() {
+            continue;
+        }
+        let path = bytes_to_path(path_bytes);
+        if path == Path::new(".git") {
+            continue;
+        }
+        entries.push(path);
+    }
+    Ok(entries)
+}
+
+#[cfg(unix)]
+fn bytes_to_path(bytes: &[u8]) -> PathBuf {
+    use std::os::unix::ffi::OsStrExt;
+    PathBuf::from(std::ffi::OsStr::from_bytes(bytes))
+}
+
+#[cfg(not(unix))]
+fn bytes_to_path(bytes: &[u8]) -> PathBuf {
+    PathBuf::from(String::from_utf8_lossy(bytes).into_owned())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::process::Command;
     use tempfile::tempdir;
+
+    #[test]
+    fn test_list_untracked_and_ignored_collapses_dirs_and_skips_tracked() {
+        let temp = tempdir().unwrap();
+        let repo = temp.path();
+
+        Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.email", "t@e.com"])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.name", "T"])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+
+        std::fs::write(repo.join(".gitignore"), "node_modules/\n*.log\n").unwrap();
+        std::fs::write(repo.join("tracked.txt"), "x").unwrap();
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-q", "-m", "init"])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+
+        // ignored directory (collapses to a single entry), ignored file, and an
+        // untracked file.
+        std::fs::create_dir_all(repo.join("node_modules/pkg")).unwrap();
+        std::fs::write(repo.join("node_modules/pkg/a.js"), "y").unwrap();
+        std::fs::write(repo.join("debug.log"), "z").unwrap();
+        std::fs::write(repo.join(".env"), "SECRET=1").unwrap();
+
+        let entries = list_untracked_and_ignored(repo).unwrap();
+
+        assert!(
+            entries.contains(&PathBuf::from("node_modules")),
+            "ignored dir collapses to one entry: {entries:?}"
+        );
+        assert!(entries.contains(&PathBuf::from("debug.log")), "{entries:?}");
+        assert!(entries.contains(&PathBuf::from(".env")), "{entries:?}");
+        assert!(
+            !entries.contains(&PathBuf::from("tracked.txt")),
+            "tracked files must not be overlaid: {entries:?}"
+        );
+        assert!(
+            !entries
+                .iter()
+                .any(|e| e != Path::new("node_modules") && e.starts_with("node_modules")),
+            "whole ignored dir must not be expanded to files: {entries:?}"
+        );
+    }
 
     #[test]
     fn test_git_repo_operations() {

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -22,36 +22,32 @@ impl PathRewriter {
         }
     }
 
-    /// Rewrite absolute paths in gitignored files
+    /// Rewrite absolute paths across the whole destination worktree.
+    ///
+    /// The `warp` bin scopes rewriting to the overlaid entries via
+    /// [`Self::rewrite_paths_under`]; this whole-tree variant remains for the
+    /// library's tests and benchmarks.
+    #[allow(dead_code)]
     pub fn rewrite_paths(&self) -> Result<()> {
+        let dest_path = self.dest_path.clone();
+        self.rewrite_files(collect_files(&dest_path))
+    }
+
+    /// Rewrite absolute paths only within `roots` (files or directories),
+    /// instead of walking the entire worktree.
+    ///
+    /// The CoW overlay copies just the untracked/ignored entries, so only those
+    /// can carry a baked-in old path. Scoping to them keeps the walk small and,
+    /// critically, never rewrites tracked files — which git already checked out
+    /// and which must not gain spurious diffs.
+    pub fn rewrite_paths_under(&self, roots: &[PathBuf]) -> Result<()> {
+        let files: Vec<PathBuf> = roots.iter().flat_map(|root| collect_files(root)).collect();
+        self.rewrite_files(files)
+    }
+
+    fn rewrite_files(&self, files: Vec<PathBuf>) -> Result<()> {
         let src_str = self.src_path.to_string_lossy();
         let dest_str = self.dest_path.to_string_lossy();
-
-        // Build a list of files to process. The rewriter targets gitignored
-        // artifacts (venvs, build output, generated configs) that bake in the
-        // old worktree path, so the walker must NOT filter on gitignore. The
-        // `.git` entry is pruned explicitly: in a primary worktree it is the
-        // repo's internal directory, and in a secondary worktree it is a
-        // `gitdir:` pointer file that git owns.
-        let files: Vec<PathBuf> = WalkBuilder::new(&self.dest_path)
-            .hidden(false)
-            .git_ignore(false)
-            .git_global(false)
-            .git_exclude(false)
-            .require_git(false)
-            .filter_entry(|entry| entry.file_name() != ".git")
-            .build()
-            .filter_map(|entry| match entry {
-                Ok(entry) => {
-                    if entry.file_type()?.is_file() {
-                        Some(entry.path().to_path_buf())
-                    } else {
-                        None
-                    }
-                }
-                Err(_) => None,
-            })
-            .collect();
 
         // Process files in parallel
         files.par_iter().for_each(|file_path| {
@@ -131,6 +127,36 @@ impl PathRewriter {
             printable_ratio < 0.95
         }
     }
+}
+
+/// Collect the regular files under `root` for path rewriting.
+///
+/// The rewriter targets gitignored artifacts (venvs, build output, generated
+/// configs) that bake in the old worktree path, so the walker must NOT filter
+/// on gitignore. The `.git` entry is pruned explicitly: in a primary worktree
+/// it is the repo's internal directory, and in a secondary worktree it is a
+/// `gitdir:` pointer file that git owns. A `root` that is itself a file yields
+/// just that file.
+fn collect_files(root: &Path) -> Vec<PathBuf> {
+    WalkBuilder::new(root)
+        .hidden(false)
+        .git_ignore(false)
+        .git_global(false)
+        .git_exclude(false)
+        .require_git(false)
+        .filter_entry(|entry| entry.file_name() != ".git")
+        .build()
+        .filter_map(|entry| match entry {
+            Ok(entry) => {
+                if entry.file_type()?.is_file() {
+                    Some(entry.path().to_path_buf())
+                } else {
+                    None
+                }
+            }
+            Err(_) => None,
+        })
+        .collect()
 }
 
 /// True when `c` can continue an absolute path token, so a match that
@@ -284,6 +310,37 @@ mod tests {
         assert_eq!(
             head_before, head_after,
             ".git/HEAD must not be touched by the rewriter"
+        );
+    }
+
+    #[test]
+    fn test_rewrite_paths_under_scopes_to_roots_only() {
+        let temp_dir = tempdir().unwrap();
+        let src_dir = temp_dir.path().join("primary");
+        let dest_dir = temp_dir.path().join("worktree");
+        fs::create_dir_all(dest_dir.join("node_modules")).unwrap();
+        fs::create_dir_all(&src_dir).unwrap();
+
+        // An overlaid file (inside the root we pass) and a tracked file that is
+        // NOT in the overlay roots. Both bake in the old primary path.
+        let baked = format!("root={}", src_dir.display());
+        fs::write(dest_dir.join("node_modules/.bin_path"), &baked).unwrap();
+        fs::write(dest_dir.join("tracked.config"), &baked).unwrap();
+
+        PathRewriter::new(&src_dir, &dest_dir)
+            .rewrite_paths_under(&[dest_dir.join("node_modules")])
+            .unwrap();
+
+        // The overlaid file is rewritten to the new worktree path...
+        let overlaid = fs::read_to_string(dest_dir.join("node_modules/.bin_path")).unwrap();
+        assert!(overlaid.contains(&dest_dir.to_string_lossy().to_string()));
+        assert!(!overlaid.contains(&src_dir.to_string_lossy().to_string()));
+
+        // ...while the tracked file outside the roots is left byte-for-byte
+        // identical, so git sees no spurious diff.
+        assert_eq!(
+            fs::read_to_string(dest_dir.join("tracked.config")).unwrap(),
+            baked
         );
     }
 

--- a/tests/integration/cow_git_integration_tests.rs
+++ b/tests/integration/cow_git_integration_tests.rs
@@ -1,9 +1,118 @@
-use git_warp::cow::{clone_directory, is_cow_supported};
-use git_warp::git::GitRepository;
+use git_warp::cow::{clone_directory, clone_entry, is_cow_supported, should_overlay_entry};
+use git_warp::git::{GitRepository, list_untracked_and_ignored};
 use git_warp::rewrite::PathRewriter;
 use std::fs;
 use std::process::Command;
 use tempfile::tempdir;
+
+/// End-to-end check of the untracked-overlay worktree creation: a real
+/// `git worktree add` followed by CoW-overlaying only the primary's untracked
+/// and ignored files. Mirrors `Cli::cow_overlay_untracked`.
+#[test]
+fn test_untracked_overlay_keeps_linked_worktree_and_skips_git_and_excludes() {
+    let _cwd = crate::support::CurrentDirGuard::new();
+    let temp_dir = setup_git_repository();
+    let repo_path = temp_dir.path();
+
+    // Primary has: an ignored dep dir (node_modules, worth copying), an ignored
+    // build dir (target, excluded), an untracked local file (.env), and a
+    // config baking in the primary's absolute path.
+    fs::create_dir_all(repo_path.join("node_modules/pkg")).unwrap();
+    fs::write(repo_path.join("node_modules/pkg/index.js"), b"dep").unwrap();
+    fs::create_dir_all(repo_path.join("target/debug")).unwrap();
+    fs::write(repo_path.join("target/debug/app"), b"binary").unwrap();
+    fs::write(
+        repo_path.join(".env"),
+        format!("ROOT={}\n", repo_path.display()),
+    )
+    .unwrap();
+    // node_modules & *.log are ignored by setup_git_repository's .gitignore;
+    // also ignore target here.
+    fs::write(
+        repo_path.join(".gitignore"),
+        "node_modules/\n*.log\ntarget/\n.env\n",
+    )
+    .unwrap();
+    Command::new("git")
+        .args(["add", ".gitignore"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-q", "-m", "ignore build dirs"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+
+    // Sibling worktree (the default git-warp layout), so the primary's own
+    // status never lists the worktree-storage dir.
+    let wt_root = tempdir().unwrap();
+    let worktree_path = wt_root.path().join("feature-overlay");
+
+    // 1. Real linked worktree.
+    let ok = Command::new("git")
+        .args(["worktree", "add", "-b", "feature-overlay"])
+        .arg(&worktree_path)
+        .current_dir(repo_path)
+        .output()
+        .unwrap()
+        .status
+        .success();
+    assert!(ok, "git worktree add failed");
+
+    if !is_cow_supported(&worktree_path).unwrap_or(false) {
+        // No CoW here (e.g. ext4 CI): the linked worktree invariant still holds.
+        assert!(worktree_path.join(".git").is_file());
+        return;
+    }
+
+    // 2. Overlay untracked/ignored entries, excluding build output.
+    let exclude = vec!["target".to_string()];
+    let mut copied = Vec::new();
+    for rel in list_untracked_and_ignored(repo_path).unwrap() {
+        if !should_overlay_entry(&rel, &exclude) {
+            continue;
+        }
+        let src = repo_path.join(&rel);
+        let dst = worktree_path.join(&rel);
+        if dst.exists() {
+            continue;
+        }
+        clone_entry(&src, &dst).unwrap();
+        copied.push(dst);
+    }
+    PathRewriter::new(repo_path, &worktree_path)
+        .rewrite_paths_under(&copied)
+        .unwrap();
+
+    // `.git` stays a linked-worktree pointer FILE, never a copied directory.
+    assert!(
+        worktree_path.join(".git").is_file(),
+        ".git must remain a linked-worktree file, not a copied directory"
+    );
+    // Worth-copying untracked deps came across.
+    assert!(worktree_path.join("node_modules/pkg/index.js").is_file());
+    assert!(worktree_path.join(".env").is_file());
+    // Excluded build output did NOT.
+    assert!(
+        !worktree_path.join("target").exists(),
+        "excluded build dir must not be overlaid"
+    );
+    // Baked path in the overlaid file was rewritten to the new worktree.
+    let env = fs::read_to_string(worktree_path.join(".env")).unwrap();
+    assert!(env.contains(&worktree_path.to_string_lossy().to_string()));
+    assert!(!env.contains(&format!("ROOT={}\n", repo_path.display())));
+
+    git_repo_remove(repo_path, &worktree_path);
+}
+
+fn git_repo_remove(repo_path: &std::path::Path, worktree_path: &std::path::Path) {
+    let _ = Command::new("git")
+        .args(["worktree", "remove", "--force"])
+        .arg(worktree_path)
+        .current_dir(repo_path)
+        .output();
+}
 
 #[test]
 fn test_cow_clone_with_git_worktree_registration() {

--- a/tests/unit/config_tests.rs
+++ b/tests/unit/config_tests.rs
@@ -1,5 +1,6 @@
 use git_warp::config::{
-    AgentConfig, Config, ConfigManager, GitConfig, PostCreateConfig, ProcessConfig, TerminalConfig,
+    AgentConfig, Config, ConfigManager, CowConfig, GitConfig, PostCreateConfig, ProcessConfig,
+    TerminalConfig,
 };
 use std::fs;
 use tempfile::tempdir;
@@ -61,6 +62,9 @@ fn test_config_with_custom_values() {
         post_create: PostCreateConfig {
             auto_install: false,
         },
+        cow: CowConfig {
+            exclude: vec!["target".to_string(), "dist".to_string()],
+        },
     };
 
     let toml_str = toml::to_string(&config).unwrap();
@@ -72,6 +76,7 @@ fn test_config_with_custom_values() {
     assert_eq!(config.git.protected_branches, parsed.git.protected_branches);
     assert!(!parsed.git.auto_fetch);
     assert!(parsed.process.auto_kill);
+    assert_eq!(parsed.cow.exclude, config.cow.exclude);
 }
 
 #[test]


### PR DESCRIPTION
## What

`warp switch` used to build a worktree the long way: `git worktree add`, delete it, CoW-clone the whole primary worktree (`.git`, build output and all), then `git checkout`. That copied the entire object store and every tracked file for nothing, walked all of it again to rewrite paths, and left the new worktree with a copied `.git` directory instead of a linked-worktree pointer.

Now it keeps the `git worktree add` and CoW-overlays only the untracked and ignored files git can't recreate — `node_modules`, `.env`, local caches. `.git`, tracked files, the worktree-storage dir, and a configurable `[cow] exclude` list (build/cache output by default; `node_modules` stays) are all skipped. Rewriting only runs over what was overlaid, so tracked files stop picking up spurious diffs.

## Why

Speed and correctness. No more cloning `.git` or `target/`, and no double checkout — on a scratch repo with a 7.8 MB / 2000-file `target/`, a switch dropped to ~0.1s. And the result is an actual linked worktree again (`.git` is a file).

## Notes

- `overlay_into` merges into a directory the target branch already tracks, so its untracked siblings still come over; it deletes a partial copy if a clone fails, so you never end up with half-written files pointing at stale paths; dangling symlinks survive.
- `git status` output is parsed as raw bytes, so non-UTF-8 filenames on Linux aren't mangled.
- `[cow] exclude` is new — set it to `[]` to go back to copying everything untracked.

## Testing

`cargo test` (478, with new unit + integration cases) and `cargo clippy --all-targets` both clean. Also drove the built binary through new/existing/remote branches, worktree reuse, `--no-cow`, the nested layout, a tracked-dir name collision, a dangling symlink, partial-copy cleanup, and the sibling-worktree guard.
