### PR TITLE
docs(user-guide): document [cow].exclude section and env override (#248)

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -286,6 +286,16 @@ auto_install = true
 enabled = true
 refresh_rate = 1000
 max_activities = 100
+
+[cow]
+# Names to skip when copying the primary worktree's untracked & ignored files
+# into a new worktree. Matched per path component. `.git` and tracked files are
+# never copied. `node_modules` is kept on purpose. Set to [] to copy everything.
+exclude = [
+    "target", "dist", "build", "out", "coverage",
+    ".next", ".nuxt", ".svelte-kit", ".turbo", ".parcel-cache",
+    "__pycache__", ".pytest_cache", ".mypy_cache", ".gradle",
+]
 ```
 
 `[git].auto_fetch` controls whether `warp cleanup` runs `git fetch --all --prune`
@@ -304,6 +314,14 @@ creates a new worktree. Lockfile detection order is `pnpm-lock.yaml` →
 `yarn.lock` → `bun.lock` → `bun.lockb` → `package-lock.json` → `Cargo.toml`; the first match wins. Set
 `auto_install = false` to skip the install step entirely.
 
+`[cow].exclude` lists path components to skip when Git-Warp overlays the primary
+worktree's untracked and ignored files onto a fresh worktree. Matching is
+name-based per path component against entries reported by
+`git status -z --ignored`, so `target` also drops `crates/foo/target/`. Entries
+are bare directory or file names, not globs. `.git` and tracked files are never
+copied; `node_modules` is kept by default. Set `exclude = []` to copy every
+untracked and ignored path.
+
 Environment variables override config file values. Top-level keys map
 directly; nested sections use `__` (double underscore) as the path
 separator (`GIT_WARP_<section>__<field>`):
@@ -320,6 +338,7 @@ export GIT_WARP_PROCESS__AUTO_KILL=true
 export GIT_WARP_TERMINAL__APP=iterm2
 export GIT_WARP_AGENT__REFRESH_RATE=2000
 export GIT_WARP_POST_CREATE__AUTO_INSTALL=false
+export GIT_WARP_COW__EXCLUDE='["target","dist"]'
 ```
 
 Command-line options have the highest priority:


### PR DESCRIPTION
Refreshes `docs/user-guide.md`'s Configuration section so it reflects `[cow].exclude`, which shipped with v0.5.0 (#227) but was never mentioned in the sample config or the env-override block.

## Changes

- Append a `[cow]` block to the sample `config.toml`, mirroring what `warp config --show` prints. The default list comes from `default_cow_exclude()` in `src/config.rs` (`target`, `dist`, `build`, `out`, `coverage`, `.next`, `.nuxt`, `.svelte-kit`, `.turbo`, `.parcel-cache`, `__pycache__`, `.pytest_cache`, `.mypy_cache`, `.gradle`).
- Add an explainer paragraph next to the neighboring `[git].auto_fetch` / `post_create.auto_install` explainers, describing the name-based per-path-component matching semantics (`src/cow.rs::should_overlay_entry`), the `.git` / tracked-files carve-out, the intentional `node_modules` retention, and the `exclude = []` opt-out.
- Add `export GIT_WARP_COW__EXCLUDE='["target","dist"]'` to the nested-env-override block, using JSON-array syntax because that is what figment's `Env::split("__")` accepts for `Vec<String>`.

## Verification

- Probed `GIT_WARP_COW__EXCLUDE` decoding via a scratch figment test in `tests/unit/config_tests.rs`: `["target","dist"]` and `["target", "dist"]` both extract into `Vec<String>`; comma-separated `target,dist` fails with figment's `expected a sequence` error. The probe was reverted; only `docs/user-guide.md` is included in the diff.
- `git diff --check` — clean.

Closes #248