### PR TITLE
fix(test): repair uninstall.ps1 release-check fixture

### DIFF
--- a/tests/unit/release_tests.rs
+++ b/tests/unit/release_tests.rs
@@ -497,7 +497,8 @@ fn test_uninstall_script_missing_hooks_remove_fails() {
     .unwrap();
     fs::write(
         temp.path().join("uninstall.ps1"),
-        "& $Target hooks-remove --level user --runtime all *> $null\n",
+        "param([string]$InstallRoot = $env:GIT_WARP_INSTALL_ROOT)\n\
+         & $Target hooks-remove --level user --runtime all *> $null\n",
     )
     .unwrap();
     // uninstall.sh forgot the hooks-remove call.


### PR DESCRIPTION
main has been red on every platform since #223 merged.

#223 taught the uninstall.ps1 release-check guard to require the `-InstallRoot` / `GIT_WARP_INSTALL_ROOT` handling. But the fixture in `test_uninstall_script_missing_hooks_remove_fails` still writes a bare `hooks-remove` line, so the guard that test expects to *pass* fails instead.

Fix: give the fixture an `InstallRoot` param so it models a valid `uninstall.ps1` again. Full suite green locally.