### PR TITLE
docs(agents): document bare warp Tab-toggle to agents dashboard (#253)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ normal `git worktree` creation when CoW is not available.
   current terminal, or prints the target path/command.
 - Lists worktrees with primary/current/dirty/detached/busy state, ordered for
   fast scanning in busy repositories.
-- Bare `warp` opens an interactive switcher with multi-select and batch removal.
+- Bare `warp` opens an interactive switcher with multi-select and batch removal;
+  press `Tab` to toggle to the agent session dashboard and `Tab` again to return.
 - Cleans up eligible worktrees with dry-run, interactive selection, process
   checks, protected branches, optional process termination, and per-worktree
   eligibility reasons.
@@ -121,6 +122,11 @@ dirty worktrees and running processes before removing anything.
 The agent dashboard is optional. It shows live hook records when hooks are
 installed, plus recent local Claude/Codex session history for the current
 repository and its worktrees.
+
+Two entry points open it: `warp agents` jumps in directly, and pressing `Tab`
+inside the bare `warp` switcher toggles between the switcher and the dashboard.
+When `agent.enabled=false` in the config, `Tab` shows a notice instead of
+switching.
 
 ```bash
 warp hooks-install --level user --runtime all

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -133,7 +133,9 @@ branch, or new branch and prints a labeled status line. When a branch only
 exists on a remote, Git-Warp creates a local tracking branch from that remote
 ref instead of branching from `HEAD`. Running bare `warp` opens an interactive
 switcher with a `local-only` badge for branches with no matching remote ref;
-`Space` and `a` toggle multi-select for batch worktree removal.
+`Space` and `a` toggle multi-select for batch worktree removal. Press `Tab` to
+switch the surface to the [Agent Session Dashboard](#agent-session-dashboard)
+and `Tab` again to return.
 
 Terminal handoff modes:
 
@@ -203,6 +205,12 @@ checks.
 
 The `agents` command opens a TUI dashboard for live hook records and recent local
 Claude/Codex session history scoped to the current repository and its worktrees.
+
+The dashboard has two entry points: `warp agents` opens it directly, and
+pressing `Tab` inside the [bare `warp` switcher](#switching-worktrees) toggles
+between the switcher and the dashboard. `Tab` again returns to the switcher.
+When `agent.enabled=false` in the config, `Tab` shows a notice instead of
+switching.
 
 ```bash
 warp hooks-install --level user --runtime all


### PR DESCRIPTION
## Summary
- "What It Does Today" bullet now says bare `warp` toggles to the agents dashboard with `Tab`.
- README "Agent Session Dashboard" lists both entry points and calls out the `agent.enabled=false` notice.
- `docs/user-guide.md`: switcher paragraph links out to the dashboard via `Tab`; dashboard section mirrors it and mentions the same notice.

## Verification
- `git diff --check` — clean

Closes #253