### PR TITLE
ci: cover aarch64 Linux and x86_64 macOS in clippy/test matrix (#237)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14, windows-latest]
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - macos-14
+          - macos-15-intel
+          - windows-latest
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -56,7 +61,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14, windows-latest]
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - macos-14
+          - macos-15-intel
+          - windows-latest
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary

- Extend the `clippy` and `test` matrices in `.github/workflows/ci.yml` from three OSes to the same five targets that `release-binaries.yml` already ships (`ubuntu-latest`, `ubuntu-24.04-arm`, `macos-14`, `macos-15-intel`, `windows-latest`).
- Keeps `fail-fast: false` so a single OS regression does not blank the rest of the matrix.
- Same shape as the #90 parity fix that added `windows-latest`, so ARM Linux and Intel macOS breakage no longer waits until tag time to appear.

## Verification

- ``python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`` (parses clean)
- `git diff --check`

Closes #237