### PR TITLE
docs(doctor): surface PowerShell in unknown-shell hint and README (#249)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ normal `git worktree` creation when CoW is not available.
   per-scope `Complete` / `Partial` / `Missing` / `Conflicting` diagnostics and
   the exact repair command.
 - Shows a TUI dashboard for live hook data and recent local agent sessions.
-- Generates shell completion snippets for Bash, Zsh, and Fish.
+- Generates shell completion snippets for Bash, Zsh, Fish, and PowerShell.
 - Validates release metadata before tagging with `warp release-check`.
 
 ## Install

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2230,12 +2230,14 @@ impl Cli {
             }
             DoctorShell::Unknown { value } => {
                 let detail = match value {
-                    Some(v) => format!("unsupported shell `{v}`; supported: bash, zsh, fish"),
+                    Some(v) => {
+                        format!("unsupported shell `{v}`; supported: bash, zsh, fish, powershell")
+                    }
                     None => "SHELL is not set".to_string(),
                 };
                 Self::doctor_warn("Shell integration", detail);
                 next_steps.push(
-                    "Set SHELL to bash, zsh, or fish, then run `warp shell-config` for setup snippets.".to_string(),
+                    "Set SHELL to bash, zsh, or fish (or use PowerShell), then run `warp shell-config <shell>` for setup snippets.".to_string(),
                 );
             }
         }

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -1945,7 +1945,14 @@ fn test_doctor_shell_check_handles_unknown_shell() {
         stdout.contains("unsupported shell `/usr/bin/tcsh`"),
         "{stdout}"
     );
-    assert!(stdout.contains("supported: bash, zsh, fish"), "{stdout}");
+    assert!(
+        stdout.contains("supported: bash, zsh, fish, powershell"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("(or use PowerShell), then run `warp shell-config <shell>`"),
+        "{stdout}"
+    );
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
Brings the two remaining bash/zsh/fish-only text surfaces in line with the PowerShell shell-config emitter that shipped in v0.5.0 (#219).

## Changes
- `README.md:31` — feature bullet now reads `Bash, Zsh, Fish, and PowerShell` (matches the `warp shell-config powershell` snippet documented a few paragraphs below).
- `src/cli.rs` `DoctorShell::Unknown` branch — warn detail becomes `unsupported shell `<v>`; supported: bash, zsh, fish, powershell` and the next-step is `Set SHELL to bash, zsh, or fish (or use PowerShell), then run `warp shell-config <shell>` for setup snippets.` This aligns with the sibling `shell-config` error at `src/cli.rs:2740` and only fires when `SHELL` is not `bash`/`zsh`/`fish` and `PSModulePath` is unset (e.g. `pwsh` on Linux/macOS).
- `tests/integration/cli_surface_tests.rs::test_doctor_shell_check_handles_unknown_shell` — asserts the new `powershell` mention in both the detail and the next-step so future drift is caught. The `#[cfg(windows)]` `test_doctor_shell_check_recognizes_powershell` is unaffected (PowerShell auto-detection still routes through `DoctorShell::PowerShell`, not `Unknown`).

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --test mod doctor_shell_check` (6 tests, all pass)
- `git diff --check`

Closes #249