### PR TITLE
docs(changelog): populate Unreleased with post-v0.5.0 entries (#247)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Ship MIT `LICENSE` at repo root, matching the `license = "MIT"` field
+  already declared in `Cargo.toml`. (#246)
+
+### Fixed
+
+- `abbreviate_path` no longer collapses a sibling of the home directory
+  (e.g. `/Users/alice-scratch` → `~-scratch`) in the worktree switcher's
+  removal messages. The strip only applies when the remainder is empty or
+  starts with a path separator. (#236)
+- `warp release-check` guards the `-SkipChecksum` / `GIT_WARP_SKIP_CHECKSUM`
+  opt-out in `install.ps1`, mirroring the existing `install.sh` guard so a
+  release cannot ship a Windows installer that dropped the opt-out. (#231)
+
+### Dependencies
+
+- Bump `windows-sys` from 0.60.2 to 0.61.2. (#243)
+- Bump the cargo minor-and-patch group across 3 updates
+  (`clap`, `ignore`, `sysinfo`). (#245)
+
 ## v0.5.0 - 2026-07-08
 
 Follow-up release to v0.4.0. It finishes the Windows shell story with a


### PR DESCRIPTION
Adds an `## Unreleased` heading above `## v0.5.0` in `CHANGELOG.md` so `warp release-check` has a populated source of truth for the next tag. Entries are grouped `Added` / `Fixed` / `Dependencies` to mirror the v0.5.0 layout and are sourced from `git log v0.5.0..HEAD`:

- **Added**: MIT `LICENSE` at repo root (#246)
- **Fixed**: `abbreviate_path` sibling-of-home collapse (#236, PR #240); `warp release-check` guard for `install.ps1` `-SkipChecksum` / `GIT_WARP_SKIP_CHECKSUM` opt-out (#231, PR #235)
- **Dependencies**: `windows-sys` 0.60.2 → 0.61.2 (#243); cargo minor-and-patch group across `clap`, `ignore`, `sysinfo` (#245)

CI-only (#241), test-only (#244), bench-only (#239), and internal docs (#233) commits are excluded per the issue's "skip entries with no user impact" guidance.

## Verification

- `git diff --check` — clean.
- `git diff CHANGELOG.md` — only the new `## Unreleased` block above `## v0.5.0`; existing sections untouched.

Closes #247