### PR TITLE
docs: link v0.5.0 release notes and bump release-check example (#255)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ git diff --check
 Before tagging a release, run the release validation flow:
 
 ```bash
-warp release-check --version v0.4.0
+warp release-check --version v0.5.0
 ```
 
 Useful manual checks:
@@ -260,6 +260,7 @@ cargo run -- --dry-run cleanup --mode merged
 - [Technical Overview](docs/technical-overview.md)
 - [Documentation Index](docs/README.md)
 - [Changelog](CHANGELOG.md)
+- [Release Notes (v0.5.0)](docs/releases/v0.5.0.md)
 - [Release Notes (v0.4.0)](docs/releases/v0.4.0.md)
 - [Release Notes (v0.3.0)](docs/releases/v0.3.0.md)
 - [Release Notes (v0.2.0)](docs/releases/v0.2.0.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,8 @@ planning material for Git-Warp.
 - [Technical Overview](technical-overview.md): architecture, modules, and
   implementation notes.
 - [Changelog](../CHANGELOG.md): release notes and verification commands.
+- [Release Notes (v0.5.0)](releases/v0.5.0.md): pasteable notes for the
+  `v0.5.0` GitHub release.
 - [Release Notes (v0.4.0)](releases/v0.4.0.md): pasteable notes for the
   `v0.4.0` GitHub release.
 - [Release Notes (v0.3.0)](releases/v0.3.0.md): pasteable notes for the


### PR DESCRIPTION
v0.5.0 shipped on 2026-07-08 but the root README kept the v0.4.0 release-check example and neither top-level doc index linked `docs/releases/v0.5.0.md`.

## Changes

- `README.md` — bump the Development-section `warp release-check --version` example from `v0.4.0` to `v0.5.0`.
- `README.md`, `docs/README.md` — link `docs/releases/v0.5.0.md` above the v0.4.0 entry so newest ships first. `docs/release-check.md` is untouched (its examples double as release-check fixtures).

## Verification

- `git diff --check`

Closes #255