### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,56 @@
 # Changelog
 
-## Unreleased
+## v0.5.0 - 2026-07-08
+
+Follow-up release to v0.4.0. It finishes the Windows shell story with a
+PowerShell shell-config emitter, and fixes `warp switch` so a new worktree
+overlays only the primary's untracked and ignored files instead of copying the
+whole tree.
+
+Release notes: [docs/releases/v0.5.0.md](docs/releases/v0.5.0.md)
+
+### Added
+
+- PowerShell shell-config: `warp shell-config powershell` (alias `pwsh`) emits a
+  `warp_cd` helper and a `Register-ArgumentCompleter` block for branch
+  completion. `warp doctor` recognizes PowerShell via `PSModulePath` and points
+  at the `warp shell-config powershell` snippet and `$env:PATH` instead of the
+  old "not yet shipped" placeholder. (#219)
+- `[cow] exclude` config knob: a list of untracked/ignored paths to skip when a
+  new worktree overlays the primary. It defaults to build and cache output;
+  `node_modules` is still copied so a fresh worktree stays runnable. (#227)
+
+### Changed
+
+- Worktree removal prints a single terser line.
 
 ### Fixed
 
-- `warp cleanup --kill` on Windows now honors `[process].kill_timeout`. The
-  Windows branch of `ProcessManager::terminate_single_process` fires a single
+- `warp switch` keeps the real `git worktree add` and CoW-overlays only the
+  primary worktree's untracked and ignored files (`git status -z --ignored`).
+  The previous path did `git worktree add`, `rm -rf`, then cloned the entire
+  primary tree — `.git` and build output included — which copied the whole
+  object store for nothing, walked all of it during path rewriting, and left
+  the worktree with a copied `.git` instead of a linked-worktree pointer.
+  Rewriting is now scoped to the overlaid files so tracked files never gain
+  spurious diffs, and a failed overlay is removed so no half-copied state
+  survives. (#227)
+- `warp cleanup --kill` on Windows honors `[process].kill_timeout`. The Windows
+  branch of `ProcessManager::terminate_single_process` fires a single
   `taskkill /T` for the graceful attempt, waits on the process handle via
   `WaitForSingleObject(kill_timeout)`, then falls back to `TerminateProcess`
   through the same handle instead of a second `taskkill /F` spawn. (#212)
+- `uninstall.ps1` honors `-InstallRoot` / `GIT_WARP_INSTALL_ROOT`, mirroring
+  `install.ps1`, so a Cargo install with a custom root uninstalls from the right
+  place. (#218)
+- `warp release-check` guards `install.sh` and `uninstall.sh` contents, so a
+  release can't ship scripts that dropped the checksum verification or the
+  `hooks-remove` cleanup. (#214)
+
+### Dependencies
+
+- Bump `crossbeam-epoch` to 0.9.20 (RUSTSEC-2026-0204).
+- Bump the cargo minor-and-patch group across 7 updates. (#224)
 
 ## v0.4.0 - 2026-07-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "git-warp"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-warp"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 authors = ["Git-Warp Contributors"]
 description = "High-performance, UX-focused Git worktree manager combining CoW speed with advanced features"

--- a/docs/install.md
+++ b/docs/install.md
@@ -114,7 +114,7 @@ installs that tag. The resolved tag is printed before the download starts.
 Pin a specific version with `GIT_WARP_VERSION` to skip the API lookup:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.sh | GIT_WARP_VERSION=v0.4.0 sh
+curl -fsSL https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.sh | GIT_WARP_VERSION=v0.5.0 sh
 ```
 
 If the API lookup fails (no network, rate-limited, custom non-`github.com`
@@ -148,7 +148,7 @@ Release binaries are published for:
 If you prefer to bypass `install.ps1`, grab the archive yourself:
 
 ```powershell
-$tag = 'v0.4.0'
+$tag = 'v0.5.0'
 $asset = "git-warp-$tag-x86_64-pc-windows-msvc.zip"
 $base = "https://github.com/denysbutenko/git-warp/releases/download/$tag"
 irm "$base/$asset" -OutFile $asset

--- a/docs/releases/v0.5.0.md
+++ b/docs/releases/v0.5.0.md
@@ -1,0 +1,145 @@
+# Git-Warp v0.5.0
+
+Follow-up release to v0.4.0.
+
+It finishes the Windows shell story with a PowerShell shell-config emitter, and
+reworks `warp switch` so a new worktree overlays only the primary's untracked
+and ignored files instead of copying the whole tree.
+
+## Highlights
+
+- PowerShell shell-config: `warp shell-config powershell` (alias `pwsh`) emits a
+  `warp_cd` helper and a `Register-ArgumentCompleter` block for branch
+  completion. `warp doctor` now recognizes PowerShell via `PSModulePath` and
+  points at the setup snippet and `$env:PATH` instead of the old "not yet
+  shipped" placeholder.
+- `warp switch` overlay fix: the CoW path keeps the real `git worktree add` and
+  copies only the primary worktree's untracked and ignored files. The previous
+  path removed the fresh worktree and cloned the entire primary tree — `.git`
+  and build output included — which copied the whole object store for nothing
+  and left the worktree with a copied `.git` rather than a linked-worktree
+  pointer. Path rewriting is scoped to the overlaid files, so tracked files
+  never gain spurious diffs.
+- New `[cow] exclude` knob: a list of untracked/ignored paths to skip on
+  overlay. It defaults to build and cache output; `node_modules` is still copied
+  so a fresh worktree stays runnable.
+- Windows `warp cleanup --kill` honors `[process].kill_timeout` via a
+  handle-based wait, and `uninstall.ps1` honors `-InstallRoot` /
+  `GIT_WARP_INSTALL_ROOT` like `install.ps1`.
+
+See the [changelog](../../CHANGELOG.md) for the complete list, including
+dependency bumps.
+
+## Install Or Upgrade
+
+One command, no Rust/Cargo required:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.sh | sh
+```
+
+Then verify the install:
+
+```bash
+warp --version
+warp doctor
+```
+
+The installer downloads the matching release archive for macOS/Linux and
+Intel/Apple Silicon and installs to `~/.local/bin` by default. On Windows, use
+`install.ps1` (see [docs/install.md](../install.md)).
+
+Upgrading from v0.4.0 is the same command — re-running the installer overwrites
+the existing binary at the install directory. The installer prints any other
+`warp` binaries it finds and warns when `warp` on `PATH` resolves to a
+different binary than the one just installed. Run `warp doctor` to confirm only
+one `warp` is active.
+
+Cargo fallback:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/denysbutenko/git-warp/main/install.sh | GIT_WARP_INSTALL_METHOD=cargo sh
+```
+
+Source checkout:
+
+```bash
+git clone https://github.com/denysbutenko/git-warp
+cd git-warp
+git checkout v0.5.0
+cargo install --path .
+warp --version
+warp doctor
+```
+
+Expected version output:
+
+```text
+warp 0.5.0
+```
+
+## PowerShell Setup
+
+Add the emitter output to your PowerShell profile so `warp_cd` and completions
+load in every session:
+
+```powershell
+warp shell-config powershell | Out-String | Invoke-Expression
+```
+
+To persist it, append the same output to `$PROFILE.CurrentUserAllHosts`. `pwsh`
+is an alias for `powershell` and emits the identical snippet.
+
+## Uninstall
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/denysbutenko/git-warp/main/uninstall.sh | sh
+```
+
+The uninstaller removes `~/.local/bin/warp` (or `$GIT_WARP_INSTALL_DIR/warp`),
+also clears installed hooks and shell-config entries, lists any other detected
+`warp` installs without touching them, and warns if `warp` is still on `PATH`.
+Use `--dry-run` to preview without changing anything. On Windows, use
+`uninstall.ps1`, which now honors `-InstallRoot` / `GIT_WARP_INSTALL_ROOT`. For
+Cargo installs, also run `cargo uninstall git-warp`.
+
+## Useful Commands
+
+```bash
+warp switch feature/my-change
+warp                     # switcher TUI; press Tab for agent sessions
+warp ls --interactive
+warp config --interactive
+warp shell-config powershell
+warp --dry-run cleanup --mode merged
+warp cleanup --interactive
+warp doctor
+warp release-check --metadata-only --version v0.5.0
+```
+
+## Verification
+
+Release prep was checked with:
+
+```bash
+cargo fmt --check
+cargo test
+cargo build --release --bin warp
+./target/release/warp --version
+./target/release/warp doctor
+```
+
+`warp release-check --version v0.5.0` runs the same flow plus metadata checks
+against `Cargo.toml`, `CHANGELOG.md`, `docs/releases/v0.5.0.md`,
+`docs/install.md`, and `install.sh`.
+
+## Notes
+
+- Copy-on-Write acceleration works on macOS/APFS and on Linux filesystems that
+  implement the FICLONE ioctl. Other filesystems fall back to normal Git
+  worktree creation.
+- The installer resolves the latest release tag from the GitHub API by default.
+  Set `GIT_WARP_VERSION` before running it to install a specific tag, or
+  `GIT_WARP_INSTALL_DIR` to install somewhere other than `~/.local/bin`.
+- Git-Warp is still a `0.x` tool. Use `warp doctor`, `--dry-run`, and focused
+  command help when setting it up on a new repo.

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -658,7 +658,7 @@ fn test_release_check_metadata_only_accepts_current_release_metadata() {
 #[test]
 fn test_release_check_metadata_only_rejects_missing_future_release_updates() {
     let output = Command::new(env!("CARGO_BIN_EXE_warp"))
-        .args(["release-check", "--metadata-only", "--version", "v0.5.0"])
+        .args(["release-check", "--metadata-only", "--version", "v0.6.0"])
         .current_dir(env!("CARGO_MANIFEST_DIR"))
         .output()
         .unwrap();
@@ -667,11 +667,11 @@ fn test_release_check_metadata_only_rejects_missing_future_release_updates() {
 
     assert!(!output.status.success(), "{stdout}");
     assert!(
-        stderr.contains("Cargo.toml package version is 0.4.0, expected 0.5.0"),
+        stderr.contains("Cargo.toml package version is 0.5.0, expected 0.6.0"),
         "{stderr}"
     );
     assert!(
-        normalized_path_text(&stderr).contains("docs/releases/v0.5.0.md is missing"),
+        normalized_path_text(&stderr).contains("docs/releases/v0.6.0.md is missing"),
         "{stderr}"
     );
 }


### PR DESCRIPTION
Cuts v0.5.0.

**Feature**
- PowerShell shell-config: `warp shell-config powershell` (alias `pwsh`) emits a `warp_cd` helper and a `Register-ArgumentCompleter` block, and `warp doctor` now recognizes PowerShell via `PSModulePath`. (#219)

**Fixes**
- `warp switch` overlays only the primary worktree's untracked and ignored files instead of removing the fresh worktree and cloning the whole tree; adds a `[cow] exclude` knob. (#227)
- Windows `cleanup --kill` honors `kill_timeout`. (#212)
- `uninstall.ps1` honors `-InstallRoot` / `GIT_WARP_INSTALL_ROOT`. (#218)
- `release-check` guards `install.sh` / `uninstall.sh` contents. (#214)
- Bump `crossbeam-epoch` to 0.9.20 (RUSTSEC-2026-0204).

**Release mechanics**
- Cargo.toml / Cargo.lock to 0.5.0, CHANGELOG, `docs/install.md` pins, new `docs/releases/v0.5.0.md`.
- Rolls the release-check future-version test forward to v0.6.0.

`warp release-check --version v0.5.0` passes locally (metadata + fmt/clippy/test/build/doctor). After merge, tag `v0.5.0` on main to trigger the release-binaries workflow.