### PR TITLE
feat(complete): include remote-tracking branches and tags in warp __complete (#254)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2749,8 +2749,8 @@ complete -c warp -n '__fish_seen_subcommand_from switch' -f -a '(warp __complete
             "branches" => {
                 let git_repo =
                     crate::git::GitRepository::find().map_err(|_| Self::not_in_git_repo_error())?;
-                for branch in git_repo.list_local_branches_matching_prefix(prefix.unwrap_or(""))? {
-                    println!("{branch}");
+                for name in git_repo.list_switchable_refs_matching_prefix(prefix.unwrap_or(""))? {
+                    println!("{name}");
                 }
                 Ok(())
             }

--- a/src/git.rs
+++ b/src/git.rs
@@ -879,30 +879,57 @@ impl GitRepository {
         Ok(output.status.success())
     }
 
-    /// List local branches matching a prefix for shell completion
-    pub fn list_local_branches_matching_prefix(&self, prefix: &str) -> Result<Vec<String>> {
+    /// List refs (local branches, remote-tracking branches, tags) that `warp switch`
+    /// can resolve, matching a prefix for shell completion. Remote-tracking branches
+    /// are exposed by their trailing name (`origin/foo` → `foo`) so users can complete
+    /// a fetched-but-not-checked-out branch and let `warp switch` create the local
+    /// tracking branch. Duplicates (same name local and on a remote) collapse into
+    /// one suggestion; the symbolic `refs/remotes/<remote>/HEAD` alias is skipped.
+    pub fn list_switchable_refs_matching_prefix(&self, prefix: &str) -> Result<Vec<String>> {
+        use std::collections::BTreeSet;
         use std::process::Command;
 
         let output = Command::new("git")
-            .args(["for-each-ref", "--format=%(refname:short)", "refs/heads"])
+            .args([
+                "for-each-ref",
+                "--format=%(refname)",
+                "refs/heads",
+                "refs/remotes",
+                "refs/tags",
+            ])
             .current_dir(&self.repo_path)
             .output()
-            .map_err(|e| anyhow::anyhow!("Failed to list local branches: {}", e))?;
+            .map_err(|e| anyhow::anyhow!("Failed to list refs: {}", e))?;
 
         if !output.status.success() {
             let error = String::from_utf8_lossy(&output.stderr);
-            return Err(anyhow::anyhow!("Failed to list local branches: {}", error));
+            return Err(anyhow::anyhow!("Failed to list refs: {}", error));
         }
 
-        let mut branches: Vec<String> = String::from_utf8_lossy(&output.stdout)
-            .lines()
-            .filter(|branch| branch.starts_with(prefix))
-            .map(str::to_string)
-            .collect();
-        branches.sort();
-        branches.dedup();
+        let mut refs: BTreeSet<String> = BTreeSet::new();
+        for line in String::from_utf8_lossy(&output.stdout).lines() {
+            let name = if let Some(rest) = line.strip_prefix("refs/heads/") {
+                rest
+            } else if let Some(rest) = line.strip_prefix("refs/remotes/") {
+                let Some((_, branch)) = rest.split_once('/') else {
+                    continue;
+                };
+                if branch == "HEAD" {
+                    continue;
+                }
+                branch
+            } else if let Some(rest) = line.strip_prefix("refs/tags/") {
+                rest
+            } else {
+                continue;
+            };
 
-        Ok(branches)
+            if name.starts_with(prefix) {
+                refs.insert(name.to_string());
+            }
+        }
+
+        Ok(refs.into_iter().collect())
     }
 
     /// Get the current HEAD commit

--- a/tests/integration/cli_surface_tests.rs
+++ b/tests/integration/cli_surface_tests.rs
@@ -1215,6 +1215,52 @@ fn test_complete_branches_outputs_local_branches_matching_prefix() {
 }
 
 #[test]
+fn test_complete_branches_includes_remote_tracking_tags_and_dedupes() {
+    let temp_dir = setup_test_repo();
+    let repo_path = temp_dir.path();
+
+    run_git(repo_path, &["branch", "254-local"]);
+    run_git(repo_path, &["tag", "254-tag"]);
+    run_git(
+        repo_path,
+        &["update-ref", "refs/remotes/origin/254-remote-only", "HEAD"],
+    );
+    run_git(repo_path, &["branch", "254-dup"]);
+    run_git(
+        repo_path,
+        &["update-ref", "refs/remotes/origin/254-dup", "HEAD"],
+    );
+    run_git(
+        repo_path,
+        &[
+            "symbolic-ref",
+            "refs/remotes/origin/HEAD",
+            "refs/remotes/origin/254-remote-only",
+        ],
+    );
+
+    let output = warp_command(repo_path)
+        .args(["__complete", "branches", "254"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "{stdout}");
+
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(lines.contains(&"254-local"), "{stdout}");
+    assert!(lines.contains(&"254-tag"), "{stdout}");
+    assert!(lines.contains(&"254-remote-only"), "{stdout}");
+    assert!(lines.contains(&"254-dup"), "{stdout}");
+    assert_eq!(
+        lines.iter().filter(|l| **l == "254-dup").count(),
+        1,
+        "expected 254-dup exactly once, got {stdout}"
+    );
+    assert!(!lines.contains(&"HEAD"), "{stdout}");
+    assert!(!lines.contains(&"origin/254-remote-only"), "{stdout}");
+}
+
+#[test]
 fn test_shell_config_zsh_outputs_branch_completion_for_root_and_switch() {
     let output = Command::new(env!("CARGO_BIN_EXE_warp"))
         .args(["shell-config", "zsh"])


### PR DESCRIPTION
`warp switch` accepts remote-tracking branches (creates a local tracking branch), tags, and SHAs (shipped in #88), but `warp __complete branches` — the source every shell-config snippet reads from — only enumerated `refs/heads`. Tab-completion was strictly weaker than the resolver: freshly fetched `origin/foo` never completed until checked out, and tags added by `warp release-check` never completed at all.

## Changes

- `src/git.rs` — rename `list_local_branches_matching_prefix` to `list_switchable_refs_matching_prefix` and switch to `for-each-ref refs/heads refs/remotes refs/tags`, matching prefixes by ref kind:
  - local branch → short name as before
  - remote-tracking → trailing branch name (`origin/foo` → `foo`), so `warp switch foo` can create the tracking branch on the first switch
  - tag → short name
- Skip the symbolic `refs/remotes/<remote>/HEAD` alias (it would otherwise leak as `HEAD`).
- Collect into a `BTreeSet<String>`, so names that exist both locally and on a remote collapse into a single suggestion and the result is sorted+deduped.
- `src/cli.rs` — `handle_complete("branches", ...)` now calls the renamed helper; return value semantics unchanged (one match per line).
- `tests/integration/cli_surface_tests.rs` — the existing local-only test stays; new `test_complete_branches_includes_remote_tracking_tags_and_dedupes` covers a remote-only branch, a tag, a duplicated local+remote name (asserts one line, not two), and the `refs/remotes/origin/HEAD` symref (asserts it is not surfaced as `HEAD`).

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --test mod complete_branches` — 2 passed
- `git diff --check`

Closes #254